### PR TITLE
Remove lodash methods

### DIFF
--- a/src/victory-animation/util.js
+++ b/src/victory-animation/util.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import d3Interpolate from "d3-interpolate";
 
 export const isInterpolatable = function (obj) {
@@ -10,7 +9,7 @@ export const isInterpolatable = function (obj) {
     case "number":
       // The standard `isNaN` is fine in this case since we already know the
       // type is number.
-      return !isNaN(obj) && _.isFinite(obj);
+      return !isNaN(obj) && obj !== Number.POSITIVE_INFINITY && obj !== Number.NEGATIVE_INFINITY;
     case "string":
       // d3 might not *actually* be able to interpolate the string, but it
       // won't cause any issues to let it try.
@@ -22,7 +21,7 @@ export const isInterpolatable = function (obj) {
       return false;
     case "object":
       // Don't try to interpolate class instances (except Date or Array).
-      return _.isDate(obj) || _.isArray(obj) || _.isPlainObject(obj);
+      return obj instanceof Date || Array.isArray(obj) || typeof obj === "object";
     case "function":
       // Careful! There may be extra properties on function objects that the
       // component expects to access - for instance, it may be a `d3.scale()`

--- a/src/victory-animation/util.js
+++ b/src/victory-animation/util.js
@@ -1,5 +1,5 @@
 import d3Interpolate from "d3-interpolate";
-import isPlainObject  from "lodash/lang/isPlainObject";
+import isPlainObject from "lodash/lang/isPlainObject";
 
 export const isInterpolatable = function (obj) {
   // d3 turns null into 0 and undefined into NaN, which we don't want.

--- a/src/victory-animation/util.js
+++ b/src/victory-animation/util.js
@@ -21,7 +21,8 @@ export const isInterpolatable = function (obj) {
       return false;
     case "object":
       // Don't try to interpolate class instances (except Date or Array).
-      return obj instanceof Date || Array.isArray(obj) || typeof obj === "object";
+      const proto = Object.getPrototypeOf(obj);
+      return proto === Object.prototype ||  proto === null;
     case "function":
       // Careful! There may be extra properties on function objects that the
       // component expects to access - for instance, it may be a `d3.scale()`

--- a/src/victory-animation/util.js
+++ b/src/victory-animation/util.js
@@ -1,4 +1,5 @@
 import d3Interpolate from "d3-interpolate";
+import isPlainObject  from "lodash/lang/isPlainObject";
 
 export const isInterpolatable = function (obj) {
   // d3 turns null into 0 and undefined into NaN, which we don't want.
@@ -21,8 +22,7 @@ export const isInterpolatable = function (obj) {
       return false;
     case "object":
       // Don't try to interpolate class instances (except Date or Array).
-      const proto = Object.getPrototypeOf(obj);
-      return proto === Object.prototype || proto === null;
+      return obj instanceof Date || Array.isArray(obj) || isPlainObject(obj);
     case "function":
       // Careful! There may be extra properties on function objects that the
       // component expects to access - for instance, it may be a `d3.scale()`

--- a/src/victory-animation/util.js
+++ b/src/victory-animation/util.js
@@ -22,7 +22,7 @@ export const isInterpolatable = function (obj) {
     case "object":
       // Don't try to interpolate class instances (except Date or Array).
       const proto = Object.getPrototypeOf(obj);
-      return proto === Object.prototype ||  proto === null;
+      return proto === Object.prototype || proto === null;
     case "function":
       // Careful! There may be extra properties on function objects that the
       // component expects to access - for instance, it may be a `d3.scale()`

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -1,25 +1,21 @@
-import some from "lodash/collection/some";
-import every from "lodash/collection/every";
-import isDate from "lodash/lang/isDate";
-
 export const isNonEmptyArray = function (collection) {
   return Array.isArray(collection) && collection.length > 0;
 };
 
 export const containsStrings = function (collection) {
-  return some(collection, (value) => typeof value === "string");
+  return Array.isArray(collection) && collection.some((value) => typeof value === "string");
 };
 
 export const containsDates = function (collection) {
-  return some(collection, isDate);
+  return Array.isArray(collection) && collection.some((value) => value instanceof Date);
 };
 
 export const containsOnlyStrings = function (collection) {
-  return isNonEmptyArray(collection) && every(collection, (value) => typeof value === "string");
+  return isNonEmptyArray(collection) && collection.every((value) => typeof value === "string");
 };
 
 export const isArrayOfArrays = function (collection) {
-  return isNonEmptyArray(collection) && every(collection, Array.isArray);
+  return isNonEmptyArray(collection) && collection.every(Array.isArray);
 };
 
 export const removeUndefined = function (arr) {

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,5 +1,6 @@
 import defaults from "lodash/object/defaults";
 import property from "lodash/utility/property";
+import isFunction from "lodash/lang/isFunction";
 
 module.exports = {
   getPadding(props) {
@@ -27,11 +28,11 @@ module.exports = {
   },
 
   evaluateProp(prop, data) {
-    return typeof prop === "function" ? prop(data) : prop;
+    return isFunction(prop) ? prop(data) : prop;
   },
 
   evaluateStyle(style, data) {
-    if (!Object.keys(style).some((value) => typeof style[value] === "function")) {
+    if (!Object.keys(style).some((value) => isFunction(style[value]))) {
       return style;
     }
     return Object.keys(style).reduce((prev, curr) => {
@@ -116,7 +117,7 @@ module.exports = {
   createAccessor(key) {
     // creates a data accessor function
     // given a property key, path, array index, or null for identity.
-    if (typeof key === "function") {
+    if (isFunction(key)) {
       return key;
     } else if (key === null || typeof key === "undefined") {
       // null/undefined means "return the data item itself"

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,6 +1,7 @@
 import defaults from "lodash/object/defaults";
-import property from "lodash/utility/property";
 import isFunction from "lodash/lang/isFunction";
+import property from "lodash/utility/property";
+import zipObject from "lodash/array/zipObject";
 
 module.exports = {
   getPadding(props) {
@@ -90,10 +91,7 @@ module.exports = {
   createStringMap(props, axis) {
     const stringsFromData = this.getStringsFromData(props, axis);
     return stringsFromData.length === 0 ? null :
-      stringsFromData.reduce((prev, curr, index) => {
-        prev[curr] = index + 1;
-        return prev;
-      }, {});
+      zipObject(stringsFromData.map((string, index) => [string, index + 1]));
   },
 
   getStringsFromData(props, axis) {

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -15,14 +15,14 @@ module.exports = {
 
   getStyles(style, defaultStyles, height, width) {  // eslint-disable-line max-params
     if (!style) {
-      return merge({}, defaultStyles, { parent: { height, width } });
+      return defaults({ parent: { height, width } }, defaultStyles);
     }
 
     const {data, labels, parent} = style;
     return {
-      parent: defaults({height: props.height, width: props.width}, defaultStyles.parent, parent),
-      labels: defaults({}, labels, defaultStyles.labels),
-      data: defaults({}, data, defaultStyles.data)
+      parent: defaults({ height, width }, parent, defaultStyles.parent),
+      labels: defaults(labels, defaultStyles.labels),
+      data: defaults(data, defaultStyles.data)
     };
   },
 

--- a/src/victory-util/prop-types.js
+++ b/src/victory-util/prop-types.js
@@ -1,4 +1,5 @@
 /* global console */
+import isFunction from "lodash/lang/isFunction";
 import { PropTypes } from "react";
 import { getConstructor, getConstructorName } from "./type";
 
@@ -123,7 +124,6 @@ export const domain = makeChainable((props, propName, componentName) => {
  */
 export const scale = makeChainable((props, propName, componentName) => {
   const supportedScaleStrings = ["linear", "time", "log", "sqrt"];
-  const isFunction = (val) => typeof val === "function";
   const validScale = (scl) => {
     if (isFunction(scl)) {
       return (isFunction(scl.copy) && isFunction(scl.domain) && isFunction(scl.range));

--- a/src/victory-util/prop-types.js
+++ b/src/victory-util/prop-types.js
@@ -1,8 +1,4 @@
 /* global console */
-import bind from "lodash/function/bind";
-import includes from "lodash/collection/includes";
-import isFunction from "lodash/lang/isFunction";
-
 import { PropTypes } from "react";
 import { getConstructor, getConstructorName } from "./type";
 
@@ -51,8 +47,8 @@ export const makeChainable = function (validator) {
     }
     return validator(props, propName, componentName);
   };
-  const chainable = bind(_chainable, null, false);
-  chainable.isRequired = bind(_chainable, null, true);
+  const chainable = _chainable.bind(null, false);
+  chainable.isRequired = _chainable.bind(null, true);
   return chainable;
 };
 
@@ -127,11 +123,12 @@ export const domain = makeChainable((props, propName, componentName) => {
  */
 export const scale = makeChainable((props, propName, componentName) => {
   const supportedScaleStrings = ["linear", "time", "log", "sqrt"];
+  const isFunction = (val) => typeof val === "function";
   const validScale = (scl) => {
     if (isFunction(scl)) {
       return (isFunction(scl.copy) && isFunction(scl.domain) && isFunction(scl.range));
     } else if (typeof scl === "string") {
-      return includes(supportedScaleStrings, scl);
+      return supportedScaleStrings.indexOf(scl) !== -1;
     }
     return false;
   };


### PR DESCRIPTION
cc/ @coopy this PR removes all lodash methods except `defaults` and `property`. I think we definitely need `defaults` for now, but we _might_ be able to do without `property`.  I want to check on the bloat of that particular method first and see if it might be small enough to keep. It's so handy. 
