### PR TITLE
Add `npm start` script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,34 @@
 VictoryCore
 ============
 
-IMPORTANT
-=========
+This package contains shared libraries and components for [Victory][].
 
-This project is in a pre-release state. We're hard at work fixing bugs and improving the API. Be prepared for breaking changes!
+- VictoryAnimation: Animation component
+- VictoryLabel: Label component
+- VictoryUtil: Supporting math and logic helper functions
 
 ## Development
 
-Please see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md)
+```sh
+# Run the demo app server
+$ npm start
+
+# Open the demo app
+$ open http://localhost:3000
+
+# Run tests
+$ npm test
+```
+For more on the development environment, see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md) in the project builder archetype.
 
 ## Contributing
 
-Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md)
+Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md) in the project builder archetype.
 
+[Victory]: https://github.com/FormidableLabs/victory
 [trav_img]: https://api.travis-ci.org/FormidableLabs/victory-core.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/victory-core
+
+## _IMPORTANT_
+
+This project is in a pre-release state. We're hard at work fixing bugs and improving the API. Be prepared for breaking changes!

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
+    "start": "builder run hot",
     "test": "builder run npm:test",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },

--- a/package.json
+++ b/package.json
@@ -16,13 +16,12 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
-    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\"",
-    "test": "builder run npm:test"
+    "test": "builder run npm:test",
+    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {
-    "builder": "~2.4.0",
     "builder-victory-component": "~0.2.1",
-    "lodash": "^3.10.1",
+    "builder": "~2.4.0",
     "d3-ease": "^0.3.0",
     "d3-interpolate": "^0.2.0",
     "d3-scale": "^0.2.0",
@@ -39,7 +38,8 @@
     "react-addons-test-utils": "^0.14.3",
     "react-dom": "0.14.3",
     "react-router": "^1.0.0",
-    "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "react": "0.14.3",
+    "sinon-chai": "^2.8.0",
+    "sinon": "^1.17.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
     "start": "builder run hot",
-    "test": "builder run npm:test",
+    "test": "builder run check",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {


### PR DESCRIPTION
I've added standard npm scripts and updated the README to have the minimum needed to get started on development.
- `npm start` runs `builder run hot`
- `npm test` runs `builder run check`

/cc @boygirl @tptee
