### PR TITLE
Remove Radium

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "^3.2.0",
     "history": "~1.13.0",
     "mocha": "^2.2.5",
+    "radium": "^0.16.2",
     "react": "0.14.3",
     "react-addons-test-utils": "^0.14.3",
     "react-dom": "0.14.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "d3-interpolate": "^0.2.0",
     "d3-scale": "^0.2.0",
     "d3-timer": "^0.0.6",
-    "radium": "^0.16.2",
     "reduce-css-calc": "^1.2.0"
   },
   "devDependencies": {

--- a/src/victory-label/victory-label.jsx
+++ b/src/victory-label/victory-label.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { PropTypes as CustomPropTypes, Helpers, Style } from "../victory-util/index";
 import merge from "lodash/object/merge";
 
@@ -11,7 +10,6 @@ const defaultStyles = {
   backgroundColor: "#ccc"
 };
 
-@Radium
 export default class VictoryLabel extends React.Component {
   static propTypes = {
     /**


### PR DESCRIPTION
This removes Radium as a dependency of victory-core.  Tests pass and demos work.

Related to https://github.com/FormidableLabs/victory/issues/141.

cc @coopy @boygirl 
