### PR TITLE
Add support for providing label text as a prop

### DIFF
--- a/src/victory-label/victory-label.jsx
+++ b/src/victory-label/victory-label.jsx
@@ -31,6 +31,14 @@ export default class VictoryLabel extends React.Component {
      */
     data: PropTypes.object,
     /**
+     * all Victory components will pass a label prop to their label component.
+     * This defines the content of the label when child nodes are absent.
+     */
+    label: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
+    /**
      * The children of this component define the content of the label. This
      * makes using the component similar to normal HTML spans or labels.
      * Currently, only strings are supported.
@@ -143,7 +151,7 @@ export default class VictoryLabel extends React.Component {
       const child = Helpers.evaluateProp(props.children);
       return `${child}`.split("\n");
     }
-    return [""];
+    return [props.label];
   }
 
   getDy(props, content, lineHeight) {

--- a/src/victory-label/victory-label.jsx
+++ b/src/victory-label/victory-label.jsx
@@ -31,10 +31,11 @@ export default class VictoryLabel extends React.Component {
      */
     data: PropTypes.object,
     /**
-     * all Victory components will pass a label prop to their label component.
-     * This defines the content of the label when child nodes are absent.
+     * all Victory components will pass a text prop to their label component.
+     * This defines the content of the label when child nodes are absent. It
+     * will be ignored if children are provided.
      */
-    label: PropTypes.oneOfType([
+    text: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number
     ]),
@@ -151,7 +152,7 @@ export default class VictoryLabel extends React.Component {
       const child = Helpers.evaluateProp(props.children);
       return `${child}`.split("\n");
     }
-    return [props.label];
+    return [props.text];
   }
 
   getDy(props, content, lineHeight) {

--- a/test/client/spec/victory-label/victory-label.spec.jsx
+++ b/test/client/spec/victory-label/victory-label.spec.jsx
@@ -42,7 +42,7 @@ describe("components/victory-label", () => {
 
   it("falls back to label prop without children", () => {
     const renderer = TestUtils.createRenderer();
-    renderer.render(<VictoryLabel label="such label" />);
+    renderer.render(<VictoryLabel text="such label" />);
     const output = renderer.getRenderOutput();
 
     expect(output.type).to.equal("text");

--- a/test/client/spec/victory-label/victory-label.spec.jsx
+++ b/test/client/spec/victory-label/victory-label.spec.jsx
@@ -39,4 +39,13 @@ describe("components/victory-label", () => {
     expect(output.type).to.equal("text");
     expect(output.props.children[0].props.children).to.contain("time (ms)");
   });
+
+  it("falls back to label prop without children", () => {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<VictoryLabel label="such label" />);
+    const output = renderer.getRenderOutput();
+
+    expect(output.type).to.equal("text");
+    expect(output.props.children[0].props.children).to.contain("such label");
+  });
 });


### PR DESCRIPTION
This is a fallback in the absence of children for the label. Custom label
components will receive label text through this prop when created by
victory components. Custom label components will not have their children
modified. Therefore, if we use VictoryLabel as a custom label component
as in:
https://github.com/FormidableLabs/victory-chart/blob/c72cfe78cb4a6091fa2a77e730bbce7ef78ba16e/demo/components/victory-scatter-demo.jsx#L101
then we need to allow for setting the label text through props.
