### PR TITLE
Use lodash@^4.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {
-    "builder-victory-component": "0.2.1",
     "builder": "~2.4.0",
+    "builder-victory-component": "0.2.1",
     "d3-ease": "^0.3.0",
     "d3-interpolate": "^0.2.0",
     "d3-scale": "^0.2.0",
     "d3-timer": "^0.0.6",
-    "lodash": "^3.10.1",
+    "lodash": "^4.6.1",
     "reduce-css-calc": "^1.2.0"
   },
   "devDependencies": {

--- a/src/victory-animation/util.js
+++ b/src/victory-animation/util.js
@@ -1,5 +1,5 @@
 import d3Interpolate from "d3-interpolate";
-import isPlainObject from "lodash/lang/isPlainObject";
+import isPlainObject from "lodash/isPlainObject";
 
 export const isInterpolatable = function (obj) {
   // d3 turns null into 0 and undefined into NaN, which we don't want.

--- a/src/victory-label/victory-label.jsx
+++ b/src/victory-label/victory-label.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Helpers, Style } from "../victory-util/index";
-import merge from "lodash/object/merge";
+import merge from "lodash/merge";
 
 const defaultStyles = {
   stroke: "transparent",

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,7 +1,6 @@
-import defaults from "lodash/object/defaults";
-import isFunction from "lodash/lang/isFunction";
-import property from "lodash/utility/property";
-import zipObject from "lodash/array/zipObject";
+import defaults from "lodash/defaults";
+import isFunction from "lodash/isFunction";
+import property from "lodash/property";
 
 module.exports = {
   getPadding(props) {
@@ -90,8 +89,13 @@ module.exports = {
 
   createStringMap(props, axis) {
     const stringsFromData = this.getStringsFromData(props, axis);
-    return stringsFromData.length === 0 ? null :
-      zipObject(stringsFromData.map((string, index) => [string, index + 1]));
+    if (stringsFromData.length) {
+      return stringsFromData.reduce((acc, string, index) => {
+        acc[string] = index + 1;
+        return acc;
+      }, {});
+    }
+    return null;
   },
 
   getStringsFromData(props, axis) {

--- a/src/victory-util/prop-types.js
+++ b/src/victory-util/prop-types.js
@@ -1,5 +1,5 @@
 /* global console */
-import isFunction from "lodash/lang/isFunction";
+import isFunction from "lodash/isFunction";
 import { PropTypes } from "react";
 import { getConstructor, getConstructorName } from "./type";
 


### PR DESCRIPTION
Update lodash to v.4.6.1 and its imports.
Used `Array.prototype.reduce` instead `zipObject` cause tests failed.
