### PR TITLE
Add local .eslintrc files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,2 @@
+---
+  extends: ./node_modules/builder-victory-component/config/eslint/.eslintrc-source

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "builder": "~2.9.1",
-    "builder-victory-component": "^1.0.3",
+    "builder-victory-component": "^2.0.0",
     "d3-ease": "^0.3.0",
     "d3-interpolate": "^0.2.0",
     "d3-scale": "^0.2.0",
@@ -31,7 +31,7 @@
     "reduce-css-calc": "^1.2.0"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^1.0.3",
+    "builder-victory-component-dev": "^2.0.0",
     "chai": "^3.2.0",
     "ecology": "^1.2.0",
     "enzyme": "^2.0.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,2 @@
+---
+  extends: ../node_modules/builder-victory-component/config/eslint/.eslintrc-test


### PR DESCRIPTION
**DO NOT MERGE YET - DEPENDS ON CHANGE IN ARCHETYPE**
https://github.com/FormidableLabs/builder-victory-component/pull/50

This change adds local `.eslintrc` files that extend the archetype configuration files.

Local .eslintrc files in the tree enables integration with IDE/editor linting plugins, such as [linter-eslint](https://atom.io/packages/linter-eslint).
