### PR TITLE
Fix docs-hot webpack config

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -1,8 +1,6 @@
 import React from "react";
-import ReactDOM from "react-dom";
-import { Router, Route, Link } from "react-router";
-import AnimationDocs from "./victory-animation/docs";
-import LabelDocs from "./victory-label/docs";
+import { Link } from "react-router";
+import { StyleRoot } from "radium";
 
 const content = document.getElementById("content");
 
@@ -24,11 +22,8 @@ const App = React.createClass({
   }
 });
 
-ReactDOM.render((
-  <Router>
-    <Route path="/" component={App}>
-      <Route path="animation" component={AnimationDocs}/>
-      <Route path="label" component={LabelDocs}/>
-    </Route>
-  </Router>
-), content);
+App.propTypes = {
+  children: React.PropTypes.element
+};
+
+export default App;

--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -13,13 +13,13 @@ const App = React.createClass({
 
   render() {
     return (
-      <div>
+      <StyleRoot>
         <ul>
           <li><Link to="/animation">Victory Animation Docs</Link></li>
           <li><Link to="/label">Victory Label Docs</Link></li>
         </ul>
         {this.props.children}
-      </div>
+      </StyleRoot>
     );
   }
 });

--- a/docs/entry.jsx
+++ b/docs/entry.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { Router, Route } from "react-router";
+import App from "./app";
+import AnimationDocs from "./victory-animation/docs";
+import LabelDocs from "./victory-label/docs";
+
+const content = document.getElementById("content");
+
+ReactDOM.render((
+  <Router>
+    <Route path="/" component={App}>
+      <Route path="animation" component={AnimationDocs}/>
+      <Route path="label" component={LabelDocs}/>
+    </Route>
+  </Router>
+), content);

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,6 @@
   <div id="content" class="Container">
     <p>Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>
   <script async defer type="text/javascript" src="main.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,6 @@
   <div id="content" class="Container">
     <p>Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
-  <script src="https://fb.me/react-0.13.3.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "builder": "~2.9.1",
-    "builder-victory-component": "^2.0.0",
+    "builder-victory-component": "^2.0.1",
     "d3-ease": "^0.3.0",
     "d3-interpolate": "^0.2.0",
     "d3-scale": "^0.2.0",
@@ -32,7 +32,7 @@
     "reduce-css-calc": "^1.2.0"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^2.0.0",
+    "builder-victory-component-dev": "^2.0.1",
     "chai": "^3.2.0",
     "ecology": "^1.2.0",
     "enzyme": "^2.0.0",


### PR DESCRIPTION
**Don't merge**: Depends on https://github.com/FormidableLabs/builder-victory-component/pull/52
- Export app.jsx as module to support hot reloading.
- `docs/entry.jsx` is the new entrypoint.
- Wrap docs in `StyleRoot`
