### PR TITLE
Data transitions!

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,10 @@
-import Collection from "./victory-util/collection";
-import Helpers from "./victory-util/helpers";
-import Log from "./victory-util/log";
-import Style from "./victory-util/style";
-import PropTypes from "./victory-util/prop-types";
-import VictoryAnimation from "./victory-animation/victory-animation";
-import VictoryLabel from "./victory-label/victory-label";
+export { default as Collection } from "./victory-util/collection";
+export { default as Helpers } from "./victory-util/helpers";
+export { default as Log } from "./victory-util/log";
+export { default as Style } from "./victory-util/style";
+export { default as PropTypes } from "./victory-util/prop-types";
+import * as Transitions from "./victory-util/transitions";
+export { Transitions };
 
-export {
-  Collection,
-  Helpers,
-  Log,
-  PropTypes,
-  Style,
-  VictoryAnimation,
-  VictoryLabel
-};
+export { default as VictoryAnimation } from "./victory-animation/victory-animation";
+export { default as VictoryLabel } from "./victory-label/victory-label";

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -174,35 +174,122 @@ function getChildPropsOnEnter(animate, data, enteringNodes, cb) {
   return { animate, data };
 }
 
-export function childTransitionProps(parentState, parentAnimate, setParentState, childProps, index) {
+/**
+ * For each transition type (enter, exit, move), find the longest duration
+ * of each type from any of the children.
+ *
+ * @param  {Array}  children            `this.props.children` from parent component.
+ * @param  {Object} childrenTransitions Child transitions data, as calculated by the
+ *                                      `getInitialTransitionState` function.
+ * @param  {Object} parentAnimate       `this.props.animate` from parent component, to
+ *                                      be used for transition duration defaults.
+ *
+ * @return {Object}                     `{ exit, enter, move }`
+ */
+function getTransitionDurations (children, childrenTransitions, parentAnimate) {
+  if (!childrenTransitions) {
+    return {};
+  }
+
+  return children.reduce((durations, child, idx) => {
+    if (
+      childrenTransitions[idx] &&
+      childrenTransitions[idx].exiting &&
+      child.props.animate &&
+      child.props.animate.onExit &&
+      child.props.animate.onExit.duration > durations.exit
+    ) {
+      durations.exit = child.props.animate.onExit.duration;
+    }
+    if (
+      childrenTransitions[idx] &&
+      childrenTransitions[idx].entering &&
+      child.props.animate &&
+      child.props.animate.onEnter &&
+      child.props.animate.onEnter.duration > durations.enter
+    ) {
+      durations.enter = child.props.animate.onEnter.duration;
+    }
+    if (
+      child.props.animate &&
+      child.props.animate.duration > durations.move
+    ) {
+      durations.move = child.props.animate.duration;
+    }
+
+    return durations;
+  }, {
+    exit: parentAnimate.onExit && parentAnimate.onExit.duration || null,
+    enter: parentAnimate.onEnter && parentAnimate.onEnter.duration || null,
+    move: parentAnimate.duration || null
+  });
+}
+
+/**
+ * getTransitionPropsFactory - putting the Java in JavaScript.  This will return a
+ * function that returns prop transformations for a child, given that child's props
+ * and its index in the parent's children array.
+ *
+ * In particular, this will include an `animate` object that is set appropriately
+ * so that each child will be synchoronized for each stage of a transition
+ * animation.  It will also include a transformed `data` object, where each datum
+ * is transformed by `animate.onExit` and `animate.onEnter` `before` and `after`
+ * functions.
+ *
+ * @param  {Array}  children       `this.props.children` for the parent component.
+ * @param  {Object} parentState    `this.state` for the parent component.
+ * @param  {Object} parentAnimate  `this.props.animate` for the parent component.
+ * @param  {Object} setParentState Function that, when called, will `this.setState` on
+ *                                 the parent component with the provided object.
+ *
+ * @return {Function}              Child-prop transformation function.
+ */
+export function getTransitionPropsFactory(children, parentState, parentAnimate, setParentState) {
   const nodesWillExit = parentState && parentState.nodesWillExit;
   const nodesWillEnter = parentState && parentState.nodesWillEnter;
   const nodesShouldEnter = parentState && parentState.nodesShouldEnter;
   const childrenTransitions = parentState && parentState.childrenTransitions;
 
-  const animate = childProps.animate || parentAnimate;
-  const data = childProps.data;
+  const transitionDurations = getTransitionDurations(children, childrenTransitions, parentAnimate);
 
-  if (nodesWillExit) {
-    const exitingNodes = childrenTransitions[index] && childrenTransitions[index].exiting;
-    return getChildPropsOnExit(animate, data, exitingNodes, () => setParentState({ nodesWillExit: false }));
-  } else if (nodesWillEnter) {
-    const enteringNodes = childrenTransitions[index] && childrenTransitions[index].entering;
-    return nodesShouldEnter ?
-      getChildPropsOnEnter(animate, data, enteringNodes) :
-      getChildPropsBeforeEnter(animate, data, enteringNodes, () => setParentState({ nodesShouldEnter: true }));
-  } else if (!parentState && animate.onExit) {
-    // This is the initial render, and nodes may enter when props change. Because
-    // animation interpolation is determined by old- and next- props, data may need
-    // to be augmented with certain properties.
-    //
-    // For example, it may be desired that exiting nodes go from `opacity: 1` to
-    // `opacity: 0`. Without setting this on a per-datum basis, the interpolation
-    // might go from `opacity: undefined` to `opacity: 0`, which would result in
-    // interpolated `opacity: NaN` values.
-    //
-    return getInitialChildProps(animate, data);
-  }
+  return function getTransitionProps (childProps, index) {
+    let animate = childProps.animate || parentAnimate;
+    const data = childProps.data;
 
-  return { animate, data };
+    if (nodesWillExit) {
+      const exitingNodes = childrenTransitions[index] && childrenTransitions[index].exiting;
+      // Synchronize exit-transition durations for all child components.
+      animate = assign({}, animate, { duration: transitionDurations.exit });
+
+      return getChildPropsOnExit(animate, data, exitingNodes, () => setParentState({ nodesWillExit: false }));
+    } else if (nodesWillEnter) {
+      const enteringNodes = childrenTransitions[index] && childrenTransitions[index].entering;
+      animate = assign(
+        {},
+        animate,
+        // Synchronize normal animate and enter-transition durations for all child
+        // components, ONLY IF an enter-transition will occur.  Otherwise, child
+        // components can have different durations for shared-node animations.
+        { duration: transitionDurations[nodesShouldEnter ? "enter" : "move"] }
+      );
+
+      return nodesShouldEnter ?
+        getChildPropsOnEnter(animate, data, enteringNodes) :
+        getChildPropsBeforeEnter(animate, data, enteringNodes, () => setParentState({ nodesShouldEnter: true }));
+    } else if (!parentState && animate.onExit) {
+      // This is the initial render, and nodes may enter when props change. Because
+      // animation interpolation is determined by old- and next- props, data may need
+      // to be augmented with certain properties.
+      //
+      // For example, it may be desired that exiting nodes go from `opacity: 1` to
+      // `opacity: 0`. Without setting this on a per-datum basis, the interpolation
+      // might go from `opacity: undefined` to `opacity: 0`, which would result in
+      // interpolated `opacity: NaN` values.
+      //
+      return getInitialChildProps(animate, data);
+    }
+
+    return { animate, data };
+
+  };
 }

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -122,11 +122,11 @@ function getChildPropsOnExit(animate, data, exitingNodes, cb) { // eslint-disabl
     // nodes that are neither exiting or entering.
     animate.onEnd = cb;
 
-    // If nodes need to exit, all we want to do is to fade them out.
+    // If nodes need to exit, transform them with the provided onExit.after function.
     data = data.map((datum, idx) => {
       const key = (datum.key || idx).toString();
       return exitingNodes[key] ?
-        Object.assign({}, datum, { opacity: 0 }) :
+        Object.assign({}, datum, animate.onExit.after(datum)) :
         datum;
     });
   }

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-style */
+
 import assign from "lodash/assign";
 
 
@@ -64,56 +66,53 @@ function getNodeTransitions(oldData, nextData) {
  *                                    - childrenTransitions
  *                                    - nodesShouldEnter
  */
-export function getInitialTransitionState (oldChildren, nextChildren) {
-    let nodesWillExit = false;
-    let nodesWillEnter = false;
+export function getInitialTransitionState(oldChildren, nextChildren) {
+  let nodesWillExit = false;
+  let nodesWillEnter = false;
 
-    // Children may be a single item, rather than an array.
-    oldChildren = [].concat(oldChildren);
-    nextChildren = [].concat(nextChildren);
+  // Children may be a single item, rather than an array.
+  oldChildren = [].concat(oldChildren);
+  nextChildren = [].concat(nextChildren);
 
-    const childrenTransitions = oldChildren.map((child, idx) => {
-      // TODO: Determine if/how we want to support variable-length children.
-      const nextChild = nextChildren[idx];
-      if (!nextChild || child.type !== nextChild.type) {
-        return {};
-      }
+  const childrenTransitions = oldChildren.map((child, idx) => {
+    // TODO: Determine if/how we want to support variable-length children.
+    const nextChild = nextChildren[idx];
+    if (!nextChild || child.type !== nextChild.type) {
+      return {};
+    }
 
-      const { entering, exiting } =
-        child.type.supportsTransitions &&
-        getNodeTransitions(child.props.data, nextChild.props.data) ||
-        {};
+    const { entering, exiting } =
+      child.type.supportsTransitions &&
+      getNodeTransitions(child.props.data, nextChild.props.data) ||
+      {};
 
-      nodesWillExit = nodesWillExit || !!exiting;
-      nodesWillEnter = nodesWillEnter || !!entering;
+    nodesWillExit = nodesWillExit || !!exiting;
+    nodesWillEnter = nodesWillEnter || !!entering;
 
-      return { entering, exiting };
-    });
+    return { entering, exiting };
+  });
 
-    return {
-      nodesWillExit,
-      nodesWillEnter,
-      childrenTransitions,
-      // TODO: This may need to be refactored for the following situation.
-      //       The component receives new props, and the data provided
-      //       is a perfect match for the previous data and domain except
-      //       for new nodes. In this case, we wouldn't want a delay before
-      //       the new nodes appear.
-      nodesShouldEnter: false
-    };
+  return {
+    nodesWillExit,
+    nodesWillEnter,
+    childrenTransitions,
+    // TODO: This may need to be refactored for the following situation.
+    //       The component receives new props, and the data provided
+    //       is a perfect match for the previous data and domain except
+    //       for new nodes. In this case, we wouldn't want a delay before
+    //       the new nodes appear.
+    nodesShouldEnter: false
+  };
 }
 
 
 function getInitialChildProps(animate, data) {
-  data = data.map((datum, idx) => {
-    const key = getDatumKey(datum, idx);
-    return assign({}, datum, animate.onExit.before(datum));
-  });
-
-  return { data };
+  return {
+    data: data.map((datum) => assign({}, datum, animate.onExit.before(datum)))
+  };
 }
 
-function getChildPropsOnExit(animate, data, exitingNodes, cb) {
+function getChildPropsOnExit(animate, data, exitingNodes, cb) { // eslint-disable-line max-params
   // Whether or not _this_ child has exiting nodes, we want the exit-
   // transition for all children to have the same duration, delay, etc.
   animate = assign({}, animate, animate.onExit);
@@ -129,13 +128,13 @@ function getChildPropsOnExit(animate, data, exitingNodes, cb) {
       return exitingNodes[key] ?
         Object.assign({}, datum, { opacity: 0 }) :
         datum;
-    })
+    });
   }
 
   return { animate, data };
 }
 
-function getChildPropsBeforeEnter(animate, data, enteringNodes, cb) {
+function getChildPropsBeforeEnter(animate, data, enteringNodes, cb) { // eslint-disable-line max-params,max-len
   if (enteringNodes) {
     // Perform a normal animation here, except - when it finishes - trigger
     // the transition for entering nodes.
@@ -149,13 +148,13 @@ function getChildPropsBeforeEnter(animate, data, enteringNodes, cb) {
       return enteringNodes[key] ?
         Object.assign({}, datum, animate.onEnter.before(datum)) :
         datum;
-    });    
+    });
   }
 
   return { animate, data };
 }
 
-function getChildPropsOnEnter(animate, data, enteringNodes, cb) {
+function getChildPropsOnEnter(animate, data, enteringNodes) {
   // Whether or not _this_ child has entering nodes, we want the entering-
   // transition for all children to have the same duration, delay, etc.
   animate = assign({}, animate, animate.onEnter);
@@ -186,7 +185,7 @@ function getChildPropsOnEnter(animate, data, enteringNodes, cb) {
  *
  * @return {Object}                     `{ exit, enter, move }`
  */
-function getTransitionDurations (children, childrenTransitions, parentAnimate) {
+function getTransitionDurations(children, childrenTransitions, parentAnimate) {
   if (!childrenTransitions) {
     return {};
   }
@@ -244,7 +243,7 @@ function getTransitionDurations (children, childrenTransitions, parentAnimate) {
  *
  * @return {Function}              Child-prop transformation function.
  */
-export function getTransitionPropsFactory(children, parentState, parentAnimate, setParentState) {
+export function getTransitionPropsFactory(children, parentState, parentAnimate, setParentState) { // eslint-disable-line max-params,max-len
   const nodesWillExit = parentState && parentState.nodesWillExit;
   const nodesWillEnter = parentState && parentState.nodesWillEnter;
   const nodesShouldEnter = parentState && parentState.nodesShouldEnter;
@@ -252,7 +251,7 @@ export function getTransitionPropsFactory(children, parentState, parentAnimate, 
 
   const transitionDurations = getTransitionDurations(children, childrenTransitions, parentAnimate);
 
-  return function getTransitionProps (childProps, index) {
+  return function getTransitionProps(childProps, index) {
     let animate = childProps.animate || parentAnimate;
     const data = childProps.data;
 
@@ -261,7 +260,8 @@ export function getTransitionPropsFactory(children, parentState, parentAnimate, 
       // Synchronize exit-transition durations for all child components.
       animate = assign({}, animate, { duration: transitionDurations.exit });
 
-      return getChildPropsOnExit(animate, data, exitingNodes, () => setParentState({ nodesWillExit: false }));
+      return getChildPropsOnExit(animate, data, exitingNodes, () =>
+        setParentState({ nodesWillExit: false }));
     } else if (nodesWillEnter) {
       const enteringNodes = childrenTransitions[index] && childrenTransitions[index].entering;
       animate = assign(
@@ -275,7 +275,8 @@ export function getTransitionPropsFactory(children, parentState, parentAnimate, 
 
       return nodesShouldEnter ?
         getChildPropsOnEnter(animate, data, enteringNodes) :
-        getChildPropsBeforeEnter(animate, data, enteringNodes, () => setParentState({ nodesShouldEnter: true }));
+        getChildPropsBeforeEnter(animate, data, enteringNodes, () =>
+          setParentState({ nodesShouldEnter: true }));
     } else if (!parentState && animate.onExit) {
       // This is the initial render, and nodes may enter when props change. Because
       // animation interpolation is determined by old- and next- props, data may need

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -1,0 +1,200 @@
+import assign from "lodash/assign";
+
+
+function getKeyedData(data) {
+  return data.reduce((keyedData, datum, idx) => {
+    const key = (datum.key || idx).toString();
+    keyedData[key] = datum;
+    return keyedData;
+  }, {});
+}
+
+function getKeyedDataDifference(a, b) {
+  let hasDifference = false;
+  const difference = Object.keys(a).reduce((_difference, key) => {
+    if (!(key in b)) {
+      hasDifference = true;
+      _difference[key] = true;
+    }
+    return _difference;
+  }, {});
+  return hasDifference && difference;
+}
+
+/**
+ * Calculate which data-points exist in oldData and not nextData -
+ * these are the `entering` data-points.  Also calculate which
+ * data-points exist in nextData and not oldData - thses are the
+ * `entering` data-points.
+ *
+ * @param  {Array} oldData   this.props.data Array
+ * @param  {Array} nextData  this.props.data Array
+ *
+ * @return {Object}          Object with `entering` and `exiting` properties.
+ *                           entering[datum.key] will be true if the data is
+ *                           entering, and similarly for `exiting`.
+ */
+function getNodeTransitions(oldData, nextData) {
+  const oldDataKeyed = getKeyedData(oldData);
+  const nextDataKeyed = getKeyedData(nextData);
+
+  return {
+    entering: getKeyedDataDifference(nextDataKeyed, oldDataKeyed),
+    exiting: getKeyedDataDifference(oldDataKeyed, nextDataKeyed)
+  };
+}
+
+/**
+ * If a parent component has animation enabled, calculate the transitions
+ * for any data of any child component that supports data transitions
+ * Data transitions are defined as any two datasets where data nodes exist
+ * in the first set and not the second, in the second and not the first,
+ * or both.
+ *
+ * @param  {Children}  oldChildren   this.props.children from old props
+ * @param  {Children}  nextChildren  this.props.children from next props
+ *
+ * @return {Object}                  Object with the following properties:
+ *                                    - nodesWillExit
+ *                                    - nodesWillEnter
+ *                                    - childrenTransitions
+ *                                    - nodesShouldEnter
+ */
+export function getInitialTransitionState (oldChildren, nextChildren) {
+    let nodesWillExit = false;
+    let nodesWillEnter = false;
+
+    // Children may be a single item, rather than an array.
+    oldChildren = [].concat(oldChildren);
+    nextChildren = [].concat(nextChildren);
+
+    const childrenTransitions = oldChildren.map((child, idx) => {
+      // TODO: Determine if/how we want to support variable-length children.
+      const nextChild = nextChildren[idx];
+      if (!nextChild || child.type !== nextChild.type) {
+        return {};
+      }
+
+      const { entering, exiting } =
+        child.type.supportsTransitions &&
+        getNodeTransitions(child.props.data, nextChild.props.data) ||
+        {};
+
+      nodesWillExit = nodesWillExit || !!exiting;
+      nodesWillEnter = nodesWillEnter || !!entering;
+
+      return { entering, exiting };
+    });
+
+    return {
+      nodesWillExit,
+      nodesWillEnter,
+      childrenTransitions,
+      // TODO: This may need to be refactored for the following situation.
+      //       The component receives new props, and the data provided
+      //       is a perfect match for the previous data and domain except
+      //       for new nodes. In this case, we wouldn't want a delay before
+      //       the new nodes appear.
+      nodesShouldEnter: false
+    };
+}
+
+
+function getChildPropsOnExit(animate, data, exitingNodes, cb) {
+  if (exitingNodes) {
+    animate = assign({}, animate || {}, {
+      duration: 500,
+      onEnd: cb
+    });
+
+    // If nodes need to exit, all we want to do is to fade them out.
+    data = data.map((datum, idx) => {
+      const key = (datum.key || idx).toString();
+      return exitingNodes[key] ?
+        Object.assign({}, datum, { opacity: 0 }) :
+        datum;
+    })
+  } else {
+    // Although components without transitioning data may not seem like
+    // they need to animate here, VictoryAnimation uses old props to
+    // determine things like interpolated domain.  So we'll do a no-op
+    // animate here.
+    animate = { duration: 500 };
+  }
+
+  return { animate, data };
+}
+
+function getChildPropsBeforeEnter(animate, data, enteringNodes, cb) {
+  if (enteringNodes) {
+    // We want the nodes-to-enter to be factored into the target domain,
+    // but we do not want them to be displayed yet.
+      animate = enteringNodes ?
+        assign({}, animate || {}, {
+          delay: 0,
+          onEnd: cb
+        }) :
+        {};
+
+      data = data.map((datum, idx) => {
+        const key = (datum.key || idx).toString();
+        return enteringNodes[key] ?
+          Object.assign({}, datum, { opacity: 0 }) :
+          datum;
+      });    
+  }
+
+  return { animate, data };
+}
+
+function getChildPropsOnEnter(animate, data, enteringNodes, cb) {
+  if (enteringNodes) {
+    // Old nodes have been transitioned to their new values, and the
+    // domain should encompass the nodes that will now enter. So,
+    // fade in the new nodes.
+    animate = enteringNodes ?
+      assign({}, animate, {
+        delay: 0,
+        duration: 500
+      }) :
+      // Although components without transitioning data may not seem like
+      // they need to animate here, VictoryAnimation uses old props to
+      // determine things like interpolated domain.  For that reason,
+      // trigger VictoryAnimation use by passing an empty animation object.
+      { duration: 500 };
+
+    data = data.map((datum, idx) => {
+      const key = (datum.key || idx).toString();
+      return enteringNodes[key] ?
+        Object.assign({}, datum, { opacity: 1 }) :
+        datum;
+    });
+  }
+  return { animate, data };
+}
+
+export function childTransitionProps(parentState, parentAnimate, setParentState, childProps, index) {
+  const nodesWillExit = parentState && parentState.nodesWillExit;
+  const nodesWillEnter = parentState && parentState.nodesWillEnter;
+  const nodesShouldEnter = parentState && parentState.nodesShouldEnter;
+  const childrenTransitions = parentState && parentState.childrenTransitions;
+
+  const animate = childProps.animate || parentAnimate;
+  const data = childProps.data;
+
+  if (nodesWillExit) {
+    const exitingNodes = childrenTransitions[index] && childrenTransitions[index].exiting;
+    return getChildPropsOnExit(animate, data, exitingNodes, () => setParentState({ nodesWillExit: false }));
+  }
+  if (nodesWillEnter) {
+    const enteringNodes = childrenTransitions[index] && childrenTransitions[index].entering;
+
+    if (enteringNodes) {
+      return nodesShouldEnter ?
+        getChildPropsOnEnter(animate, data, enteringNodes) :
+        getChildPropsBeforeEnter(animate, data, enteringNodes, () => setParentState({ nodesShouldEnter: true }));
+    }
+  }
+
+  return { animate, data };
+}


### PR DESCRIPTION
Transitions consist of a sequence of animations.

```
Given dataset A, composed from this.props.children...data, and dataset B,
composed from nextProps.children...data, and where:

  exitingNodes = relative complement of B with respect to A
  enteringNodes = relative complement of A with respect to B
  sharedNodes = intersection of A and B

The animation sequence occurs like so:

  exitingNodes transition --> sharedNodes transition --> enteringNodes transition
```

If `exitingNodes` and `enteringNodes` are empty sets, the animation should behave as it did before any changes related to this PR (with a very minimal one-time performance hit when `props` are received).  And to clarify, a datum is considered to be in both A and B if one datum exists in each with the same key.  In the fallback case, this key will be the datum index.  However, data can include a `key` property.

This PR adds a `Transitions` module to `victory-core`, which provides two externally-facing functions:
### `getInitialTransitionState`

This should be called in `componentWillReceiveProps` for any parent component that is orchestrating transitions for its children.

It will calculate if any data nodes will exit (`VictoryScatter` example: fade-out at beginning), if any data nodes will enter (`VictoryScatter` example: fade-in at end), whether nodes should immediately start entering (answer: usually no), and meta-data about each child's specific data transitions.

Should be used like so:

``` javascript
const {
  nodesWillExit,
  nodesWillEnter,
  childrenTransitions,
  nodesShouldEnter
} = Transitions.getInitialTransitionState(this.props.children, nextProps.children);

this.setState({
  nodesWillExit,
  nodesWillEnter,
  childrenTransitions,
  nodesShouldEnter,
  oldProps: nodesWillExit ? this.props : null,
});
```
### `getTransitionPropsFactory`

This function accepts information about the parent and about _all_ its children, and returns a function that can transform individual child props.

Should be used like so:

``` javascript
const getTransitionProps = Transitions.getTransitionPropsFactory(
  childComponents,
  this.state,
  this.props.animate,
  (newState) => this.setState(newState)
);

return childComponents.map((child, index) => {
  const transitionProps = getTransitionProps(child.props, index);
  // ...
  return React.cloneElement(child, assign({ /* ... */ }, child.props, transitionProps));
});
```
### Follow-up PRs:
- [x] ~~add functionality such that if `exitingNodes` and `sharedNodes` are empty (as described above), immediately proceed to transition for `enteringNodes`. ([link](https://github.com/FormidableLabs/victory-core/blob/57a94970e43a9547a7348f3184cddee5940e211a/src/victory-util/transitions.js#L102-L102))~~ #38 
- [x] ~~similar to how `getTransitionDurations` works, we may want something similar for animation delays.~~ #39
- [x] ~~add default transition functions for different chart types, such that if `onExit` or `onEnter` are not specified, a sensible transition will still occur.  Example: `VictoryScatter` nodes should fade in/out.~~ https://github.com/FormidableLabs/victory-chart/issues/168

![data-transitions](https://cloud.githubusercontent.com/assets/5016978/14055646/d82a7c88-f2a0-11e5-9c71-ac402c99337f.gif)

Closes #14.  `VictoryChart` and `VictoryScatter` are updated with necessary changes in https://github.com/FormidableLabs/victory-chart/pull/152.

@boygirl @coopy @kenwheeler 
