### PR TITLE
Adds label angle prop

### DIFF
--- a/demo/victory-label/demo.jsx
+++ b/demo/victory-label/demo.jsx
@@ -17,6 +17,14 @@ export default class App extends React.Component {
             text={"Victory is awesome.\nThis is default anchoring.\nCapisce?"}
           />
 
+
+          <circle cx="0" cy="75" r="2" fill="red"/>
+          <VictoryLabel
+            x={0} y={75}
+            angle={65}
+            text={"Now with angles!!"}
+          />
+
           <circle cx="300" cy="150" r="2" fill="green"/>
           <VictoryLabel x={300} y={150} textAnchor="end" verticalAnchor="start"
             style={{ fill: "blue" }}

--- a/src/victory-label/victory-label.jsx
+++ b/src/victory-label/victory-label.jsx
@@ -13,6 +13,13 @@ const defaultStyles = {
 export default class VictoryLabel extends React.Component {
   static propTypes = {
     /**
+     * Specifies the angle to rotate the text by.
+     */
+    angle: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
+    /**
      * The capHeight prop defines a text metric for the font being used: the
      * expected height of capital letters. This is necessary because of SVG,
      * which (a) positions the *bottom* of the text at `y`, and (b) has no
@@ -192,11 +199,19 @@ export default class VictoryLabel extends React.Component {
     }
   }
 
+  getTransform(props) {
+    const {transform, datum, x, y, angle} = props;
+    const transformPart = transform && Helpers.evaluateProp(transform, datum);
+    const rotatePart = angle && {rotate: [angle, x, y]};
+
+    return Style.toTransformString(transformPart, rotatePart);
+  }
+
   render() {
     const datum = this.props.datum || this.props.data;
     const lineHeight = this.getHeight(this.props, "lineHeight");
-    const transform = this.props.transform &&
-      Style.toTransformString(Helpers.evaluateProp(this.props.transform, datum));
+    const transform = this.getTransform(this.props);
+
     const textAnchor = this.props.textAnchor ?
       Helpers.evaluateProp(this.props.textAnchor, datum) : "start";
     const content = this.getContent(this.props);

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -1,16 +1,20 @@
 import reduceCSSCalc from "reduce-css-calc";
 
-export default {
-  /**
-   * Given an object with CSS/SVG transform definitions, return the string value
-   * for use with the `transform` CSS property or SVG attribute. Note that we
-   * can't always guarantee the order will match the author's intended order, so
-   * authors should only use the object notation if they know that their transform
-   * is commutative or that there is only one.
-   * @param {Object} obj An object of transform definitions.
-   * @returns {String} The generated transform string.
-   */
-  toTransformString(obj) {
+/**
+ * Given an object with CSS/SVG transform definitions, return the string value
+ * for use with the `transform` CSS property or SVG attribute. Note that we
+ * can't always guarantee the order will match the author's intended order, so
+ * authors should only use the object notation if they know that their transform
+ * is commutative or that there is only one.
+ * @param {Object} obj An object of transform definitions.
+ * @returns {String} The generated transform string.
+ */
+const toTransformString = function (obj, ...more) {
+  if (more.length > 0) {
+    return more.reduce((memo, currentObj) => {
+      return [memo, toTransformString(currentObj)].join(" ");
+    }, toTransformString(obj));
+  } else {
     if (!obj || typeof obj === "string") {
       return obj;
     }
@@ -22,7 +26,12 @@ export default {
       }
     }
     return transforms.join(" ");
-  },
+  }
+};
+
+export default {
+
+  toTransformString,
 
   calc(expr, precision) {
     return reduceCSSCalc(`calc(${expr})`, precision);

--- a/test/client/spec/victory-label/victory-label.spec.jsx
+++ b/test/client/spec/victory-label/victory-label.spec.jsx
@@ -23,6 +23,14 @@ describe("components/victory-label", () => {
     expect(output.html()).to.contain("such text, wow");
   });
 
+  it("has a transform property that rotates the text to match the labelAngle prop", () => {
+    const wrapper = shallow(
+      <VictoryLabel angle={46} text={"such text, wow"}/>
+    );
+    const output = wrapper.find("text");
+    expect(output.prop("transform")).to.contain("rotate(46");
+  });
+
   describe("event handling", () => {
     it("attaches an to the parent object", () => {
       const clickHandler = sinon.spy();

--- a/test/client/spec/victory-util/style.spec.js
+++ b/test/client/spec/victory-util/style.spec.js
@@ -4,4 +4,22 @@ describe("toTransformString", () => {
   it("returns an empty string if no transform definitions are given", () => {
     expect(Style.toTransformString({})).to.equal("");
   });
+
+  it("returns a string with two transform instructions when an object is given", () => {
+    expect(Style.toTransformString({
+      rotate: [45, 0, 1], skewY: [65]
+    })).to.equal("rotate(45,0,1) skewY(65)");
+  });
+
+  it("returns a string with two transform instructions when two objects are given", () => {
+    expect(Style.toTransformString(
+      {rotate: [45, 0, 1]}, {skewY: [65]}
+    )).to.equal("rotate(45,0,1) skewY(65)");
+  });
+
+  it("returns at least the subsequent transforms if the first is undefined", () => {
+    expect(Style.toTransformString(
+      null, {skewY: [65]}
+    )).to.contain("skewY(65)");
+  });
 });


### PR DESCRIPTION
re: FormidableLabs/victory-core#16

@coopy is this what you meant by labelAngle?

It is possible that we do not need this pull request, as, VictoryLabel already had a `transform` property.

In any case, I think this needs to be carried through to the components in VictoryChart and VictoryPie, right?

Do you want to support a `labelAngle` everywhere we have `label` or `labels` properties?

Do you want to support an `angle` property in `style: {labels: {}}` that gets filtered out and implemented in a `transform` ?

I also made an enhancement to `toTransformString` -- if it is to your liking, I will document it!
