### PR TITLE
investigate ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "d3-interpolate": "^0.2.0",
     "d3-scale": "^0.2.0",
     "d3-timer": "^0.0.6",
-    "lodash": "^4.6.1",
+    "lodash": "~4.6.1",
     "reduce-css-calc": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I tracked down the following error, and `lodash@4.7.0` looks to be responsible. 

```
Firefox 31.0.0 (Linux 0.0.0) ERROR
TypeError: Function.prototype.toString called on incompatible object
```
