### PR TITLE
Default transitions

### DIFF
--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -249,7 +249,11 @@ export function getTransitionPropsFactory(children, parentState, parentAnimate, 
 
   const transitionDurations = getTransitionDurations(children, childrenTransitions, parentAnimate);
 
-  return function getTransitionProps(childProps, childType, index) {
+  return function getTransitionProps(childProps, childType, index) { // eslint-disable-line max-statements,max-len
+    if (!childProps.data) {
+      return {};
+    }
+
     let animate = assign({}, childProps.animate || parentAnimate);
 
     if (childType.defaultTransitions) {

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -82,7 +82,7 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
     }
 
     const { entering, exiting } =
-      child.type.supportsTransitions &&
+      child.type.defaultTransitions &&
       getNodeTransitions(child.props.data, nextChild.props.data) ||
       {};
 
@@ -249,21 +249,26 @@ export function getTransitionPropsFactory(children, parentState, parentAnimate, 
 
   const transitionDurations = getTransitionDurations(children, childrenTransitions, parentAnimate);
 
-  return function getTransitionProps(childProps, index) {
-    let animate = childProps.animate || parentAnimate;
+  return function getTransitionProps(childProps, childType, index) {
+    let animate = assign({}, childProps.animate || parentAnimate);
+
+    if (childType.defaultTransitions) {
+      animate.onExit = animate.onExit || childType.defaultTransitions.onExit;
+      animate.onEnter = animate.onEnter || childType.defaultTransitions.onEnter;
+    }
+
     const data = childProps.data;
 
     if (nodesWillExit) {
       const exitingNodes = childrenTransitions[index] && childrenTransitions[index].exiting;
       // Synchronize exit-transition durations for all child components.
-      animate = assign({}, animate, { duration: transitionDurations.exit });
+      animate = assign(animate, { duration: transitionDurations.exit });
 
       return getChildPropsOnExit(animate, data, exitingNodes, () =>
         setParentState({ nodesWillExit: false }));
     } else if (nodesWillEnter) {
       const enteringNodes = childrenTransitions[index] && childrenTransitions[index].entering;
       animate = assign(
-        {},
         animate,
         // Synchronize normal animate and enter-transition durations for all child
         // components, ONLY IF an enter-transition will occur.  Otherwise, child


### PR DESCRIPTION
This changes allows Victory components to define default/fallback data transitions.

We're not doing any fancy merging here of provided and default transitions definitions, such that if a user were to provide only an `onEnter.before` function, the default `onEnter.after` and `onEnter.duration` would be used.  We can make this change, but it seemed reasonable to expect the user to provide explicit overrides of any default behaviors.

Thoughts @boygirl?
