### PR TITLE
Fix transitions for bar graph

### DIFF
--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -190,23 +190,32 @@ function getTransitionDurations(children, childrenTransitions, parentAnimate) {
   }
 
   return children.reduce((durations, child, idx) => {
+    const onExit =
+      child.props.animate &&
+      child.props.animate.onExit ||
+      child.type.defaultTransitions &&
+      child.type.defaultTransitions.onExit;
+    const onEnter =
+      child.props.animate &&
+      child.props.animate.onEnter ||
+      child.type.defaultTransitions &&
+      child.type.defaultTransitions.onEnter;
+
     if (
       childrenTransitions[idx] &&
       childrenTransitions[idx].exiting &&
-      child.props.animate &&
-      child.props.animate.onExit &&
-      child.props.animate.onExit.duration > durations.exit
+      onExit &&
+      onExit.duration > durations.exit
     ) {
-      durations.exit = child.props.animate.onExit.duration;
+      durations.exit = onExit.duration;
     }
     if (
       childrenTransitions[idx] &&
       childrenTransitions[idx].entering &&
-      child.props.animate &&
-      child.props.animate.onEnter &&
-      child.props.animate.onEnter.duration > durations.enter
+      onEnter &&
+      onEnter.duration > durations.enter
     ) {
-      durations.enter = child.props.animate.onEnter.duration;
+      durations.enter = onEnter.duration;
     }
     if (
       child.props.animate &&

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -260,10 +260,6 @@ export function getTransitionPropsFactory(children, parentState, parentAnimate, 
   const transitionDurations = getTransitionDurations(children, childrenTransitions, parentAnimate);
 
   return function getTransitionProps(childProps, childType, index) { // eslint-disable-line max-statements,max-len
-    if (!childProps.data) {
-      return {};
-    }
-
     let animate = assign({}, childProps.animate || parentAnimate);
 
     if (childType.defaultTransitions) {

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -109,7 +109,7 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
 function getInitialChildProps(animate, data) {
   const before = animate.onExit && animate.onExit.before ? animate.onExit.before : identity;
   return {
-    data: data.map((datum) => assign({}, datum, before(datum))),
+    data: data && data.map((datum) => assign({}, datum, before(datum))),
     animate: {}
   };
 }

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -109,7 +109,8 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
 function getInitialChildProps(animate, data) {
   const before = animate.onExit && animate.onExit.before ? animate.onExit.before : identity;
   return {
-    data: data.map((datum) => assign({}, datum, before(datum)))
+    data: data.map((datum) => assign({}, datum, before(datum))),
+    animate: {}
   };
 }
 


### PR DESCRIPTION
There were a few things overlooked, which `VictoryBar` brought to light.  This PR:
- Ensures that all child components have an `animate` prop when transitions are enabled.  This is required by `VictoryAnimation` so that next-tick state changes will animate by tweening old and new props.
- Includes `defaultTransitions` durations when calculating whole-animation exit- and enter- transition durations.
- Removes an oversight, where `animation` prop was not assigned to components with no `data` (e.g. `VictoryAxis`).
- Corrects an assumption that components passed to `getInitialChildProps` will have `data`.  This issue did not reveal itself until the above were corrected.

![bar transitions](https://cloud.githubusercontent.com/assets/5016978/14303133/e664c69a-fb5c-11e5-84ff-fbb90e306d44.gif)

There will be an accompanying PR for `VictoryChart` / `VictoryBar`.

@boygirl @kenwheeler 
