### PR TITLE
exit transition names are clearer

### DIFF
--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -116,9 +116,9 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
 }
 
 function getInitialChildProps(animate, data) {
-  const before = animate.onExit && animate.onExit.before ? animate.onExit.before : identity;
+  const after = animate.onEnter && animate.onEnter.after ? animate.onEnter.after : identity;
   return {
-    data: data.map((datum) => assign({}, datum, before(datum)))
+    data: data.map((datum) => assign({}, datum, after(datum)))
   };
 }
 
@@ -132,11 +132,11 @@ function getChildPropsOnExit(animate, data, exitingNodes, cb) { // eslint-disabl
     // After the exit transition occurs, trigger the animations for
     // nodes that are neither exiting or entering.
     animate.onEnd = cb;
-    const after = animate.onExit && animate.onExit.after ? animate.onExit.after : identity;
-    // If nodes need to exit, transform them with the provided onExit.after function.
+    const before = animate.onExit && animate.onExit.before ? animate.onExit.before : identity;
+    // If nodes need to exit, transform them with the provided onExit.before function.
     data = data.map((datum, idx) => {
       const key = (datum.key || idx).toString();
-      return exitingNodes[key] ? assign({}, datum, after(datum)) : datum;
+      return exitingNodes[key] ? assign({}, datum, before(datum)) : datum;
     });
   }
   return { animate, data };

--- a/test/client/spec/victory-util/transitions.spec.js
+++ b/test/client/spec/victory-util/transitions.spec.js
@@ -61,7 +61,7 @@ describe("getTransitionPropsFactory", () => {
     return {
       type: {
         defaultTransitions: {
-          onExit: {duration: 1, after: toZero },
+          onExit: {duration: 1, before: toZero },
           onEnter: {duration: 2, before: toZero }
         }
       },


### PR DESCRIPTION
the namespace `onExit.before` should describe the exit transition instead of `onExit.after`. `onExit.after` is unnecessary, as the node will simply be gone. Initial props should be defined by `onEnter.after`.
