### PR TITLE
add event helper

### DIFF
--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -2,7 +2,6 @@ import defaults from "lodash/defaults";
 import isFunction from "lodash/isFunction";
 import property from "lodash/property";
 import partial from "lodash/partial";
-import set from "lodash/set";
 import merge from "lodash/merge";
 
 

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -150,14 +150,13 @@ export default {
   },
 
   getEvents(events, namespace) {
-    const stateName = `${namespace}State`;
     const onEvent = (evt, childProps, index, eventName) => {
       if (this.props.events[namespace] && this.props.events[namespace][eventName]) {
         this.setState({
-          [stateName]: merge(
+          [index]: merge(
             {},
-            this.state[stateName],
-            set({}, index, this.props.events[namespace][eventName](evt, childProps, index))
+            this.state[index],
+            this.props.events[namespace][eventName](evt, childProps, index)
           )
         });
       }
@@ -168,5 +167,9 @@ export default {
         memo[event] = onEvent;
         return memo;
       }, {}) : {};
+  },
+
+  getEventState(index, namespace) {
+    return this.state[index] && this.state[index][namespace];
   }
 };

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -176,12 +176,12 @@ describe("helpers", () => {
         props: {
           events: {
             data: {
-              onClick: () => "foo"
+              onClick: () => { return {data: "foo"}; }
             }
           }
         },
         setState: (x) => x,
-        state: { dataState: {} }
+        state: {}
       };
       sandbox.spy(fake, "setState");
     });
@@ -199,8 +199,8 @@ describe("helpers", () => {
       expect(partialEvents).to.have.keys(["onClick"]);
       partialEvents.onClick();
       expect(fake.setState).calledWith({
-        dataState: {
-          [index]: "foo"
+        [index]: {
+          data: "foo"
         }
       });
     });


### PR DESCRIPTION
This PR changes how events are stored on state. Rather than being stored as 

```
state = {
 dataState: {
  [index] : {...},
  [index2]: {...}
 },
 labelsState: {
  [index] : {...},
  [index2]: {...}
 }
}
```

they will now be stored as

```
state = {
 [index]: {
  data : {...},
  labels: {...}
 },
 [index2]: {
  data : {...},
  labels: {...}
 }
}
```

this makes it easier to author events that interact with data and their associated labels i.e. tooltips
This is a breaking change, as it will require the namespace to be returned with any other props from the event i.e. 

```
events: {
 data: {
  onClick: () => { 
   return { data: { style: {fill: "red"} }, labels: { style: {fill: "black"} } };  
  }
 }
}
```
