### PR TITLE
add theme support for candlestick component

### DIFF
--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -33,6 +33,18 @@ export default {
       }),
     parent: {}
   },
+  candlestick: {
+    props: Object.assign({}, baseProps,
+      {candleColors: {positive: "#252525", negative: "#d9d9d9"}}),
+    data: {
+      fill: "grayscaleBlack",
+      opacity: 1,
+      stroke: "transparent",
+      strokeWidth: 1
+    },
+    labels: baseLabelStyles,
+    parent: {}
+  },
   bar: {
     data: {
       width: 8,

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -140,10 +140,11 @@ export default {
       {};
   },
 
-  modifyProps(props, fallbackProps) {
+  modifyProps(props, fallbackProps, themeProps) {
     const themeCheck = props.theme && props.theme.props;
+    const themePropsObject = themeCheck && !themeProps ? props.theme.props : themeProps;
 
-    return themeCheck ? defaults({}, props, props.theme.props, fallbackProps.props)
+    return themeCheck ? defaults({}, props, themePropsObject, fallbackProps.props)
     : defaults({}, props, fallbackProps.props);
   },
 


### PR DESCRIPTION
this pull request adds theme support for victory candlestick with an addition to the grayscale theme object and a modification to the modifyProps helper method

@boygirl 

references https://github.com/FormidableLabs/victory-chart/issues/260
