### PR TITLE
add a prop validation that checks if a value is greater than zero

### DIFF
--- a/src/victory-util/prop-types.js
+++ b/src/victory-util/prop-types.js
@@ -138,6 +138,22 @@ export default {
   }),
 
   /**
+   * Check that the value is greater than zero.
+   */
+  greaterThanZero: makeChainable((props, propName, componentName) => {
+    const error = PropTypes.number(props, propName, componentName);
+    if (error) {
+      return error;
+    }
+    const value = props[propName];
+    if (value < 1) {
+      return new Error(
+        `\`${propName}\` in \`${componentName}\` must be greater than zero.`
+      );
+    }
+  }),
+
+  /**
    * Check that the value is an Array of two unique values.
    */
   domain: makeChainable((props, propName, componentName) => {

--- a/src/victory-util/prop-types.js
+++ b/src/victory-util/prop-types.js
@@ -146,7 +146,7 @@ export default {
       return error;
     }
     const value = props[propName];
-    if (value < 1) {
+    if (value <= 0) {
       return new Error(
         `\`${propName}\` in \`${componentName}\` must be greater than zero.`
       );

--- a/test/client/spec/victory-util/prop-types.spec.js
+++ b/test/client/spec/victory-util/prop-types.spec.js
@@ -172,7 +172,7 @@ describe("prop-types", () => {
     });
 
     it("does not return an error for numbers greater than zero", () => {
-      let result = validate(3);
+      let result = validate(0.1);
       expect(result).not.to.be.an.instanceOf(Error);
       result = validate(5);
       expect(result).not.to.be.an.instanceOf(Error);

--- a/test/client/spec/victory-util/prop-types.spec.js
+++ b/test/client/spec/victory-util/prop-types.spec.js
@@ -142,6 +142,45 @@ describe("prop-types", () => {
     });
   });
 
+  describe("greaterThanZero", () => {
+    const validate = function (prop) {
+      return CustomPropTypes.greaterThanZero({testProp: prop}, "testProp", "TestComponent");
+    };
+
+    it("returns an error for non numeric values", () => {
+      const result = validate("a");
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).contain(
+          "`string` supplied to `TestComponent`, expected `number`."
+      );
+    });
+
+    it("returns an error for zero", () => {
+      const result = validate(0);
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).to.contain(
+          "`testProp` in `TestComponent` must be greater than zero."
+      );
+    });
+
+    it("returns an error for negative numbers", () => {
+      const result = validate(-3);
+      expect(result).to.be.an.instanceOf(Error);
+      expect(result.message).to.contain(
+          "`testProp` in `TestComponent` must be greater than zero."
+      );
+    });
+
+    it("does not return an error for numbers greater than zero", () => {
+      let result = validate(3);
+      expect(result).not.to.be.an.instanceOf(Error);
+      result = validate(5);
+      expect(result).not.to.be.an.instanceOf(Error);
+      result = validate(1);
+      expect(result).not.to.be.an.instanceOf(Error);
+    });
+  });
+
   describe("domain", () => {
     const validate = function (prop) {
       return CustomPropTypes.domain({testProp: prop}, "testProp", "TestComponent");


### PR DESCRIPTION
this adds a custom prop type that checks to ensure that a given value is greater than zero

@boygirl 

helps to support solution to https://github.com/FormidableLabs/victory-chart/issues/266 with https://github.com/FormidableLabs/victory-chart/pull/285
