### PR TITLE
modify modifyProps method for special casing with candlestick charts

### DIFF
--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -140,10 +140,11 @@ export default {
       {};
   },
 
-  modifyProps(props, fallbackProps) {
+  modifyProps(props, fallbackProps, themeProps) {
     const themeCheck = props.theme && props.theme.props;
+    const themePropsObject = themeCheck && !themeProps ? props.theme.props : themeProps;
 
-    return themeCheck ? defaults({}, props, props.theme.props, fallbackProps.props)
+    return themeCheck ? defaults({}, props, themePropsObject, fallbackProps.props)
     : defaults({}, props, fallbackProps.props);
   },
 


### PR DESCRIPTION
since grayscale is no longer a separate theme, I am closing https://github.com/FormidableLabs/victory-core/pull/76 in favor of this PR, which only modifies the helper methods to handle candlestick charts which have slightly different needs than the other ones when it comes to theme support

@boygirl 
