### PR TITLE
Docs: Move Style component and spellcheck for the props table

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router";
-import { StyleRoot } from "radium";
+import { Style, StyleRoot } from "radium";
+import { VictoryTheme } from "formidable-landers";
 
 const App = React.createClass({
   propTypes: {
@@ -15,6 +16,7 @@ const App = React.createClass({
           <li><Link to="/label">Victory Label Docs</Link></li>
         </ul>
         {this.props.children}
+        <Style rules={VictoryTheme}/>
       </StyleRoot>
     );
   }

--- a/docs/victory-animation/docs.js
+++ b/docs/victory-animation/docs.js
@@ -2,10 +2,10 @@ import React from "react";
 import { merge } from "lodash";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import * as docgen from "react-docgen";
 import { VictoryAnimation } from "../../src/index";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {
@@ -18,7 +18,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-label/docs.js
+++ b/docs/victory-label/docs.js
@@ -2,9 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { merge } from "lodash";
 import Ecology from "ecology";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import * as docgen from "react-docgen";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 import { VictoryLabel } from "../../src/index";
 
 class Docs extends React.Component {
@@ -18,7 +18,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -46,7 +46,7 @@ export default class VictoryContainer extends React.Component {
      * The title prop specifies the title to be applied to the SVG to assist
      * accessibility for screen readers. The more descriptive this title is, the more
      * useful it will be. If no title prop is passed, it will default to Victory Chart.
-     * @example "Popularity of Dog Breeds by Percentage"
+     * @examples "Popularity of Dog Breeds by Percentage"
      */
     title: PropTypes.string,
     /**
@@ -54,7 +54,7 @@ export default class VictoryContainer extends React.Component {
      * accessibility for screen readers. The more info about the chart provided in
      * the description, the more usable it will be for people using screen readers.
      * This prop defaults to an empty string.
-     * @example "Golden retreivers make up 30%, Labs make up 25%, and other dog breeds are
+     * @examples "Golden retreivers make up 30%, Labs make up 25%, and other dog breeds are
      * not represented above 5% each."
      */
     desc: PropTypes.string


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/victory-docs/issues/38
- Move repeated `<Style rules={VictoryTheme />` to `app.js` and delete from every `docs.js` 
- Spellcheck: `@example` should be `@examples` 

/cc @ebrillhart @kylecesmat @bmathews 
