### PR TITLE
Add code exports to docs

### DIFF
--- a/docs/victory-animation/docs.js
+++ b/docs/victory-animation/docs.js
@@ -17,6 +17,8 @@ class Docs extends React.Component {
           scope={{React, ReactDOM, VictoryAnimation}}
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
+          exportGist
+          copyToClipboard
         />
         <Style rules={VictoryTheme}/>
       </div>

--- a/docs/victory-label/docs.js
+++ b/docs/victory-label/docs.js
@@ -17,6 +17,8 @@ class Docs extends React.Component {
           scope={{React, ReactDOM, VictoryLabel}}
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
+          exportGist
+          copyToClipboard
         />
         <Style rules={VictoryTheme}/>
       </div>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "builder-victory-component-dev": "^2.3.0",
     "chai": "^3.2.0",
-    "ecology": "^1.5.1",
+    "ecology": "^1.6.0",
     "enzyme": "^2.3.0",
     "mocha": "^2.2.5",
     "radium": "^0.16.2",


### PR DESCRIPTION
This will add export buttons to the codeblocks when used in victory docs.

cc @paulathevalley 
