### PR TITLE
add a date check method

### DIFF
--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -22,5 +22,19 @@ export default {
 
   removeUndefined(arr) {
     return arr.filter((el) => el !== undefined);
+  },
+
+  getMaxValue(arr, value) {
+    const array = value ? arr.concat(value) : arr;
+    return this.containsDates(array) ?
+    new Date(Math.max(...array)) :
+    Math.max(...array);
+  },
+
+  getMinValue(arr, value) {
+    const array = value ? arr.concat(value) : arr;
+    return this.containsDates(array) ?
+    new Date(Math.min(...array)) :
+    Math.min(...array);
   }
 };

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -25,14 +25,14 @@ export default {
   },
 
   getMaxValue(arr, ...values) {
-    const array = values ? arr.concat(values) : arr;
+    const array = arr.concat(values);
     return this.containsDates(array) ?
     new Date(Math.max(...array)) :
     Math.max(...array);
   },
 
   getMinValue(arr, ...values) {
-    const array = values ? arr.concat(values) : arr;
+    const array = arr.concat(values);
     return this.containsDates(array) ?
     new Date(Math.min(...array)) :
     Math.min(...array);

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -27,14 +27,14 @@ export default {
   getMaxValue(arr, ...values) {
     const array = arr.concat(values);
     return this.containsDates(array) ?
-    new Date(Math.max(...array)) :
-    Math.max(...array);
+      new Date(Math.max(...array)) :
+      Math.max(...array);
   },
 
   getMinValue(arr, ...values) {
     const array = arr.concat(values);
     return this.containsDates(array) ?
-    new Date(Math.min(...array)) :
-    Math.min(...array);
+      new Date(Math.min(...array)) :
+      Math.min(...array);
   }
 };

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -24,15 +24,15 @@ export default {
     return arr.filter((el) => el !== undefined);
   },
 
-  getMaxValue(arr, value) {
-    const array = value ? arr.concat(value) : arr;
+  getMaxValue(arr, ...values) {
+    const array = values ? arr.concat(values) : arr;
     return this.containsDates(array) ?
     new Date(Math.max(...array)) :
     Math.max(...array);
   },
 
-  getMinValue(arr, value) {
-    const array = value ? arr.concat(value) : arr;
+  getMinValue(arr, ...values) {
+    const array = values ? arr.concat(values) : arr;
     return this.containsDates(array) ?
     new Date(Math.min(...array)) :
     Math.min(...array);

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -170,5 +170,9 @@ export default {
 
   getEventState(index, namespace) {
     return this.state[index] && this.state[index][namespace];
+  },
+
+  retainDate(value) {
+    return new Date(value);
   }
 };

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -170,9 +170,5 @@ export default {
 
   getEventState(index, namespace) {
     return this.state[index] && this.state[index][namespace];
-  },
-
-  retainDate(value) {
-    return new Date(value);
   }
 };

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -115,4 +115,40 @@ describe("collections", () => {
       expect(Collection.removeUndefined(testArray)).to.eql(expectedArray);
     });
   });
+
+  describe("getMaxValue", () => {
+
+    it("returns a date if array contains dates", () => {
+      const array = [new Date(2016, 3, 6), new Date(2017, 5, 3), 10];
+      expect(Collection.getMaxValue(array)).to.eql(new Date(2017, 5, 3));
+    });
+
+    it("returns a number if array does not contain dates", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMaxValue(array)).to.eql(10);
+    });
+
+    it("allows values to be concated and returns the appropriate number", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMaxValue(array, 1, 20)).to.eql(20);
+    });
+  });
+
+  describe("getMinValue", () => {
+
+    it("returns a date if array contains dates", () => {
+      const array = [new Date(2016, 3, 6), new Date(2017, 5, 3), new Date(2015, 11, 4)];
+      expect(Collection.getMinValue(array)).to.eql(new Date(2015, 11, 4));
+    });
+
+    it("returns a number if array does not contain dates", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMinValue(array)).to.eql(3);
+    });
+
+    it("allows values to be concated and returns the appropriate number", () => {
+      const array = [3, 8, 10];
+      expect(Collection.getMinValue(array, 1, 20)).to.eql(1);
+    });
+  });
 });


### PR DESCRIPTION
this adds a date check method in order to support the fix for axes auto crossing if values contain Jan 1, 1970

https://github.com/FormidableLabs/victory/issues/139

@boygirl 
