### PR TITLE
Simplify theme and fallback props

### DIFF
--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -203,7 +203,8 @@ export default class VictoryLabel extends React.Component {
     const transform = props.transform || style.transform;
     const transformPart = transform && Helpers.evaluateProp(transform, datum);
     const rotatePart = angle && {rotate: [angle, x, y]};
-    return (transformPart || angle) && Style.toTransformString(transformPart, rotatePart);
+    return transformPart || angle ?
+      Style.toTransformString(transformPart, rotatePart) : undefined;
   }
 
   renderElements(props, content) {
@@ -230,12 +231,13 @@ export default class VictoryLabel extends React.Component {
   render() {
     const datum = this.props.datum || this.props.data;
     const style = this.getStyles(this.props);
+    const fontSize = style.fontSize || 14;
     const lineHeight = this.getHeight(this.props, "lineHeight");
     const textAnchor = this.props.textAnchor ?
       Helpers.evaluateProp(this.props.textAnchor, datum) : "start";
     const content = this.getContent(this.props);
     const dx = this.props.dx ? Helpers.evaluateProp(this.props.dx, datum) : 0;
-    const dy = this.getDy(this.props, content, lineHeight) * style.fontSize;
+    const dy = this.getDy(this.props, content, lineHeight) * fontSize;
     const labelProps = assign(
       {}, this.props, { dy, dx, datum, lineHeight, textAnchor, style }, this.props.events
     );

--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -138,7 +138,7 @@ export default {
       })
     }
   }, baseProps),
-  pie: assign({
+  pie: {
     style: {
       data: {
         padding: 10,
@@ -150,8 +150,11 @@ export default {
         textAnchor: "middle"
       })
     },
-    colorScale: colors
-  }, baseProps),
+    colorScale: colors,
+    width: 400,
+    height: 400,
+    padding: 50
+  },
   scatter: assign({
     style: {
       data: {

--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -1,0 +1,169 @@
+import { assign } from "lodash";
+
+// *
+// * Colors
+// *
+const colors = [
+  "#ffffff",
+  "#f0f0f0",
+  "#d9d9d9",
+  "#bdbdbd",
+  "#969696",
+  "#737373",
+  "#525252",
+  "#252525",
+  "#000000"
+];
+
+const charcoal = "#252525";
+// *
+// * Typography
+// *
+const sansSerif = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
+const letterSpacing = "normal";
+const fontSize = 14;
+// *
+// * Layout
+// *
+const baseProps = {
+  width: 450,
+  height: 300,
+  padding: 50,
+  colorScale: colors
+};
+// *
+// * Labels
+// *
+const baseLabelStyles = {
+  fontFamily: sansSerif,
+  fontSize,
+  letterSpacing,
+  padding: 10,
+  fill: charcoal,
+  stroke: "transparent"
+};
+// *
+// * Strokes
+// *
+const strokeDasharray = "10, 5";
+const strokeLinecap = "round";
+const strokeLinejoin = "round";
+
+export default {
+  area: {
+    style: {
+      data: {
+        fill: charcoal
+      },
+      labels: baseLabelStyles
+    }
+  },
+  axis: {
+    style: {
+      axis: {
+        fill: "none",
+        stroke: charcoal,
+        strokeWidth: 1,
+        strokeLinecap,
+        strokeLinejoin
+      },
+      axisLabel: assign({}, baseLabelStyles, {
+        padding: 25
+      }),
+      grid: {
+        fill: "none",
+        stroke: "transparent",
+      },
+      ticks: {
+        fill: "none",
+        padding: 10,
+        size: 1,
+        stroke: "transparent"
+      },
+      tickLabels: baseLabelStyles
+    }
+  },
+  bar: {
+    style: {
+      data: {
+        fill: charcoal,
+        padding: 10,
+        stroke: "transparent",
+        strokeWidth: 0,
+        width: 8
+      },
+      labels: baseLabelStyles
+    }
+  },
+  candlestick: {
+    style: {
+      data: {
+        stroke: charcoal,
+        strokeWidth: 1
+      },
+      labels: assign({}, baseLabelStyles, {
+        padding: 25,
+        textAnchor: "end"
+      })
+    },
+    candleColors: {
+      positive: "#ffffff",
+      negative: charcoal
+    }
+  },
+  errorbar: {
+    style: {
+      data: {
+        fill: "none",
+        stroke: charcoal,
+        strokeWidth: 2
+      },
+      labels: assign({}, baseLabelStyles, {
+        textAnchor: "start"
+      })
+    }
+  },
+  line: {
+    style: {
+      data: {
+        fill: "none",
+        stroke: charcoal,
+        strokeWidth: 2
+      },
+      labels: assign({}, baseLabelStyles, {
+        textAnchor: "start"
+      })
+    }
+  },
+  pie: {
+    style: {
+      data: {
+        padding: 10,
+        stroke: "none",
+        strokeWidth: 1
+      },
+      labels: assign({}, baseLabelStyles, {
+        padding: 200,
+        textAnchor: "middle"
+      })
+    },
+    colorScale: colors
+  },
+  scatter: {
+    style: {
+      data: {
+        fill: charcoal,
+        stroke: "transparent",
+        strokeWidth: 0
+      },
+      labels: Object.assign({}, baseLabelStyles, {
+        textAnchor: "middle"
+      })
+    }
+  },
+  props: Object.assign({}, baseProps,
+    {
+      colorScale: colors
+    }
+  )
+};

--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -49,15 +49,15 @@ const strokeLinecap = "round";
 const strokeLinejoin = "round";
 
 export default {
-  area: {
+  area: assign({
     style: {
       data: {
         fill: charcoal
       },
       labels: baseLabelStyles
     }
-  },
-  axis: {
+  }, baseProps),
+  axis: assign({
     style: {
       axis: {
         fill: "none",
@@ -81,8 +81,8 @@ export default {
       },
       tickLabels: baseLabelStyles
     }
-  },
-  bar: {
+  }, baseProps),
+  bar: assign({
     style: {
       data: {
         fill: charcoal,
@@ -93,8 +93,8 @@ export default {
       },
       labels: baseLabelStyles
     }
-  },
-  candlestick: {
+  }, baseProps),
+  candlestick: assign({
     style: {
       data: {
         stroke: charcoal,
@@ -109,8 +109,9 @@ export default {
       positive: "#ffffff",
       negative: charcoal
     }
-  },
-  errorbar: {
+  }, baseProps),
+  chart: baseProps,
+  errorbar: assign({
     style: {
       data: {
         fill: "none",
@@ -121,8 +122,11 @@ export default {
         textAnchor: "start"
       })
     }
-  },
-  line: {
+  }, baseProps),
+  group: assign({
+    colorScale: colors
+  }, baseProps),
+  line: assign({
     style: {
       data: {
         fill: "none",
@@ -133,8 +137,8 @@ export default {
         textAnchor: "start"
       })
     }
-  },
-  pie: {
+  }, baseProps),
+  pie: assign({
     style: {
       data: {
         padding: 10,
@@ -147,8 +151,8 @@ export default {
       })
     },
     colorScale: colors
-  },
-  scatter: {
+  }, baseProps),
+  scatter: assign({
     style: {
       data: {
         fill: charcoal,
@@ -159,10 +163,8 @@ export default {
         textAnchor: "middle"
       })
     }
-  },
-  props: Object.assign({}, baseProps,
-    {
-      colorScale: colors
-    }
-  )
+  }, baseProps),
+  stack: assign({
+    colorScale: colors
+  }, baseProps)
 };

--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -45,7 +45,6 @@ const baseLabelStyles = {
 // *
 // * Strokes
 // *
-const strokeDasharray = "10, 5";
 const strokeLinecap = "round";
 const strokeLinejoin = "round";
 
@@ -72,7 +71,7 @@ export default {
       }),
       grid: {
         fill: "none",
-        stroke: "transparent",
+        stroke: "transparent"
       },
       ticks: {
         fill: "none",

--- a/src/victory-theme/material.js
+++ b/src/victory-theme/material.js
@@ -33,7 +33,8 @@ const fontSize = 12;
 const padding = 8;
 const baseProps = {
   width: 350,
-  height: 350
+  height: 350,
+  padding: 50
 };
 // *
 // * Labels
@@ -53,15 +54,15 @@ const strokeLinecap = "round";
 const strokeLinejoin = "round";
 
 export default {
-  area: {
+  area: assign({
     style: {
       data: {
         fill: grey900
       },
       labels: baseLabelStyles
     }
-  },
-  axis: {
+  }, baseProps),
+  axis: assign({
     style: {
       axis: {
         fill: "none",
@@ -95,8 +96,8 @@ export default {
         stroke: "transparent"
       })
     }
-  },
-  bar: {
+  }, baseProps),
+  bar: assign({
     style: {
       data: {
         fill: blueGrey700,
@@ -107,23 +108,21 @@ export default {
       },
       labels: baseLabelStyles
     }
-  },
-  candlestick: {
+  }, baseProps),
+  candlestick: assign({
     style: {
       data: {
         stroke: blueGrey700
       },
       labels: baseLabelStyles
     },
-    props: assign({}, baseProps,
-      {
-        candleColors: {
-          positive: "#ffffff",
-          negative: blueGrey700
-        }
-      })
-  },
-  errorbar: {
+    candleColors: {
+      positive: "#ffffff",
+      negative: blueGrey700
+    }
+  }, baseProps),
+  chart: baseProps,
+  errorbar: assign({
     style: {
       data: {
         fill: "none",
@@ -137,8 +136,11 @@ export default {
         textAnchor: "start"
       })
     }
-  },
-  line: {
+  }, baseProps),
+  group: assign({
+    colorScale: colors
+  }, baseProps),
+  line: assign({
     style: {
       data: {
         fill: "none",
@@ -152,12 +154,9 @@ export default {
         textAnchor: "start"
       })
     }
-  },
-  pie: {
-    props: assign({}, baseProps,
-      {
-        colorScale: colors
-      }),
+  }, baseProps),
+  pie: assign({
+    colorScale: colors,
     style: {
       data: {
         padding,
@@ -171,8 +170,8 @@ export default {
         textAnchor: "middle"
       })
     }
-  },
-  scatter: {
+  }, baseProps),
+  scatter: assign({
     style: {
       data: {
         fill: blueGrey700,
@@ -185,10 +184,8 @@ export default {
         textAnchor: "middle"
       })
     }
-  },
-  props: Object.assign({}, baseProps,
-    {
-      colorScale: colors
-    }
-  )
+  }, baseProps),
+  stack: assign({
+    colorScale: colors
+  }, baseProps)
 };

--- a/src/victory-theme/material.js
+++ b/src/victory-theme/material.js
@@ -39,11 +39,11 @@ const baseProps = {
 // * Labels
 // *
 const baseLabelStyles = {
-  fontFamily: sansSerif,
-  fontSize,
-  letterSpacing,
-  padding,
-  fill: blueGrey700
+  // fontFamily: sansSerif,
+  // fontSize,
+  // letterSpacing,
+  // padding,
+  // fill: blueGrey700
 };
 // *
 // * Strokes
@@ -54,65 +54,67 @@ const strokeLinejoin = "round";
 
 export default {
   area: {
-    data: {
-      fill: grey900
-    },
-    labels: baseLabelStyles,
-    parent: {}
+    style: {
+      data: {
+        // fill: grey900
+      },
+      labels: baseLabelStyles
+    }
   },
   axis: {
-    axis: {
-      fill: "none",
-      stroke: blueGrey300,
-      strokeWidth: 2,
-      strokeLinecap,
-      strokeLinejoin
-    },
-    axisLabel: assign({}, baseLabelStyles,
-      {
-        padding,
-        stroke: "transparent"
+    style: {
+      axis: {
+        // fill: "none",
+        // stroke: blueGrey300,
+        // strokeWidth: 2,
+        // strokeLinecap,
+        // strokeLinejoin
+      },
+      axisLabel: assign({}, baseLabelStyles, {
+        // padding,
+        // stroke: "transparent"
       }),
-    grid: {
-      fill: "none",
-      stroke: blueGrey50,
-      strokeDasharray,
-      strokeLinecap,
-      strokeLinejoin
-    },
-    ticks: {
-      fill: "none",
-      padding,
-      size: 5,
-      stroke: blueGrey300,
-      strokeWidth: 1,
-      strokeLinecap,
-      strokeLinejoin
-    },
-    tickLabels: assign({}, baseLabelStyles,
-      {
-        fill: blueGrey700,
-        stroke: "transparent"
+      grid: {
+        // fill: "none",
+        // stroke: blueGrey50,
+        // strokeDasharray,
+        // strokeLinecap,
+        // strokeLinejoin
+      },
+      ticks: {
+        // fill: "none",
+        // padding: 0,
+        // size: 0,
+        // stroke: blueGrey300,
+        // strokeWidth: 1,
+        // strokeLinecap,
+        // strokeLinejoin
+      },
+      tickLabels: assign({}, baseLabelStyles, {
+        // fill: blueGrey700,
+        // stroke: "transparent"
       })
+    }
   },
   bar: {
-    data: {
-      fill: blueGrey700,
-      opacity: 1,
-      padding,
-      stroke: "transparent",
-      strokeWidth: 0,
-      width: 5
-    },
-    labels: baseLabelStyles,
-    parent: {}
+    style: {
+      data: {
+        // fill: blueGrey700,
+        // padding,
+        // stroke: "transparent",
+        // strokeWidth: 0,
+        // width: 5
+      },
+      labels: baseLabelStyles
+    }
   },
   candlestick: {
-    data: {
-      stroke: blueGrey700
+    style: {
+      data: {
+        // stroke: blueGrey700
+      },
+      labels: baseLabelStyles
     },
-    labels: baseLabelStyles,
-    parent: {},
     props: assign({}, baseProps,
       {
         candleColors: {
@@ -122,34 +124,34 @@ export default {
       })
   },
   errorbar: {
-    data: {
-      fill: "none",
-      opacity: 1,
-      stroke: blueGrey700,
-      strokeWidth: 2
-    },
-    labels: assign({}, baseLabelStyles,
-      {
+    style: {
+      data: {
+        // fill: "none",
+        // opacity: 1,
+        // stroke: blueGrey700,
+        // strokeWidth: 2
+      },
+      labels: assign({}, baseLabelStyles, {
         stroke: "transparent",
         strokeWidth: 0,
         textAnchor: "start"
-      }),
-    parent: {}
+      })
+    }
   },
   line: {
-    data: {
-      fill: "none",
-      opacity: 1,
-      stroke: blueGrey700,
-      strokeWidth: 2
-    },
-    labels: assign({}, baseLabelStyles,
-      {
+    style: {
+      data: {
+        // fill: "none",
+        // opacity: 1,
+        // stroke: blueGrey700,
+        // strokeWidth: 2
+      },
+      labels: assign({}, baseLabelStyles, {
         stroke: "transparent",
         strokeWidth: 0,
         textAnchor: "start"
-      }),
-    parent: {}
+      })
+    }
   },
   pie: {
     props: assign({}, baseProps,
@@ -162,29 +164,27 @@ export default {
         stroke: blueGrey50,
         strokeWidth: 1
       },
-      labels: assign({}, baseLabelStyles,
-        {
-          padding: 200,
-          stroke: "transparent",
-          strokeWidth: 0,
-          textAnchor: "middle"
-        }),
-      parent: {}
+      labels: assign({}, baseLabelStyles, {
+        padding: 200,
+        stroke: "transparent",
+        strokeWidth: 0,
+        textAnchor: "middle"
+      })
     }
   },
   scatter: {
-    data: {
-      fill: blueGrey700,
-      opacity: 1,
-      stroke: "transparent",
-      strokeWidth: 0
-    },
-    labels: Object.assign({}, baseLabelStyles,
-      {
-        stroke: "transparent",
-        textAnchor: "middle"
-      }),
-    parent: {}
+    style: {
+      data: {
+        // fill: blueGrey700,
+        // opacity: 1,
+        // stroke: "transparent",
+        // strokeWidth: 0
+      },
+      labels: Object.assign({}, baseLabelStyles, {
+        // stroke: "transparent",
+        // textAnchor: "middle"
+      })
+    }
   },
   props: Object.assign({}, baseProps,
     {

--- a/src/victory-theme/material.js
+++ b/src/victory-theme/material.js
@@ -39,11 +39,11 @@ const baseProps = {
 // * Labels
 // *
 const baseLabelStyles = {
-  // fontFamily: sansSerif,
-  // fontSize,
-  // letterSpacing,
-  // padding,
-  // fill: blueGrey700
+  fontFamily: sansSerif,
+  fontSize,
+  letterSpacing,
+  padding,
+  fill: blueGrey700
 };
 // *
 // * Strokes
@@ -56,7 +56,7 @@ export default {
   area: {
     style: {
       data: {
-        // fill: grey900
+        fill: grey900
       },
       labels: baseLabelStyles
     }
@@ -64,46 +64,46 @@ export default {
   axis: {
     style: {
       axis: {
-        // fill: "none",
-        // stroke: blueGrey300,
-        // strokeWidth: 2,
-        // strokeLinecap,
-        // strokeLinejoin
+        fill: "none",
+        stroke: blueGrey300,
+        strokeWidth: 2,
+        strokeLinecap,
+        strokeLinejoin
       },
       axisLabel: assign({}, baseLabelStyles, {
-        // padding,
-        // stroke: "transparent"
+        padding,
+        stroke: "transparent"
       }),
       grid: {
-        // fill: "none",
-        // stroke: blueGrey50,
-        // strokeDasharray,
-        // strokeLinecap,
-        // strokeLinejoin
+        fill: "none",
+        stroke: blueGrey50,
+        strokeDasharray,
+        strokeLinecap,
+        strokeLinejoin
       },
       ticks: {
-        // fill: "none",
-        // padding: 0,
-        // size: 0,
-        // stroke: blueGrey300,
-        // strokeWidth: 1,
-        // strokeLinecap,
-        // strokeLinejoin
+        fill: "none",
+        padding: 0,
+        size: 0,
+        stroke: blueGrey300,
+        strokeWidth: 1,
+        strokeLinecap,
+        strokeLinejoin
       },
       tickLabels: assign({}, baseLabelStyles, {
-        // fill: blueGrey700,
-        // stroke: "transparent"
+        fill: blueGrey700,
+        stroke: "transparent"
       })
     }
   },
   bar: {
     style: {
       data: {
-        // fill: blueGrey700,
-        // padding,
-        // stroke: "transparent",
-        // strokeWidth: 0,
-        // width: 5
+        fill: blueGrey700,
+        padding,
+        stroke: "transparent",
+        strokeWidth: 0,
+        width: 5
       },
       labels: baseLabelStyles
     }
@@ -111,7 +111,7 @@ export default {
   candlestick: {
     style: {
       data: {
-        // stroke: blueGrey700
+        stroke: blueGrey700
       },
       labels: baseLabelStyles
     },
@@ -126,10 +126,10 @@ export default {
   errorbar: {
     style: {
       data: {
-        // fill: "none",
-        // opacity: 1,
-        // stroke: blueGrey700,
-        // strokeWidth: 2
+        fill: "none",
+        opacity: 1,
+        stroke: blueGrey700,
+        strokeWidth: 2
       },
       labels: assign({}, baseLabelStyles, {
         stroke: "transparent",
@@ -141,10 +141,10 @@ export default {
   line: {
     style: {
       data: {
-        // fill: "none",
-        // opacity: 1,
-        // stroke: blueGrey700,
-        // strokeWidth: 2
+        fill: "none",
+        opacity: 1,
+        stroke: blueGrey700,
+        strokeWidth: 2
       },
       labels: assign({}, baseLabelStyles, {
         stroke: "transparent",
@@ -175,14 +175,14 @@ export default {
   scatter: {
     style: {
       data: {
-        // fill: blueGrey700,
-        // opacity: 1,
-        // stroke: "transparent",
-        // strokeWidth: 0
+        fill: blueGrey700,
+        opacity: 1,
+        stroke: "transparent",
+        strokeWidth: 0
       },
       labels: Object.assign({}, baseLabelStyles, {
-        // stroke: "transparent",
-        // textAnchor: "middle"
+        stroke: "transparent",
+        textAnchor: "middle"
       })
     }
   },

--- a/src/victory-theme/victory-theme.js
+++ b/src/victory-theme/victory-theme.js
@@ -1,5 +1,7 @@
 import materialTheme from "./material";
+import grayscaleTheme from "./grayscale";
 
 export default {
-  material: materialTheme
+  material: materialTheme,
+  grayscale: grayscaleTheme
 };

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,4 +1,4 @@
-import { defaults, isFunction, isEmpty, merge, partial, property, omit } from "lodash";
+import { defaults, isFunction, merge, partial, property, omit } from "lodash";
 
 export default {
   getPadding(props) {
@@ -40,18 +40,6 @@ export default {
       prev[curr] = this.evaluateProp(style[curr], data, index);
       return prev;
     }, {});
-  },
-
-  getWidth(props, role) {
-    const theme = props.theme && props.theme[role];
-    const themeWidth = theme && theme.width;
-    return props.width || themeWidth || 350
-  },
-
-  getHeight(props, role) {
-    const theme = props.theme && props.theme[role];
-    const themeHeight = theme && theme.height;
-    return props.width || themeHeight || 350
   },
 
   getRange(props, axis) {

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -145,7 +145,7 @@ export default {
 
   modifyProps(props, fallbackProps, role) {
     const theme = props.theme && props.theme[role] ? props.theme[role] : {};
-    const themeProps = omit(theme, "style");
+    const themeProps = omit(theme, ["style"]);
     return defaults({}, props, themeProps, fallbackProps);
   },
 

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,4 +1,4 @@
-import { defaults, isFunction, merge, partial, property } from "lodash";
+import { defaults, isFunction, isEmpty, merge, partial, property, omit } from "lodash";
 
 export default {
   getPadding(props) {
@@ -18,10 +18,13 @@ export default {
     }
 
     const {data, labels, parent} = style;
+    const defaultParent = defaultStyles && defaultStyles.parent || {};
+    const defaultLabels = defaultStyles && defaultStyles.labels || {};
+    const defaultData = defaultStyles && defaultStyles.data || {};
     return {
-      parent: defaults({ height, width }, parent, defaultStyles.parent),
-      labels: defaults({}, labels, defaultStyles.labels),
-      data: defaults({}, data, defaultStyles.data)
+      parent: defaults({ height, width }, parent, defaultParent),
+      labels: defaults({}, labels, defaultLabels),
+      data: defaults({}, data, defaultData)
     };
   },
 
@@ -30,13 +33,25 @@ export default {
   },
 
   evaluateStyle(style, data, index) {
-    if (!Object.keys(style).some((value) => isFunction(style[value]))) {
+    if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
       return style;
     }
     return Object.keys(style).reduce((prev, curr) => {
       prev[curr] = this.evaluateProp(style[curr], data, index);
       return prev;
     }, {});
+  },
+
+  getWidth(props, role) {
+    const theme = props.theme && props.theme[role];
+    const themeWidth = theme && theme.width;
+    return props.width || themeWidth || 350
+  },
+
+  getHeight(props, role) {
+    const theme = props.theme && props.theme[role];
+    const themeHeight = theme && theme.height;
+    return props.width || themeHeight || 350
   },
 
   getRange(props, axis) {
@@ -140,21 +155,10 @@ export default {
       {};
   },
 
-  modifyProps(props, fallbackProps, themeProps) {
-    const themeCheck = props.theme && props.theme.props;
-    const themePropsObject = themeCheck && !themeProps ? props.theme.props : themeProps;
-
-    return themeCheck ?
-      defaults({}, props, {
-        clipWidth: props.width,
-        clipHeight: props.height
-      },
-      themePropsObject,
-      fallbackProps.props)
-    : defaults({}, props, {
-      clipWidth: props.width,
-      clipHeight: props.height
-    }, fallbackProps.props);
+  modifyProps(props, fallbackProps, role) {
+    const theme = props.theme && props.theme[role] ? props.theme[role] : {};
+    const themeProps = omit(theme, "style");
+    return defaults({}, props, themeProps, fallbackProps);
   },
 
   getEvents(events, namespace) {


### PR DESCRIPTION
this PR:
- adds a `style` namespace to all themes
- removes the `props` namespace
- Extracts all the default styles from the components into a new theme called grayscale
- Adds checks for `getStyles`
- simplifies `modifyProps`

TODO
- [x] update themes for VictoryPie
