### PR TITLE
fix error, respect dates

### DIFF
--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -1,6 +1,6 @@
 import React from "react";
 import VictoryAnimation from "../victory-animation/victory-animation";
-import { Transitions } from "../victory-util/index";
+import { Transitions, Collection } from "../victory-util/index";
 import { defaults, isFunction, pick, filter } from "lodash";
 
 export default class VictoryTransition extends React.Component {
@@ -76,7 +76,7 @@ export default class VictoryTransition extends React.Component {
     } else {
       const childDomains = getChildDomains(childComponents);
       return childDomains.length === 0 ?
-        [0, 1] : [Math.min(...childDomains), Math.max(...childDomains)];
+        [0, 1] : [Collection.getMinValue(childDomains), Collection.getMaxValue(childDomains)];
     }
   }
 

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -94,7 +94,7 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
 
   const getTransitionsFromChildren = (old, next) => {
     return old.map((child, idx) => {
-      if (child.props.children) {
+      if (child && child.props && child.props.children) {
         return getTransitionsFromChildren(
           React.Children.toArray(old[idx].props.children),
           React.Children.toArray(next[idx].props.children)


### PR DESCRIPTION
this PR:
- fixes an error `Cannot read property 'children' of undefined` that was showing up when `<VictoryLabel/>` was nested inside an animating chart
- Respects dates when calculating the domain in `VictoryTransition`
