### PR TITLE
fix clipPath width didn't update correctly when chart onExit

### DIFF
--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -146,7 +146,9 @@ export default {
   modifyProps(props, fallbackProps, role) {
     const theme = props.theme && props.theme[role] ? props.theme[role] : {};
     const themeProps = omit(theme, ["style"]);
-    return defaults({}, props, themeProps, fallbackProps);
+    const clipPathProps = { clipWidth: props.width, clipHeight: props.height };
+
+    return defaults({}, props, clipPathProps, themeProps, fallbackProps);
   },
 
   getEvents(events, namespace) {


### PR DESCRIPTION
Area, and line chart is not update correctly when chart is onExit. This fix the thing.

cc @boygirl 
![error](https://cloud.githubusercontent.com/assets/1216029/18027070/b7d42776-6c8b-11e6-8423-322f1ff8f0e4.gif)
