### PR TITLE
[WIP] export primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "builder-victory-component": "^2.4.0",
     "d3-ease": "^0.3.0",
     "d3-interpolate": "0.2.0",
+    "d3-shape": "^1.0.0",
     "d3-timer": "^0.0.6",
     "lodash": "^4.12.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export { default as PropTypes } from "./victory-util/prop-types";
 export { default as Events } from "./victory-util/events";
 import * as Transitions from "./victory-util/transitions";
 import * as DefaultTransitions from "./victory-util/default-transitions";
-export { Transitions, DefaultTransitions};
+export { Transitions, DefaultTransitions };
 
 export { default as VictoryAnimation } from "./victory-animation/victory-animation";
 export { default as VictoryLabel } from "./victory-label/victory-label";
@@ -15,5 +15,5 @@ export { default as VictorySharedEvents } from "./victory-shared-events/victory-
 export { default as VictoryContainer } from "./victory-container/victory-container";
 export { default as VictoryTheme } from "./victory-theme/victory-theme";
 export {
-  Area, Bar, Candle, Curve, ErrorBar, Line, Point, Slice
+  Area, Bar, Candle, ClipPath, Curve, ErrorBar, Line, Point, Slice
 } from "./victory-primitives/index";

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export { default as PropTypes } from "./victory-util/prop-types";
 export { default as Events } from "./victory-util/events";
 import * as Transitions from "./victory-util/transitions";
 import * as DefaultTransitions from "./victory-util/default-transitions";
-export { Transitions, DefaultTransitions };
+export { Transitions, DefaultTransitions};
 
 export { default as VictoryAnimation } from "./victory-animation/victory-animation";
 export { default as VictoryLabel } from "./victory-label/victory-label";
@@ -14,3 +14,6 @@ export { default as VictoryTransition } from "./victory-transition/victory-trans
 export { default as VictorySharedEvents } from "./victory-shared-events/victory-shared-events";
 export { default as VictoryContainer } from "./victory-container/victory-container";
 export { default as VictoryTheme } from "./victory-theme/victory-theme";
+export {
+  Area, Bar, Candle, Curve, ErrorBar, Line, Point, Slice
+} from "./victory-primitives/index";

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -1,0 +1,85 @@
+import React, { PropTypes } from "react";
+import { assign } from "lodash";
+import * as d3Shape from "d3-shape";
+
+export default class Area extends React.Component {
+  static propTypes = {
+    clipId: PropTypes.number,
+    data: PropTypes.array,
+    events: PropTypes.object,
+    groupComponent: PropTypes.element,
+    interpolation: PropTypes.string,
+    role: PropTypes.string,
+    scale: PropTypes.object,
+    style: PropTypes.object
+  };
+
+  toNewName(interpolation) {
+    // d3 shape changed the naming scheme for interpolators from "basis" -> "curveBasis" etc.
+    const capitalize = (s) => s && s[0].toUpperCase() + s.slice(1);
+    return `curve${capitalize(interpolation)}`;
+  }
+
+  getAreaPath(props) {
+    const xScale = props.scale.x;
+    const yScale = props.scale.y;
+    const areaFunction = d3Shape.area()
+      .curve(d3Shape[this.toNewName(props.interpolation)])
+      .x((data) => xScale(data.x1 || data.x))
+      .y1((data) => yScale(data.y1 || data.y))
+      .y0((data) => yScale(data.y0));
+    return areaFunction(props.data);
+  }
+
+  getLinePath(props) {
+    const xScale = props.scale.x;
+    const yScale = props.scale.y;
+    const lineFunction = d3Shape.line()
+      .curve(d3Shape[this.toNewName(props.interpolation)])
+      .x((data) => xScale(data.x1 || data.x))
+      .y((data) => yScale(data.y1));
+    return lineFunction(props.data);
+  }
+
+  renderArea(path, style, events) {
+    const areaStroke = style.stroke ? "none" : style.fill;
+    const areaStyle = assign({}, style, {stroke: areaStroke});
+    const { role, clipId } = this.props;
+    return (
+      <path
+        key="area"
+        style={areaStyle}
+        role={role}
+        d={path}
+        {...events}
+        clipPath={`url(#${clipId})`}
+      />
+    );
+  }
+
+  renderLine(path, style, events) {
+    if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
+      return undefined;
+    }
+    const { role, clipId } = this.props;
+    const lineStyle = assign({}, style, {fill: "none"});
+    return (
+      <path
+        key="area-stroke"
+        style={lineStyle}
+        role={role}
+        d={path}
+        {...events}
+        clipPath={`url(#${clipId})`}
+      />
+    );
+  }
+
+  render() {
+    const { events, groupComponent } = this.props;
+    const style = assign({fill: "black"}, this.props.style);
+    const area = this.renderArea(this.getAreaPath(this.props), style, events);
+    const line = this.renderLine(this.getLinePath(this.props), style, events);
+    return React.cloneElement(groupComponent, {}, area, line);
+  }
+}

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -1,0 +1,80 @@
+import React, { PropTypes } from "react";
+import { assign } from "lodash";
+
+export default class Bar extends React.Component {
+
+  static propTypes = {
+    clipId: PropTypes.number,
+    datum: PropTypes.object,
+    events: PropTypes.object,
+    horizontal: PropTypes.bool,
+    index: PropTypes.number,
+    role: PropTypes.string,
+    scale: PropTypes.object,
+    style: PropTypes.object,
+    x: React.PropTypes.number,
+    y: React.PropTypes.number,
+    y0: React.PropTypes.number,
+    width: PropTypes.number,
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.object
+    ]),
+    data: PropTypes.array
+  };
+
+  getVerticalBarPath(props, width) {
+    const {x, y0, y} = props;
+    const size = width / 2;
+    return `M ${x - size}, ${y0}
+      L ${x - size}, ${y}
+      L ${x + size}, ${y}
+      L ${x + size}, ${y0}
+      L ${x - size}, ${y0}`;
+  }
+
+  getHorizontalBarPath(props, width) {
+    const {x, y0, y} = props;
+    const size = width / 2;
+    return `M ${y0}, ${x - size}
+      L ${y0}, ${x + size}
+      L ${y}, ${x + size}
+      L ${y}, ${x - size}
+      L ${y0}, ${x - size}`;
+  }
+
+  getBarPath(props, width) {
+    return this.props.horizontal ?
+      this.getHorizontalBarPath(props, width) : this.getVerticalBarPath(props, width);
+  }
+
+  getBarWidth(props) {
+    const {style, width, data} = props;
+    const padding = props.padding.left || props.padding;
+    const defaultWidth = data.length === 0 ? 8 : (width - 2 * padding) / data.length;
+    return style && style.width ? style.width : defaultWidth;
+  }
+
+  renderBar(path, style, events) {
+    const { role, clipId } = this.props;
+    return (
+      <path
+        d={path}
+        style={style}
+        role={role}
+        shapeRendering="optimizeSpeed"
+        {...events}
+        clipPath={`url(#${clipId})`}
+      />
+    );
+  }
+
+  render() {
+    // TODO better bar width calculation
+    const barWidth = this.getBarWidth(this.props);
+    const path = typeof this.props.x === "number" ?
+      this.getBarPath(this.props, barWidth) : undefined;
+    const style = assign({fill: "black", stroke: "none"}, this.props.style);
+    return this.renderBar(path, style, this.props.events);
+  }
+}

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -1,0 +1,57 @@
+import React, { PropTypes } from "react";
+import { assign } from "lodash";
+
+
+export default class Candle extends React.Component {
+  static propTypes = {
+    index: React.PropTypes.number,
+    x: PropTypes.number,
+    y1: PropTypes.number,
+    y2: PropTypes.number,
+    y: PropTypes.number,
+    events: PropTypes.object,
+    candleHeight: PropTypes.number,
+    scale: PropTypes.object,
+    style: PropTypes.object,
+    datum: PropTypes.object,
+    width: PropTypes.number,
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.object
+    ]),
+    data: PropTypes.array,
+    groupComponent: PropTypes.element,
+    role: PropTypes.string
+  }
+
+  renderWick(wickProps) {
+    return <line {...wickProps}/>;
+  }
+
+  renderCandle(candleProps) {
+    return <rect {...candleProps}/>;
+  }
+
+  getCandleProps(props) {
+    const { width, candleHeight, x, y, data, events, role} = props;
+    const style = assign({stroke: "black"}, props.style);
+    const padding = props.padding.left || props.padding;
+    const candleWidth = style.width || 0.5 * (width - 2 * padding) / data.length;
+    const candleX = x - candleWidth / 2;
+    return assign({x: candleX, y, style, role, width: candleWidth, height: candleHeight}, events);
+  }
+
+  getWickProps(props) {
+    const {x, y1, y2, events, role} = props;
+    const style = assign({stroke: "black"}, props.style);
+    return assign({x1: x, x2: x, y1, y2, style, role}, events);
+  }
+
+  render() {
+    const candleProps = this.getCandleProps(this.props);
+    const wickProps = this.getWickProps(this.props);
+    return React.cloneElement(
+      this.props.groupComponent, {}, this.renderWick(wickProps), this.renderCandle(candleProps)
+    );
+  }
+}

--- a/src/victory-primitives/clip-path.js
+++ b/src/victory-primitives/clip-path.js
@@ -1,0 +1,91 @@
+import React, { PropTypes } from "react";
+import {
+  PropTypes as CustomPropTypes, Helpers
+} from "../index";
+
+export default class ClipPath extends React.Component {
+  static propTypes = {
+    /**
+     * A unique ID for clipPath so, it could make sure using specific clipPath on
+     * specific chart
+     * @type {Number}
+     */
+    clipId: PropTypes.number,
+    /**
+     * The clipPadding props specifies the paddings in clipPath
+     * @type {Number}
+     */
+    clipPadding: PropTypes.shape({
+      top: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number,
+      right: PropTypes.number
+    }),
+    /**
+     * The clipHeight props specifies the height of the clipPath
+     * This value should be given as a number of pixels
+     */
+    clipHeight: CustomPropTypes.nonNegative,
+    /**
+     * The clipWidth props specifies the width of the clipPath
+     * This value should be given as a number of pixels
+     */
+    clipWidth: CustomPropTypes.nonNegative,
+    /**
+     * The padding props specifies the amount of padding in number of pixels between
+     * the edge of the chart and any rendered child components. This prop can be given
+     * as a number or as an object with padding specified for top, bottom, left
+     * and right.
+     */
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        top: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number
+      })
+    ])
+  };
+
+  static defaultProps = {
+    clipPadding: {
+      top: 5,
+      bottom: 5,
+      left: 0,
+      right: 0
+    }
+  }
+
+  renderClipPath(props, id) {
+    return (
+      <defs>
+        <clipPath id={id}>
+          <rect {...props}/>
+        </clipPath>
+      </defs>
+    );
+  }
+
+  render() {
+    const {
+      clipId,
+      clipWidth,
+      clipHeight,
+      clipPadding
+    } = this.props;
+
+    const padding = Helpers.getPadding(this.props);
+
+    const totalPadding = (side) => padding[side] - (clipPadding[side] || 0);
+
+    const clipProps = {
+      x: totalPadding("left"),
+      y: totalPadding("top"),
+      width: clipWidth - totalPadding("left") - totalPadding("right"),
+      height: clipHeight - totalPadding("top") - totalPadding("bottom")
+    };
+
+    return this.renderClipPath(clipProps, clipId);
+  }
+}

--- a/src/victory-primitives/clip-path.js
+++ b/src/victory-primitives/clip-path.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import {
   PropTypes as CustomPropTypes, Helpers
-} from "../index";
+} from "../victory-util/index";
 
 export default class ClipPath extends React.Component {
   static propTypes = {

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -1,0 +1,48 @@
+import React, { PropTypes } from "react";
+import { assign } from "lodash";
+import * as d3Shape from "d3-shape";
+
+export default class Curve extends React.Component {
+  static propTypes = {
+    clipId: PropTypes.number,
+    data: PropTypes.array,
+    events: PropTypes.object,
+    index: PropTypes.number,
+    interpolation: PropTypes.string,
+    role: PropTypes.string,
+    scale: PropTypes.object,
+    style: PropTypes.object
+  };
+
+  toNewName(interpolation) {
+    // d3 shape changed the naming scheme for interpolators from "basis" -> "curveBasis" etc.
+    const capitalize = (s) => s && s[0].toUpperCase() + s.slice(1);
+    return `curve${capitalize(interpolation)}`;
+  }
+
+  renderLine(path, style, events) {
+    const { role, clipId } = this.props;
+    return (
+      <path
+        style={style}
+        d={path}
+        role={role}
+        {...events}
+        clipPath={`url(#${clipId})`}
+        vectorEffect="non-scaling-stroke"
+      />
+    );
+  }
+
+  render() {
+    const { data, events, interpolation, scale, style } = this.props;
+    const xScale = scale.x;
+    const yScale = scale.y;
+    const lineFunction = d3Shape.line()
+      .curve(d3Shape[this.toNewName(interpolation)])
+      .x((d) => xScale(d.x1 || d.x))
+      .y((d) => yScale(d.y1 || d.y));
+    const lineStyle = assign({fill: "none", stroke: "black"}, style);
+    return this.renderLine(lineFunction(data), lineStyle, events);
+  }
+}

--- a/src/victory-primitives/error-bar.js
+++ b/src/victory-primitives/error-bar.js
@@ -1,0 +1,179 @@
+/* eslint-disable max-statements */
+import React, { PropTypes } from "react";
+import { assign } from "lodash";
+
+export default class ErrorBar extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  static propTypes = {
+    index: React.PropTypes.number,
+    datum: PropTypes.object,
+    events: PropTypes.object,
+    scale: PropTypes.object,
+    style: PropTypes.object,
+    x: PropTypes.number,
+    y: PropTypes.number,
+    errorX: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.array,
+      PropTypes.bool
+    ]),
+    errorY: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.array,
+      PropTypes.bool
+    ]),
+    borderWidth: PropTypes.number,
+    groupComponent: PropTypes.element
+  };
+
+  static defaultProps = {
+    borderWidth: 10
+  }
+
+  renderErrorBar(error) {
+    const { x, y, borderWidth, groupComponent, events} = this.props;
+    const style = assign({stroke: "black"}, this.props.style);
+    return React.cloneElement(groupComponent, {},
+      error.errorRight ?
+        <line
+          key="borderRight"
+          {...events}
+          style={style}
+          x1={error.errorRight}
+          x2={error.errorRight}
+          y1={y - borderWidth}
+          y2={y + borderWidth}
+        />
+        : null
+      ,
+      error.errorLeft ?
+        <line
+          key="borderLeft"
+          {...events}
+          style={style}
+          x1={error.errorLeft}
+          x2={error.errorLeft}
+          y1={y - borderWidth}
+          y2={y + borderWidth}
+        />
+        : null
+      ,
+      error.errorBottom ?
+        <line
+          key="borderBottom"
+          {...events}
+          style={style}
+          x1={x - borderWidth}
+          x2={x + borderWidth}
+          y1={error.errorBottom}
+          y2={error.errorBottom}
+        />
+        : null
+      ,
+      error.errorTop ?
+        <line
+          key="borderTop"
+          {...events}
+          style={style}
+          x1={x - borderWidth}
+          x2={x + borderWidth}
+          y1={error.errorTop}
+          y2={error.errorTop}
+        />
+        : null
+      ,
+      error.errorTop ?
+        <line
+          key="crossTop"
+          {...events}
+          style={style}
+          x1={x}
+          x2={x}
+          y1={y}
+          y2={error.errorTop}
+          shapeRendering="optimizeSpeed"
+        />
+        : null
+      ,
+      error.errorBottom ?
+        <line
+          key="crossBottom"
+          {...events}
+          style={style}
+          x1={x}
+          x2={x}
+          y1={y}
+          y2={error.errorBottom}
+          shapeRendering="optimizeSpeed"
+        />
+        : null
+      ,
+      error.errorLeft ?
+        <line
+          key="crossLeft"
+          {...events}
+          style={style}
+          x1={x}
+          x2={error.errorLeft}
+          y1={y}
+          y2={y}
+          shapeRendering="optimizeSpeed"
+        /> : null
+      ,
+      error.errorRight ?
+        <line
+          key="crossRight"
+          {...events}
+          style={style}
+          x1={x}
+          x2={error.errorRight}
+          y1={y}
+          y2={y}
+          shapeRendering="optimizeSpeed"
+        /> : null
+    );
+  }
+
+  render() {
+    const {
+      errorX,
+      errorY,
+      scale
+    } = this.props;
+    let rangeX;
+    let rangeY;
+    let positiveErrorX;
+    let negativeErrorX;
+    let positiveErrorY;
+    let negativeErrorY;
+    let errorTop;
+    let errorBottom;
+    let errorRight;
+    let errorLeft;
+
+    if (errorX) {
+      rangeX = scale.x.range();
+      positiveErrorX = errorX[0];
+      negativeErrorX = errorX[1];
+      errorRight = positiveErrorX >= rangeX[1] ? rangeX[1] : positiveErrorX;
+      errorLeft = negativeErrorX <= rangeX[0] ? rangeX[0] : negativeErrorX;
+    }
+
+    if (errorY) {
+      rangeY = scale.y.range();
+      positiveErrorY = errorY[1];
+      negativeErrorY = errorY[0];
+      errorTop = positiveErrorY >= rangeY[0] ? rangeY[0] : positiveErrorY;
+      errorBottom = negativeErrorY <= rangeY[1] ? rangeY[1] : negativeErrorY;
+    }
+
+    return React.cloneElement(
+      this.props.groupComponent,
+      {},
+      this.renderErrorBar({errorTop, errorBottom, errorRight, errorLeft})
+    );
+  }
+}

--- a/src/victory-primitives/index.js
+++ b/src/victory-primitives/index.js
@@ -1,6 +1,7 @@
 import Area from "./area";
 import Bar from "./bar";
 import Candle from "./candle";
+import ClipPath from "./clip-path";
 import Curve from "./curve";
 import ErrorBar from "./error-bar";
 import Line from "./line";
@@ -8,4 +9,4 @@ import Point from "./point";
 import Slice from "./slice";
 
 
-export { Area, Bar, Candle, Curve, ErrorBar, Line, Point, Slice };
+export { Area, Bar, Candle, ClipPath, Curve, ErrorBar, Line, Point, Slice };

--- a/src/victory-primitives/index.js
+++ b/src/victory-primitives/index.js
@@ -1,0 +1,11 @@
+import Area from "./area";
+import Bar from "./bar";
+import Candle from "./candle";
+import Curve from "./curve";
+import ErrorBar from "./error-bar";
+import Line from "./line";
+import Point from "./point";
+import Slice from "./slice";
+
+
+export { Area, Bar, Candle, Curve, ErrorBar, Line, Point, Slice };

--- a/src/victory-primitives/line.js
+++ b/src/victory-primitives/line.js
@@ -1,0 +1,25 @@
+import React, { PropTypes } from "react";
+import { assign } from "lodash";
+
+export default class Line extends React.Component {
+  static propTypes = {
+    index: PropTypes.number,
+    tick: PropTypes.any,
+    x1: PropTypes.number,
+    x2: PropTypes.number,
+    y1: PropTypes.number,
+    y2: PropTypes.number,
+    style: PropTypes.object,
+    events: PropTypes.object
+  };
+
+  renderAxisLine(props, style, events) {
+    return <line {...props} style={style} {...events} vectorEffect="non-scaling-stroke"/>;
+  }
+
+  render() {
+    const { x1, x2, y1, y2, events} = this.props;
+    const style = assign({stroke: "black"}, this.props.style);
+    return this.renderAxisLine({x1, x2, y1, y2}, style, events);
+  }
+}

--- a/src/victory-primitives/path-helpers.js
+++ b/src/victory-primitives/path-helpers.js
@@ -1,0 +1,72 @@
+import { range } from "lodash";
+
+export default {
+  circle(x, y, size) {
+    return `M ${x}, ${y} m ${-size}, 0
+      a ${size}, ${size} 0 1,0 ${size * 2},0
+      a ${size}, ${size} 0 1,0 ${-size * 2},0`;
+  },
+
+  square(x, y, size) {
+    const baseSize = 0.87 * size;
+    return `M ${x - baseSize}, ${y + baseSize}
+      L ${x + baseSize}, ${y + baseSize}
+      L ${x + baseSize}, ${y - baseSize}
+      L ${x - baseSize}, ${y - baseSize}
+      z`;
+  },
+
+  diamond(x, y, size) {
+    const baseSize = 0.87 * size;
+    const length = Math.sqrt(2 * (baseSize * baseSize));
+    return `M ${x}, ${y + length}
+      L ${x + length}, ${y}
+      L ${x}, ${y - length}
+      L ${x - length}, ${y}
+      z`;
+  },
+
+  triangleDown(x, y, size) {
+    const height = (size / 2 * Math.sqrt(3));
+    return `M ${x - size}, ${y - size}
+      L ${x + size}, ${y - size}
+      L ${x}, ${y + height}
+      z`;
+  },
+
+  triangleUp(x, y, size) {
+    const height = (size / 2 * Math.sqrt(3));
+    return `M ${x - size}, ${y + size}
+      L ${x + size}, ${y + size}
+      L ${x}, ${y - height}
+      z`;
+  },
+
+  plus(x, y, size) {
+    const baseSize = 1.1 * size;
+    return `M ${x - baseSize / 2.5}, ${y + baseSize}
+      L ${x + baseSize / 2.5}, ${y + baseSize}
+      L ${x + baseSize / 2.5}, ${y + baseSize / 2.5}
+      L ${x + baseSize}, ${y + baseSize / 2.5}
+      L ${x + baseSize}, ${y - baseSize / 2.5}
+      L ${x + baseSize / 2.5}, ${y - baseSize / 2.5}
+      L ${x + baseSize / 2.5}, ${y - baseSize}
+      L ${x - baseSize / 2.5}, ${y - baseSize}
+      L ${x - baseSize / 2.5}, ${y - baseSize / 2.5}
+      L ${x - baseSize}, ${y - baseSize / 2.5}
+      L ${x - baseSize}, ${y + baseSize / 2.5}
+      L ${x - baseSize / 2.5}, ${y + baseSize / 2.5}
+      z`;
+  },
+
+  star(x, y, size) {
+    const baseSize = 1.35 * size;
+    const angle = Math.PI / 5;
+    const starCoords = range(10).map((index) => {
+      const length = index % 2 === 0 ? baseSize : baseSize / 2;
+      return `${length * Math.sin(angle * (index + 1)) + x},
+        ${length * Math.cos(angle * (index + 1)) + y}`;
+    });
+    return `M ${starCoords.join("L")} z`;
+  }
+};

--- a/src/victory-primitives/point.js
+++ b/src/victory-primitives/point.js
@@ -1,0 +1,49 @@
+import React, { PropTypes } from "react";
+import pathHelpers from "./path-helpers";
+
+export default class Point extends React.Component {
+  static propTypes = {
+    datum: PropTypes.object,
+    events: PropTypes.object,
+    index: PropTypes.number,
+    role: PropTypes.string,
+    size: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.func
+    ]),
+    symbol: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        "circle", "diamond", "plus", "square", "star", "triangleDown", "triangleUp"
+      ]),
+      PropTypes.func
+    ]),
+    scale: PropTypes.object,
+    style: PropTypes.object,
+    x: PropTypes.number,
+    y: PropTypes.number
+  };
+
+  getPath(props) {
+    const pathFunctions = {
+      circle: pathHelpers.circle,
+      square: pathHelpers.square,
+      diamond: pathHelpers.diamond,
+      triangleDown: pathHelpers.triangleDown,
+      triangleUp: pathHelpers.triangleUp,
+      plus: pathHelpers.plus,
+      star: pathHelpers.star
+    };
+    return pathFunctions[props.symbol].call(null, props.x, props.y, props.size);
+  }
+
+  renderPoint(path, style, events) {
+    const { role } = this.props;
+    return (
+      <path {...events} d={path} role={role} shapeRendering="optimizeSpeed" style={style}/>
+    );
+  }
+
+  render() {
+    return this.renderPoint(this.getPath(this.props), this.props.style, this.props.events);
+  }
+}

--- a/src/victory-primitives/slice.js
+++ b/src/victory-primitives/slice.js
@@ -1,0 +1,26 @@
+import React, { PropTypes } from "react";
+
+export default class Slice extends React.Component {
+  static propTypes = {
+    index: PropTypes.number,
+    slice: PropTypes.object,
+    pathFunction: PropTypes.func,
+    style: PropTypes.object,
+    datum: PropTypes.object,
+    events: PropTypes.object
+  };
+
+  renderSlice(props) {
+    return (
+      <path
+        d={props.pathFunction(props.slice)}
+        style={props.style}
+        {...props.events}
+      />
+    );
+  }
+
+  render() {
+    return this.renderSlice(this.props);
+  }
+}

--- a/test/client/spec/victory-primitives/path-helper.spec.js
+++ b/test/client/spec/victory-primitives/path-helper.spec.js
@@ -1,0 +1,62 @@
+/* eslint no-unused-expressions: 0 */
+import PathHelpers from "src/victory-primitives/path-helpers";
+
+describe("path-helpers", () => {
+  const x = 0;
+  const y = 0;
+  const size = 1;
+  describe("circle", () => {
+    it("draws a path for a circle at the correct location", () => {
+      const pathResult = PathHelpers.circle(x, y, size);
+      expect(pathResult).to.contain(`M ${x}, ${y}`);
+    });
+  });
+
+  describe("square", () => {
+    it("draws a path for a square at the correct location", () => {
+      const pathResult = PathHelpers.square(x, y, size);
+      const baseSize = 0.87 * size;
+      expect(pathResult).to.contain(`M ${x - baseSize}, ${y + baseSize}`);
+    });
+  });
+
+  describe("diamond", () => {
+    it("draws a path for a diamond at the correct location", () => {
+      const pathResult = PathHelpers.diamond(0, 0, 1);
+      const baseSize = 0.87 * size;
+      const length = Math.sqrt(2 * (baseSize * baseSize));
+      expect(pathResult).to.contain(`M ${x}, ${y + length}`);
+    });
+  });
+
+  describe("triangleUp", () => {
+    it("draws a path for a triangleUp at the correct location", () => {
+      const pathResult = PathHelpers.triangleUp(0, 0, 1);
+      expect(pathResult).to.contain(`M ${x - size}, ${y + size}`);
+    });
+  });
+
+  describe("triangleDown", () => {
+    it("draws a path for a triangleDown at the correct location", () => {
+      const pathResult = PathHelpers.triangleDown(0, 0, 1);
+      expect(pathResult).to.contain(`M ${x - size}, ${y - size}`);
+    });
+  });
+
+  describe("plus", () => {
+    it("draws a path for a plus at the correct location", () => {
+      const pathResult = PathHelpers.plus(0, 0, 1);
+      const baseSize = 1.1 * size;
+      expect(pathResult).to.contain(`M ${x - baseSize / 2.5}, ${y + baseSize}`);
+    });
+  });
+
+  describe("star", () => {
+    it("draws a path for a star at the correct location", () => {
+      const pathResult = PathHelpers.star(0, 0, 1);
+      const angle = Math.PI / 5;
+      expect(pathResult).to.contain(`M ${(1.35 * size) * Math.sin(angle) + x },
+        ${(1.35 * size) * Math.cos(angle) + y}`);
+    });
+  });
+});

--- a/test/client/spec/victory-primitives/slice.spec.js
+++ b/test/client/spec/victory-primitives/slice.spec.js
@@ -1,0 +1,27 @@
+/*eslint-disable max-nested-callbacks,no-unused-expressions,max-len */
+import React from "react";
+import { shallow } from "enzyme";
+import Slice from "src/victory-primitives/slice";
+
+describe("components/slice", () => {
+  describe("rendering", () => {
+    it("renders a path with attribute `d` equal to the result of `props.pathFunction` called with `props.slice`", () => {
+      const EXPECTED_D_ATTR = "M1,1";
+      const slice = {x: 1, y: 1};
+      const pathFunction = (sli) => {
+        expect(sli, "The path function is called with `props.slice`").to.eql(slice);
+
+        return EXPECTED_D_ATTR;
+      };
+
+      const wrapper = shallow(
+        <Slice
+          pathFunction={pathFunction}
+          slice={slice}
+        />
+      );
+
+      expect(wrapper.html()).to.eql(`<path d="${EXPECTED_D_ATTR}"></path>`);
+    });
+  });
+});


### PR DESCRIPTION
This PR moves all the basic rendered components from victory-chart and victory-pie to victory-core (_i.e._ `Bar`, `Point` etc.)
- [ ] Add basic test coverage for components
