### PR TITLE
Fix labels not showing if falsey (i.e. {0})

### DIFF
--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -170,8 +170,8 @@ export default class VictoryLabel extends React.Component {
   }
 
   getContent(props) {
-    const text = props.text || props.children;
-    if (text) {
+    const text = props.text !== undefined ? props.text : props.children;
+    if (text !== undefined) {
       const datum = props.datum || props.data;
       const child = Helpers.evaluateProp(text, datum);
       return `${child}`.split("\n");


### PR DESCRIPTION
Fixes #134

<!---
@huboard:{"order":342.0,"milestone_order":135,"custom_state":"archived"}
-->
