### PR TITLE
standardize on datum as evaluated prop

### DIFF
--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -37,12 +37,7 @@ export default class VictoryLabel extends React.Component {
      * Victory components can pass a datum prop to their label component. This can
      * be used to calculate functional styles, and determine child text
      */
-    datum: PropTypes.object,
-    /**
-     * Labels that apply to an entire data series will recieve the entire series
-     * as `data` instead of an individual datum prop.
-     */
-    data: PropTypes.array,
+    datum: PropTypes.any,
     /**
      * The events prop attaches arbitrary event handlers to the label component.
      * Event handlers are currently only called with their corresponding events.
@@ -247,7 +242,7 @@ export default class VictoryLabel extends React.Component {
   }
 
   render() {
-    const datum = this.props.datum || this.props.data;
+    const { datum, events } = this.props;
     const style = this.getStyles(this.props);
     const lineHeight = this.getHeight(this.props, "lineHeight");
     const textAnchor = this.props.textAnchor ?
@@ -256,7 +251,7 @@ export default class VictoryLabel extends React.Component {
     const dx = this.props.dx ? Helpers.evaluateProp(this.props.dx, datum) : 0;
     const dy = this.getDy(this.props, content, lineHeight) * style.fontSize;
     const labelProps = assign(
-      {}, this.props, { dy, dx, datum, lineHeight, textAnchor, style }, this.props.events
+      {}, this.props, { dy, dx, datum, lineHeight, textAnchor, style }, events
     );
     return this.renderElements(labelProps, content);
   }

--- a/src/victory-primitives/line.js
+++ b/src/victory-primitives/line.js
@@ -4,7 +4,7 @@ import { assign } from "lodash";
 export default class Line extends React.Component {
   static propTypes = {
     index: PropTypes.number,
-    tick: PropTypes.any,
+    datum: PropTypes.any,
     x1: PropTypes.number,
     x2: PropTypes.number,
     y1: PropTypes.number,


### PR DESCRIPTION
standardizes on `datum` as the prop that will be evaluated in `VictoryLabel` and `Line` to match other components

part of https://github.com/FormidableLabs/victory/issues/371
