### PR TITLE
Improvement/clip path container

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ export { default as VictoryLabel } from "./victory-label/victory-label";
 export { default as VictoryTransition } from "./victory-transition/victory-transition";
 export { default as VictorySharedEvents } from "./victory-shared-events/victory-shared-events";
 export { default as VictoryContainer } from "./victory-container/victory-container";
+export {
+  default as VictoryGroupContainer
+} from "./victory-group-container/victory-group-container";
 export { default as VictoryTheme } from "./victory-theme/victory-theme";
 export { default as VictoryTooltip } from "./victory-tooltip/victory-tooltip";
 export { default as VictoryPortal } from "./victory-portal/victory-portal";

--- a/src/victory-group-container/victory-group-container.js
+++ b/src/victory-group-container/victory-group-container.js
@@ -1,0 +1,113 @@
+import React, { PropTypes } from "react";
+import { ClipPath } from "../victory-primitives/index";
+
+export default class VictoryGroupContainer extends React.Component {
+  static displayName = "VictoryGroupContainer";
+
+  static propTypes = {
+    /**
+     * The style prop specifies styles for your VictoryContainer. Any valid inline style properties
+     * will be applied. Height and width should be specified via the height
+     * and width props, as they are used to calculate the alignment of
+     * components within the container. Styles from the child component will
+     * also be passed, if any exist.
+     * @examples {border: 1px solid red}
+     */
+    style: PropTypes.object,
+    /**
+     * The padding props specifies the amount of padding in number of pixels between
+     * the edge of the chart and any rendered child components. This prop should be given
+     * as an object with padding specified for top, bottom, left and right.
+     */
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        top: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number
+      })
+    ]),
+    /**
+     * The clipHeight props specifies the height of the clipPath
+     * This value should be given as a number of pixels
+     */
+    clipHeight: PropTypes.number,
+    /**
+     * The clipWidth props specifies the width of the clipPath
+     * This value should be given as a number of pixels
+     */
+    clipWidth: PropTypes.number,
+    /**
+     * The events prop attaches arbitrary event handlers to the container component.
+     * Event handlers passed from other Victory components are called with their
+     * corresponding events as well as scale, style, width, height, and data when
+     * applicable. Use the invert method to convert event coordinate information to
+     * data. `scale.x.invert(evt.offsetX)`.
+     * @examples {(evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}
+     */
+    events: PropTypes.object,
+    /**
+     * VictoryContainer is a wrapper component that controls some props and behaviors of its
+     * children. VictoryContainer works with all Victory components.
+     * If no children are provided, VictoryContainer will render an empty SVG.
+     * Props from children are used to determine default style, height, and width.
+     */
+    children: React.PropTypes.oneOfType([
+      React.PropTypes.arrayOf(React.PropTypes.node),
+      React.PropTypes.node
+    ]),
+    /**
+     * The clipPathComponent prop takes an entire component which will be used to
+     * create clipPath elements for use within container elements.
+     */
+    clipPathComponent: PropTypes.element,
+    /**
+     * A unique ID for clipPath so, it could make sure using specific clipPath on
+     * specific chart
+     * @type {Number}
+     */
+    clipId: PropTypes.number,
+    /**
+     * The translateX props specifies the x-axis translation of the clipPath
+     */
+    translateX: PropTypes.number,
+    transform: PropTypes.string
+  }
+
+  static defaultProps = {
+    clipPathComponent: <ClipPath/>
+  }
+
+  render() {
+    const { style, events, children, transform, clipWidth } = this.props;
+    if (clipWidth || clipWidth === 0) {
+      const { padding, clipId, translateX, clipHeight, clipPathComponent } = this.props;
+      const clipComponent = React.cloneElement(
+        clipPathComponent,
+        { padding, clipId, translateX, clipWidth, clipHeight }
+      );
+      return (
+        <g
+          style={style}
+          {...events}
+          transform={transform}
+        >
+          {clipComponent}
+          <g clipPath={`url(#${clipId})`}>
+            {children}
+          </g>
+        </g>
+      );
+    }
+    return (
+      <g
+        style={style}
+        {...events}
+        transform={transform}
+      >
+        {children}
+      </g>
+    );
+  }
+}

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -4,7 +4,6 @@ import * as d3Shape from "d3-shape";
 
 export default class Area extends React.Component {
   static propTypes = {
-    clipId: PropTypes.number,
     data: PropTypes.array,
     events: PropTypes.object,
     groupComponent: PropTypes.element,
@@ -44,7 +43,7 @@ export default class Area extends React.Component {
   renderArea(path, style, events) {
     const areaStroke = style.stroke ? "none" : style.fill;
     const areaStyle = assign({}, style, {stroke: areaStroke});
-    const { role, clipId } = this.props;
+    const { role } = this.props;
     return (
       <path
         key="area"
@@ -52,7 +51,6 @@ export default class Area extends React.Component {
         role={role}
         d={path}
         {...events}
-        clipPath={`url(#${clipId})`}
       />
     );
   }
@@ -61,7 +59,7 @@ export default class Area extends React.Component {
     if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
       return undefined;
     }
-    const { role, clipId } = this.props;
+    const { role } = this.props;
     const lineStyle = assign({}, style, {fill: "none"});
     return (
       <path
@@ -70,7 +68,6 @@ export default class Area extends React.Component {
         role={role}
         d={path}
         {...events}
-        clipPath={`url(#${clipId})`}
       />
     );
   }

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -4,7 +4,6 @@ import { assign } from "lodash";
 export default class Bar extends React.Component {
 
   static propTypes = {
-    clipId: PropTypes.number,
     datum: PropTypes.object,
     events: PropTypes.object,
     horizontal: PropTypes.bool,
@@ -57,7 +56,7 @@ export default class Bar extends React.Component {
   }
 
   renderBar(path, style, events) {
-    const { role, clipId, shapeRendering } = this.props;
+    const { role, shapeRendering } = this.props;
     return (
       <path
         d={path}
@@ -65,7 +64,6 @@ export default class Bar extends React.Component {
         role={role}
         shapeRendering={shapeRendering || "auto"}
         {...events}
-        clipPath={`url(#${clipId})`}
       />
     );
   }

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -4,7 +4,6 @@ import * as d3Shape from "d3-shape";
 
 export default class Curve extends React.Component {
   static propTypes = {
-    clipId: PropTypes.number,
     data: PropTypes.array,
     events: PropTypes.object,
     index: PropTypes.number,
@@ -21,14 +20,13 @@ export default class Curve extends React.Component {
   }
 
   renderLine(path, style, events) {
-    const { role, clipId } = this.props;
+    const { role } = this.props;
     return (
       <path
         style={style}
         d={path}
         role={role}
         {...events}
-        clipPath={`url(#${clipId})`}
         vectorEffect="non-scaling-stroke"
       />
     );

--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -1,7 +1,7 @@
 import React from "react";
 import VictoryAnimation from "../victory-animation/victory-animation";
 import { Transitions, Collection } from "../victory-util/index";
-import { defaults, isFunction, pick, filter, identity, isEqual } from "lodash";
+import { assign, defaults, isFunction, pick, filter, identity, isEqual } from "lodash";
 
 export default class VictoryTransition extends React.Component {
   static displayName = "VictoryTransition";
@@ -31,6 +31,9 @@ export default class VictoryTransition extends React.Component {
       nodesDoneClipPathLoad: false,
       animating: true
     };
+    const child = this.props.children;
+    this.continuous = child.type && child.type.continuous;
+    this.clipId = Math.round(Math.random() * 10000);
     this.getTransitionState = this.getTransitionState.bind(this);
   }
 
@@ -118,19 +121,24 @@ export default class VictoryTransition extends React.Component {
         nodesDoneClipPathExit,
         animating
       } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
-      return {
+      const transitionState = {
         nodesWillExit,
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter,
-        nodesDoneClipPathEnter,
-        nodesDoneClipPathExit,
-        nodesDoneLoad: nodesDoneLoad || this.state.nodesDoneLoad,
-        nodesDoneClipPathLoad: nodesDoneClipPathLoad || this.state.nodesDoneClipPathLoad,
         nodesShouldLoad: nodesShouldLoad || this.state.nodesShouldLoad,
+        nodesDoneLoad: nodesDoneLoad || this.state.nodesDoneLoad,
         animating: animating || this.state.animating,
         oldProps: nodesWillExit ? props : null
       };
+      return this.continuous ? assign(
+        {
+          nodesDoneClipPathEnter,
+          nodesDoneClipPathExit,
+          nodesDoneClipPathLoad: nodesDoneClipPathLoad || this.state.nodesDoneClipPathLoad
+        },
+        transitionState
+      ) : transitionState;
     }
   }
 
@@ -192,18 +200,26 @@ export default class VictoryTransition extends React.Component {
     const combinedProps = defaults(
       {domain}, transitionProps, child.props
     );
-    const animationWhitelist = props.animationWhitelist;
-    const clipPathWhitelist = this.getClipPathWhitelist(transitionProps);
-
-    const propsToAnimate = animationWhitelist ?
-      pick(combinedProps, animationWhitelist.concat(clipPathWhitelist)) : combinedProps;
-
+    const animationWhitelist = props.animationWhitelist || [];
+    const whitelist = this.continuous ?
+      animationWhitelist.concat(this.getClipPathWhitelist(transitionProps)) : animationWhitelist;
+    const propsToAnimate = whitelist.length ? pick(combinedProps, whitelist) : combinedProps;
     return (
       <VictoryAnimation {...combinedProps.animate} data={propsToAnimate}>
         {(newProps) => {
-          const component = React.cloneElement(
-            child, defaults({animate: null}, newProps, combinedProps));
-          return component;
+          if (this.continuous) {
+            const { clipWidth, clipHeight, translateX, padding } = newProps;
+            const groupComponent = React.cloneElement(
+              child.props.groupComponent,
+              { clipWidth, clipHeight, translateX, padding, clipId: this.clipId }
+            );
+            return React.cloneElement(
+              child, defaults({animate: null, groupComponent}, newProps, combinedProps)
+            );
+          }
+          return React.cloneElement(
+            child, defaults({animate: null}, newProps, combinedProps)
+          );
         }}
       </VictoryAnimation>
     );


### PR DESCRIPTION
This PR creates a new `VictoryGroupContainer` to be used when components need to "curtain in" transitions with clipPath (_i.e._ VictoryLine, VictoryArea). This solution is instead of applying clipPaths directly to the `Curve` and `Area` primitives, and allows users to supply custom `dataComponents` to `VictoryLine` and `VictoryArea` without breaking curtain transitions. This will also remove `clipPathComponent` and `clipId` props from `VictoryLine` and `VictoryArea`. These never should have been user facing to begin with, and were a significant source of confusion. 

Addresses https://github.com/FormidableLabs/victory/issues/367

*_IMPORTANT: Should be merged after #146 *_
