### PR TITLE
Improvement/add events hoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "builder-victory-component": "^2.4.0",
     "d3-ease": "^0.3.0",
     "d3-interpolate": "0.2.0",
+    "d3-scale": "^1.0.0",
     "d3-shape": "^1.0.0",
     "d3-timer": "^0.0.6",
     "lodash": "^4.12.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,8 @@
-export { default as Collection } from "./victory-util/collection";
-export { default as Helpers } from "./victory-util/helpers";
-export { default as Log } from "./victory-util/log";
-export { default as Style } from "./victory-util/style";
-export { default as PropTypes } from "./victory-util/prop-types";
-export { default as Events } from "./victory-util/events";
-export { default as addEvents } from "./victory-util/add-events";
-export { default as TextSize } from "./victory-util/textsize";
-import * as Transitions from "./victory-util/transitions";
-import * as DefaultTransitions from "./victory-util/default-transitions";
-export { Transitions, DefaultTransitions };
-
 export { default as VictoryAnimation } from "./victory-animation/victory-animation";
+export { default as VictoryContainer } from "./victory-container/victory-container";
 export { default as VictoryLabel } from "./victory-label/victory-label";
 export { default as VictoryTransition } from "./victory-transition/victory-transition";
 export { default as VictorySharedEvents } from "./victory-shared-events/victory-shared-events";
-export { default as VictoryContainer } from "./victory-container/victory-container";
 export {
   default as VictoryGroupContainer
 } from "./victory-group-container/victory-group-container";
@@ -25,3 +13,7 @@ export { default as Portal } from "./victory-portal/portal";
 export {
   Area, Bar, Candle, ClipPath, Curve, ErrorBar, Line, Point, Slice, Voronoi, Flyout
 } from "./victory-primitives/index";
+export {
+  addEvents, Collection, Data, DefaultTransitions, Domain, Events, Helpers, Log,
+  PropTypes, Scale, Style, TextSize, Transitions
+} from "./victory-util/index";

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export { default as Log } from "./victory-util/log";
 export { default as Style } from "./victory-util/style";
 export { default as PropTypes } from "./victory-util/prop-types";
 export { default as Events } from "./victory-util/events";
+export { default as addEvents } from "./victory-util/add-events";
 export { default as TextSize } from "./victory-util/textsize";
 import * as Transitions from "./victory-util/transitions";
 import * as DefaultTransitions from "./victory-util/default-transitions";

--- a/src/victory-primitives/slice.js
+++ b/src/victory-primitives/slice.js
@@ -7,25 +7,15 @@ export default class Slice extends React.Component {
     pathFunction: PropTypes.func,
     style: PropTypes.object,
     datum: PropTypes.object,
-    events: PropTypes.object,
-    endAngle: PropTypes.number,
-    startAngle: PropTypes.number,
-    padAngle: PropTypes.number
+    events: PropTypes.object
   };
 
   renderSlice(path, style, events) {
     return <path d={path} style={style} {...events}/>;
   }
 
-  getPath(props) {
-    const { endAngle, startAngle, padAngle, index, datum, pathFunction } = props;
-    return pathFunction({
-      endAngle, startAngle, padAngle, index, data: datum, value: datum.y
-    });
-  }
-
   render() {
-    const path = this.getPath(this.props);
+    const path = this.props.pathFunction(this.props.slice);
     const { style, events } = this.props;
     return this.renderSlice(path, style, events);
   }

--- a/src/victory-primitives/slice.js
+++ b/src/victory-primitives/slice.js
@@ -7,20 +7,26 @@ export default class Slice extends React.Component {
     pathFunction: PropTypes.func,
     style: PropTypes.object,
     datum: PropTypes.object,
-    events: PropTypes.object
+    events: PropTypes.object,
+    endAngle: PropTypes.number,
+    startAngle: PropTypes.number,
+    padAngle: PropTypes.number
   };
 
-  renderSlice(props) {
-    return (
-      <path
-        d={props.pathFunction(props.slice)}
-        style={props.style}
-        {...props.events}
-      />
-    );
+  renderSlice(path, style, events) {
+    return <path d={path} style={style} {...events}/>;
+  }
+
+  getPath(props) {
+    const { endAngle, startAngle, padAngle, index, datum, pathFunction } = props;
+    return pathFunction({
+      endAngle, startAngle, padAngle, index, data: datum, value: datum.y
+    });
   }
 
   render() {
-    return this.renderSlice(this.props);
+    const path = this.getPath(this.props);
+    const { style, events } = this.props;
+    return this.renderSlice(path, style, events);
   }
 }

--- a/src/victory-util/add-events.js
+++ b/src/victory-util/add-events.js
@@ -1,0 +1,61 @@
+import { defaults, assign, isFunction, partialRight } from "lodash";
+import Events from "./events";
+
+export default (WrappedComponent) => {
+  return class addEvents extends WrappedComponent {
+    constructor() {
+      super();
+      this.state = {};
+      const getScopedEvents = Events.getScopedEvents.bind(this);
+      this.getEvents = partialRight(Events.getEvents.bind(this), getScopedEvents);
+      this.getEventState = Events.getEventState.bind(this);
+    }
+
+    componentWillMount() {
+      this.setupEvents(this.props);
+    }
+
+    componentWillReceiveProps(newProps) {
+      this.setupEvents(newProps);
+    }
+
+    setupEvents(props) {
+      const { sharedEvents } = props;
+      const components = WrappedComponent.expectedComponents;
+      this.componentEvents = Events.getComponentEvents(props, components);
+      this.baseProps = WrappedComponent.getBaseProps(props);
+      this.dataKeys = Object.keys(this.baseProps).filter((key) => key !== "parent");
+      this.getSharedEventState = sharedEvents && isFunction(sharedEvents.getEventState) ?
+        sharedEvents.getEventState : () => undefined;
+      this.hasEvents = props.events || props.sharedEvents || this.componentEvents;
+    }
+
+    getComponentProps(component, type, index) {
+      const { role } = WrappedComponent;
+      const key = this.dataKeys && this.dataKeys[index] || index;
+      const baseProps = this.baseProps[key][type] || this.baseProps[key];
+      if (!baseProps && !this.hasEvents) {
+        return undefined;
+      }
+      if (this.hasEvents) {
+        const events = this.getEvents(this.props, type, key);
+        const componentProps = defaults(
+          {index, key: `${role}-${type}-${key}`, role: `${role}-${index}`},
+          this.getEventState(key, type),
+          this.getSharedEventState(key, type),
+          component.props,
+          baseProps
+        );
+        return assign(
+          {}, componentProps, {events: Events.getPartialEvents(events, key, componentProps)}
+        );
+      }
+      return defaults(
+        {index, key: `${role}-${type}-${key}`, role: `${role}-${index}`},
+        component.props,
+        baseProps
+      );
+    }
+  };
+};
+

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -1,0 +1,214 @@
+import { assign, uniq, range, last, isFunction, property } from "lodash";
+import Helpers from "./helpers";
+import Collection from "./collection";
+import Log from "./log";
+import Scale from "./scale";
+
+export default {
+  /**
+   * Returns an array of formatted data
+   * @param {Object} props: the props object
+   * @returns {Array} an array of data
+   */
+  getData(props) {
+    let data;
+    if (props.data) {
+      if (props.data.length < 1) {
+        Log.warn("This is an empty dataset.");
+        return [];
+      } else {
+        data = this.formatData(props.data, props);
+      }
+    } else {
+      const generatedData = (props.x || props.y) && this.generateData(props);
+      data = this.formatData(generatedData, props);
+    }
+    return this.addEventKeys(props, data);
+  },
+
+  /**
+   * Returns generated data based on domain and sample from props
+   * @param {Object} props: the props object
+   * @returns {Array} an array of data
+   */
+  generateData(props) {
+    // create an array of values evenly spaced across the x domain that include domain min/max
+    const domain = props.domain ? (props.domain.x || props.domain) :
+      Scale.getBaseScale(props, "x").domain();
+    const samples = props.samples || 1;
+    const domainMax = Math.max(...domain);
+    const domainMin = Math.min(...domain);
+    const step = (domainMax - domainMin) / samples;
+    const values = range(domainMin, domainMax, step).map((v) => {
+      return { x: v, y: v };
+    });
+    return last(values).x === domainMax ?
+      values : values.concat([{ x: domainMax, y: domainMax }]);
+  },
+
+  /**
+   * Returns formatted data. Data accessors are applied, and string values are replaced.
+   * @param {Array} dataset: the original domain
+   * @param {Object} props: the props object
+   * @param {Object} stringMap: a mapping of string values to numeric values
+   * @returns {Array} the formatted data
+   */
+  formatData(dataset, props, stringMap) {
+    if (!dataset) {
+      return [];
+    }
+    stringMap = stringMap || {
+      x: this.createStringMap(props, "x"),
+      y: this.createStringMap(props, "y")
+    };
+    const accessor = {
+      x: Helpers.createAccessor(props.x),
+      y: Helpers.createAccessor(props.y)
+    };
+    return this.cleanData(dataset, props).map((datum) => {
+      const x = accessor.x(datum);
+      const y = accessor.y(datum);
+      return assign(
+          {},
+          datum,
+          { x, y },
+          // map string data to numeric values, and add names
+          typeof x === "string" ? { x: stringMap.x[x], xName: x } : {},
+          typeof y === "string" ? { y: stringMap.y[y], yName: y } : {}
+        );
+    });
+  },
+
+  /**
+   * Returns the cleaned data. Some scale types break when certain data is supplied.
+   * This method will remove data points that break certain scales. So far this method
+   * only removes zeroes for log scales
+   * @param {Array} dataset: the original domain
+   * @param {Object} props: the props object
+   * @returns {Array} the cleaned data
+   */
+  cleanData(dataset, props) {
+    const scaleType = {
+      x: Scale.getScaleType(props, "x"),
+      y: Scale.getScaleType(props, "y")
+    };
+    const accessor = {
+      x: Helpers.createAccessor(props.x),
+      y: Helpers.createAccessor(props.y)
+    };
+    if (scaleType.x !== "log" && scaleType.y !== "log") {
+      return dataset;
+    }
+    const rules = (datum, axis) => {
+      return scaleType[axis] === "log" ? accessor[axis](datum) !== 0 : true;
+    };
+    return dataset.filter((datum) => {
+      return rules(datum, "x") && rules(datum, "y");
+    });
+  },
+
+  // Returns a data accessor given an eventKey prop
+  getEventKey(key) {
+    // creates a data accessor function
+    // given a property key, path, array index, or null for identity.
+    if (isFunction(key)) {
+      return key;
+    } else if (key === null || typeof key === "undefined") {
+      return () => undefined;
+    }
+    // otherwise, assume it is an array index, property key or path (_.property handles all three)
+    return property(key);
+  },
+
+  // Returns data with an eventKey prop added to each datum
+  addEventKeys(props, data) {
+    const eventKeyAccessor = this.getEventKey(props.eventKey);
+    return data.map((datum, index) => {
+      const eventKey = datum.eventKey || eventKeyAccessor(datum) || index;
+      return assign({eventKey}, datum);
+    });
+  },
+
+  /**
+   * Returns an object mapping string data to numeric data
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Object} an object mapping string data to numeric data
+   */
+  createStringMap(props, axis) {
+    const stringsFromAxes = this.getStringsFromAxes(props, axis);
+    const stringsFromCategories = this.getStringsFromCategories(props, axis);
+    const stringsFromData = this.getStringsFromData(props, axis);
+
+    const allStrings = uniq([...stringsFromAxes, ...stringsFromCategories, ...stringsFromData]);
+    return allStrings.length === 0 ? null :
+      allStrings.reduce((memo, string, index) => {
+        memo[string] = index + 1;
+        return memo;
+      }, {});
+  },
+
+  /**
+   * Returns an array of strings from data
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} an array of strings
+   */
+  getStringsFromData(props, axis) {
+    if (!props.data) {
+      return [];
+    }
+    const key = typeof props[axis] === "undefined" ? axis : props[axis];
+    const accessor = Helpers.createAccessor(key);
+    const dataStrings = (props.data)
+        .map((datum) => accessor(datum))
+        .filter((datum) => typeof datum === "string");
+    // return a unique set of strings
+    return dataStrings.reduce((prev, curr) => {
+      if (typeof curr !== "undefined" && curr !== null && prev.indexOf(curr) === -1) {
+        prev.push(curr);
+      }
+      return prev;
+    }, []);
+  },
+
+  /**
+   * Returns an array of strings from axis tickValues for a given axis
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} an array of strings
+   */
+  getStringsFromAxes(props, axis) {
+    if (!props.tickValues || (!Array.isArray(props.tickValues) && !props.tickValues[axis])) {
+      return [];
+    }
+    const tickValueArray = props.tickValues[axis] || props.tickValues;
+    return tickValueArray.filter((val) => typeof val === "string");
+  },
+
+  /**
+   * Returns an array of strings from categories for a given axis
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} an array of strings
+   */
+  getStringsFromCategories(props, axis) {
+    if (!props.categories) {
+      return [];
+    }
+    const categories = this.getCategories(props, axis);
+    const categoryStrings = categories && categories.filter((val) => typeof val === "string");
+    return categoryStrings ? Collection.removeUndefined(categoryStrings) : [];
+  },
+
+  /**
+   * Returns an array of categories for a given axis
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} an array of categories
+   */
+  getCategories(props, axis) {
+    return props.categories && !Array.isArray(props.categories) ?
+      props.categories[axis] : props.categories;
+  }
+};

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -1,0 +1,322 @@
+import { flatten, includes, isPlainObject } from "lodash";
+import Data from "./data";
+import Scale from "./scale";
+import Helpers from "./helpers";
+import Collection from "./collection";
+
+export default {
+
+  /**
+   * Returns a domain for a given axis based on props, catefory, or data
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} the domain for the given axis
+   */
+  getDomain(props, axis) {
+    const propsDomain = this.getDomainFromProps(props, axis);
+    if (propsDomain) {
+      return this.padDomain(propsDomain, props, axis);
+    }
+    const categoryDomain = this.getDomainFromCategories(props, axis);
+    if (categoryDomain) {
+      return this.padDomain(categoryDomain, props, axis);
+    }
+    const dataset = Data.getData(props);
+    const domain = this.getDomainFromData(props, axis, dataset);
+    return this.cleanDomain(this.padDomain(domain, props, axis), props, axis);
+  },
+
+  /**
+   * Returns the cleaned domain. Some scale types break when certain data is supplied.
+   * This method will replace elements in the domain that break certain scales.
+   * So far this method only removes zeroes for log scales
+   * @param {Array} domain: the original domain
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} the cleaned domain
+   */
+  cleanDomain(domain, props, axis) {
+    const scaleType = Scale.getScaleType(props, axis);
+
+    if (scaleType !== "log") {
+      return domain;
+    }
+
+    const rules = (dom) => {
+      const almostZero = dom[0] < 0 || dom[1] < 0 ? -1 / Number.MAX_SAFE_INTEGER
+      : 1 / Number.MAX_SAFE_INTEGER;
+      const domainOne = dom[0] === 0 ? almostZero : dom[0];
+      const domainTwo = dom[1] === 0 ? almostZero : dom[1];
+      return [domainOne, domainTwo];
+    };
+
+    return rules(domain);
+  },
+
+  /**
+   * Returns a domain for a given axis. This method forces the domain to include
+   * zero unless the deomain is explicitly specified in props.
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} the domain for the given axis
+   */
+  getDomainWithZero(props, axis) {
+    const propsDomain = this.getDomainFromProps(props, axis);
+    if (propsDomain) {
+      return this.cleanDomain(this.padDomain(propsDomain, props, axis), props, axis);
+    }
+    const { horizontal } = props;
+    const ensureZero = (domain) => {
+      const isDependent = (axis === "y" && !horizontal) || (axis === "x" && horizontal);
+      const min = Collection.getMinValue(domain, 0);
+      const max = Collection.getMaxValue(domain, 0);
+      const zeroDomain = isDependent ? [min, max] : domain;
+      return this.padDomain(zeroDomain, props, axis);
+    };
+    const categoryDomain = this.getDomainFromCategories(props, axis);
+    if (categoryDomain) {
+      return this.cleanDomain(this.padDomain(ensureZero(categoryDomain), props, axis), props, axis);
+    }
+    const dataset = Data.getData(props);
+    const domain = ensureZero(this.getDomainFromData(props, axis, dataset));
+    return this.cleanDomain(this.padDomain(domain, props, axis), props, axis);
+  },
+
+  /**
+   * Returns a the domain for a given axis if domain is given in props
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array|undefined} the domain based on props
+   */
+  getDomainFromProps(props, axis) {
+    if (props.domain && props.domain[axis]) {
+      return props.domain[axis];
+    } else if (props.domain && Array.isArray(props.domain)) {
+      return props.domain;
+    }
+  },
+
+  /**
+   * Returns a domain from a dataset for a given axis
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @param {Array} dataset: an array of data
+   * @returns {Array} the domain based on data
+   */
+  getDomainFromData(props, axis, dataset) {
+    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
+    const allData = flatten(dataset).map((datum) => datum[currentAxis]);
+
+    if (allData.length < 1) {
+      return Scale.getBaseScale(props, axis).domain();
+    }
+
+    const min = Collection.getMinValue(allData);
+    const max = Collection.getMaxValue(allData);
+    // TODO: is this the correct behavior, or should we just error. How do we
+    // handle charts with just one data point?
+    if (min === max) {
+      const adjustedMax = max === 0 ? 1 : max + max;
+      return [0, adjustedMax];
+    }
+    return [min, max];
+  },
+
+  /**
+   * Returns a domain based tickValues
+   * @param {Object} props: the props object
+   * @returns {Array} returns a domain from tickValues
+   */
+  getDomainFromTickValues(props) {
+    let domain;
+    if (Helpers.stringTicks(props)) {
+      domain = [1, props.tickValues.length];
+    } else {
+      // coerce ticks to numbers
+      const ticks = props.tickValues.map((value) => +value);
+      domain = [Math.min(...ticks), Math.max(...ticks)];
+    }
+    if (Helpers.isVertical(props)) {
+      domain.reverse();
+    }
+    return domain;
+  },
+
+  /**
+   * Returns a domain based on categories if they exist
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array|undefined} returns a domain from categories or undefined
+   */
+  getDomainFromCategories(props, axis) {
+    const categories = Data.getCategories(props, axis);
+    if (!categories) {
+      return undefined;
+    }
+    const stringArray = Collection.containsStrings(categories) ?
+     Data.getStringsFromCategories(props, axis) : [];
+    const stringMap = stringArray.length === 0 ? null :
+      stringArray.reduce((memo, string, index) => {
+        memo[string] = index + 1;
+        return memo;
+      }, {});
+    const categoryValues = stringMap ?
+      categories.map((value) => stringMap[value]) : categories;
+    return [Math.min(...categoryValues), Math.max(...categoryValues)];
+  },
+
+  /**
+   * Returns a cumulative domain for a set of grouped datasets (i.e. stacked charts)
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @param {Array} datasets: an array of data arrays
+   * @returns {Array} the cumulative domain
+   */
+  getDomainFromGroupedData(props, axis, datasets) {
+    const { horizontal } = props;
+    const dependent = (axis === "x" && !horizontal) || (axis === "y" && horizontal);
+    if (dependent && props.categories) {
+      return this.getDomainFromCategories(props, axis);
+    }
+    const globalDomain = this.getDomainFromData(props, axis, datasets);
+
+    // find the cumulative max for stacked chart types
+    const cumulativeData = !dependent ?
+      this.getCumulativeData(props, axis, datasets) : [];
+
+    const cumulativeMaxArray = cumulativeData.map((dataset) => {
+      return dataset.reduce((memo, val) => {
+        return val > 0 ? memo + val : memo;
+      }, 0);
+    });
+    const cumulativeMinArray = cumulativeData.map((dataset) => {
+      return dataset.reduce((memo, val) => {
+        return val < 0 ? memo + val : memo;
+      }, 0);
+    });
+
+    const cumulativeMin = Math.min(...cumulativeMinArray);
+    // use greatest min / max
+    const domainMin = cumulativeMin < 0 ? cumulativeMin : Math.min(...globalDomain);
+    const domainMax = Math.max(...globalDomain, ...cumulativeMaxArray);
+    // TODO: is this the correct behavior, or should we just error. How do we
+    // handle charts with just one data point?
+    if (domainMin === domainMax) {
+      const adjustedMax = domainMax === 0 ? 1 : domainMax;
+      return [0, adjustedMax];
+    }
+    return [domainMin, domainMax];
+  },
+
+  /**
+   * Returns cumulative datasets either by index or category
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @param {Array} datasets: an array of data arrays
+   * @returns {Array} an array of data arrays grouped by index or category
+   */
+  getCumulativeData(props, axis, datasets) {
+    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
+    const categories = [];
+    const axisValues = [];
+    datasets.forEach((dataset) => {
+      dataset.forEach((data) => {
+        if (data.category !== undefined && !includes(categories, data.category)) {
+          categories.push(data.category);
+        } else if (!includes(axisValues, data[currentAxis])) {
+          axisValues.push(data[currentAxis]);
+        }
+      });
+    });
+
+    const _dataByCategory = () => {
+      return categories.map((value) => {
+        return datasets.reduce((prev, data) => {
+          return data.category === value ? prev.concat(data[axis]) : prev;
+        }, []);
+      });
+    };
+
+    const _dataByIndex = () => {
+      return axisValues.map((value, index) => {
+        return datasets.map((data) => data[index] && data[index][currentAxis]);
+      });
+    };
+
+    return categories.length === 0 ? _dataByIndex() : _dataByCategory();
+  },
+
+  /**
+   * Returns the domain padding appropriate for a given axis
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Object} an object with padding specified for "left" and "right"
+   */
+  getDomainPadding(props, axis) {
+    const formatPadding = (padding) => {
+      return Array.isArray(padding) ?
+        {left: padding[0], right: padding[1]} : {left: padding, right: padding};
+    };
+
+    return isPlainObject(props.domainPadding) ?
+      formatPadding(props.domainPadding[axis]) : formatPadding(props.domainPadding);
+  },
+
+  /**
+   * Returns the domain with padding from the `domainPadding` prop applied
+   * @param {Array} domain: the original domain
+   * @param {Object} props: the props object
+   * @param {String} axis: the current axis
+   * @returns {Array} the domain with padding applied
+   */
+  padDomain(domain, props, axis) {
+    if (!props.domainPadding) {
+      return domain;
+    }
+
+    const padding = this.getDomainPadding(props, axis);
+    if (!padding.left && !padding.right) {
+      return domain;
+    }
+
+    const domainMin = Collection.getMinValue(domain);
+    const domainMax = Collection.getMaxValue(domain);
+    const range = Helpers.getRange(props, axis);
+    const rangeExtent = Math.abs(Math.max(...range) - Math.min(...range));
+
+    const paddingLeft = Math.abs(domainMax - domainMin) * padding.left / rangeExtent;
+    const paddingRight = Math.abs(domainMax - domainMin) * padding.right / rangeExtent;
+    // don't make the axes cross if they aren't already
+    const adjustedMin = (domainMin >= 0 && (domainMin - paddingLeft) <= 0) ?
+      0 : domainMin.valueOf() - paddingLeft;
+
+    const adjustedMax = (domainMax <= 0 && (domainMax + paddingRight) >= 0) ?
+      0 : domainMax.valueOf() + paddingRight;
+
+    return domainMin instanceof Date || domainMax instanceof Date ?
+      [new Date(adjustedMin), new Date(adjustedMax)] : [adjustedMin, adjustedMax];
+  },
+
+  /**
+   * Returns the domain or the reversed domain depending on orientation
+   * @param {Array} domain: the original domain
+   * @param {Object} orientations: the x and y orientations
+   * @param {String} axis: the current axis
+   * @returns {Array} the domain or the reversed domain
+   */
+  orientDomain(domain, orientations, axis) {
+    // If the other axis is in a reversed orientation, the domain of this axis
+    // needs to be reversed
+    const otherAxis = axis === "x" ? "y" : "x";
+    const defaultOrientation = (ax) => ax === "x" ? "bottom" : "left";
+    const flippedAxis = orientations.x === "left" || orientations.x === "right";
+    const standardOrientation = flippedAxis ?
+      orientations[otherAxis] === defaultOrientation(axis) :
+      orientations[otherAxis] === defaultOrientation(otherAxis);
+    if (flippedAxis) {
+      return standardOrientation ? domain.concat().reverse() : domain;
+    } else {
+      return standardOrientation ? domain : domain.concat().reverse();
+    }
+  }
+};

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -1,46 +1,5 @@
 import { assign, extend, merge, partial, isFunction, isEmpty, property } from "lodash";
 
-  /* Example Event Prop
-    [
-      {
-        childName: "firstBar",
-        target: "data",
-        eventKey: 1,
-        eventKey: "thisOne",
-        eventHandlers: {
-          onClick: () => {},
-          ...
-        }
-      },
-      {
-        target: "labels",
-        eventHandlers: {
-          onClick: () => {}
-        }
-      }
-    ]
-
-
-  */
-
-  /* Example Event handler return
-  [
-    {
-      childName: "fistBar",
-      target: "data",
-      eventKey: 1,
-      mutation: (propsForTarget) => {
-        return {style: merge({}, propsForTarget.style, {fill: "red"})}
-      }
-    },
-    {
-      target: "labels",
-      eventKey: 2,
-      mutation: () => { return {text: "hello"}; }
-    }
-  ]
-  */
-
 export default {
   /* Returns all own and shared events that should be attached to a single target element,
    * i.e. an individual bar specified by target: "data", eventKey: [index].
@@ -231,28 +190,6 @@ export default {
     return this.state[childType] &&
       this.state[childType][eventKey] &&
       this.state[childType][eventKey][namespace];
-  },
-
-  // Returns a data accessor given an eventKey prop
-  getEventKey(key) {
-    // creates a data accessor function
-    // given a property key, path, array index, or null for identity.
-    if (isFunction(key)) {
-      return key;
-    } else if (key === null || typeof key === "undefined") {
-      return () => undefined;
-    }
-    // otherwise, assume it is an array index, property key or path (_.property handles all three)
-    return property(key);
-  },
-
-  // Returns data with an eventKey prop added to each datum
-  addEventKeys(props, data) {
-    const eventKeyAccessor = this.getEventKey(props.eventKey);
-    return data.map((datum, index) => {
-      const eventKey = datum.eventKey || eventKeyAccessor(datum) || index;
-      return assign({eventKey}, datum);
-    });
   },
 
   /* Returns an array of defaultEvents from sub-components of a given component.

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -1,4 +1,4 @@
-import { assign, extend, merge, partial, isFunction, isEmpty, property } from "lodash";
+import { assign, extend, merge, partial, isEmpty } from "lodash";
 
 export default {
   /* Returns all own and shared events that should be attached to a single target element,

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -42,112 +42,15 @@ import { assign, extend, merge, partial, isFunction, isEmpty, property } from "l
   */
 
 export default {
-  getPartialEvents(events, eventKey, childProps) {
-    return events ?
-      Object.keys(events).reduce((memo, eventName) => {
-        /* eslint max-params: 0 */
-        memo[eventName] = partial(
-          events[eventName],
-          partial.placeholder, // evt will still be the first argument for event handlers
-          childProps, // event handlers will have access to data component props, including data
-          eventKey, // used in setting a unique state property
-          eventName // used in setting a unique state property
-        );
-        return memo;
-      }, {}) :
-      {};
-  },
-
-  getScopedEvents(events, namespace, childType, baseProps) {
-    if (isEmpty(events)) {
-      return {};
-    }
-
-    baseProps = baseProps || this.baseProps;
-    const getTargetProps = (identifier, type) => {
-      const { childName, target, key } = identifier;
-      const baseType = type === "props" ? baseProps : this.state;
-      const base = (!childName || !baseType[childName]) ? baseType : baseType[childName];
-      return key === "parent" ? base.parent : base[key] && base[key][target];
-    };
-
-    const parseEvent = (eventReturn, eventKey) => {
-      const childNames = namespace === "parent" ?
-        eventReturn.childName : eventReturn.childName || childType;
-      const target = eventReturn.target || namespace;
-
-      const getKeys = (childName) => {
-        if (baseProps.all || baseProps[childName] && baseProps[childName].all) {
-          return "all";
-        } else if (eventReturn.eventKey === "all") {
-          return baseProps[childName] ?
-            Object.keys(baseProps[childName]) : Object.keys(baseProps);
-        } else if (eventReturn.eventKey === undefined && eventKey === "parent") {
-          return baseProps[childName] ?
-            Object.keys(baseProps[childName]) : Object.keys(baseProps);
-        }
-        return eventReturn.eventKey !== undefined ? eventReturn.eventKey : eventKey;
-      };
-
-      const getMutationObject = (key, childName) => {
-        const nullFunction = () => null;
-        const mutationTargetProps = getTargetProps({childName, key, target}, "props");
-        const mutationTargetState = getTargetProps({childName, key, target}, "state");
-        const mutation = eventReturn.mutation || nullFunction;
-        const mutatedProps = mutation(
-          assign({}, mutationTargetProps, mutationTargetState), baseProps
-        );
-        const childState = this.state[childName] || {};
-        return childName ?
-          extend(this.state, {
-            [childName]: extend(childState, {
-              [key]: extend(childState[key], {[target]: mutatedProps})
-            })
-          }) :
-          extend(this.state, {
-            [key]: extend(this.state[key], {[target]: mutatedProps})
-          });
-      };
-
-      const getReturnByChild = (childName) => {
-        const mutationKeys = getKeys(childName);
-        return Array.isArray(mutationKeys) ?
-          mutationKeys.reduce((memo, key) => {
-            return assign(memo, getMutationObject(key, childName));
-          }, {}) :
-          getMutationObject(mutationKeys, childName);
-      };
-
-      return Array.isArray(childNames) ? childNames.reduce((memo, childName) => {
-        return assign(memo, getReturnByChild(childName));
-      }, {}) : getReturnByChild(childNames);
-    };
-
-    const parseEventReturn = (eventReturn, eventKey) => {
-      return Array.isArray(eventReturn) ?
-        eventReturn.reduce((memo, props) => {
-          memo = merge({}, memo, parseEvent(props, eventKey));
-          return memo;
-        }, {}) :
-        parseEvent(eventReturn, eventKey);
-    };
-
-    const onEvent = (evt, childProps, eventKey, eventName) => {
-      const eventReturn = events[eventName](evt, childProps, eventKey);
-      if (eventReturn) {
-        this.setState(parseEventReturn(eventReturn, eventKey));
-      }
-    };
-
-    return Object.keys(events).reduce((memo, event) => {
-      memo[event] = onEvent;
-      return memo;
-    }, {});
-  },
-
+  /* Returns all own and shared events that should be attached to a single target element,
+   * i.e. an individual bar specified by target: "data", eventKey: [index].
+   * Returned events are scoped to the appropriate state. Either that of the component itself
+   * (i.e. VictoryBar) in the case of own events, or that of the parent component
+   * (i.e. VictoryChart) in the case of shared events
+   */
   getEvents(props, target, eventKey, getScopedEvents) {
-    const getEventsFromProps = (events) => {
-
+    // Returns all events that apply to a particular target element
+    const getEventsByTarget = (events) => {
       const getSelectedEvents = () => {
         const targetEvents = events.reduce((memo, event) => {
           if (event.target !== undefined) {
@@ -173,6 +76,10 @@ export default {
       }, {});
     };
 
+    /* Returns all events from props and defaultEvents from components. Events handlers
+     * specified in props will override handlers for the same event if they are also
+     * specified in defaultEvents of a sub-component
+     */
     const getAllEvents = () => {
       if (Array.isArray(this.componentEvents)) {
         return Array.isArray(props.events) ?
@@ -182,16 +89,141 @@ export default {
     };
 
     const allEvents = getAllEvents();
-    const ownEvents = allEvents && getScopedEvents(getEventsFromProps(allEvents), target);
+    const ownEvents = allEvents && getScopedEvents(getEventsByTarget(allEvents), target);
     if (!props.sharedEvents) {
       return ownEvents;
     }
     const getSharedEvents = props.sharedEvents.getEvents;
     const sharedEvents = props.sharedEvents.events &&
-      getSharedEvents(getEventsFromProps(props.sharedEvents.events), target);
+      getSharedEvents(getEventsByTarget(props.sharedEvents.events), target);
     return assign({}, sharedEvents, ownEvents);
   },
 
+  /* Returns a modified events object where each event handler is replaced by a new
+   * function that calls the original handler and then calls setState with the return
+   * of the original event handler assigned to state property that maps to the target
+   * element.
+   */
+  getScopedEvents(events, namespace, childType, baseProps) {
+    if (isEmpty(events)) {
+      return {};
+    }
+
+    baseProps = baseProps || this.baseProps;
+    // returns the original base props or base state of a given target element
+    const getTargetProps = (identifier, type) => {
+      const { childName, target, key } = identifier;
+      const baseType = type === "props" ? baseProps : this.state;
+      const base = (!childName || !baseType[childName]) ? baseType : baseType[childName];
+      return key === "parent" ? base.parent : base[key] && base[key][target];
+    };
+
+    // Returns the state object with the mutation caused by a given eventReturn
+    // applied to the appropriate property on the state object
+    const parseEvent = (eventReturn, eventKey) => {
+      const childNames = namespace === "parent" ?
+        eventReturn.childName : eventReturn.childName || childType;
+      const target = eventReturn.target || namespace;
+
+      // returns all eventKeys to modify for a targeted childName
+      const getKeys = (childName) => {
+        if (baseProps.all || baseProps[childName] && baseProps[childName].all) {
+          return "all";
+        } else if (eventReturn.eventKey === "all") {
+          return baseProps[childName] ?
+            Object.keys(baseProps[childName]) : Object.keys(baseProps);
+        } else if (eventReturn.eventKey === undefined && eventKey === "parent") {
+          return baseProps[childName] ?
+            Object.keys(baseProps[childName]) : Object.keys(baseProps);
+        }
+        return eventReturn.eventKey !== undefined ? eventReturn.eventKey : eventKey;
+      };
+
+      // returns the state object with mutated props applied for a single key
+      const getMutationObject = (key, childName) => {
+        const nullFunction = () => null;
+        const mutationTargetProps = getTargetProps({childName, key, target}, "props");
+        const mutationTargetState = getTargetProps({childName, key, target}, "state");
+        const mutation = eventReturn.mutation || nullFunction;
+        const mutatedProps = mutation(
+          assign({}, mutationTargetProps, mutationTargetState), baseProps
+        );
+        const childState = this.state[childName] || {};
+        return childName ?
+          extend(this.state, {
+            [childName]: extend(childState, {
+              [key]: extend(childState[key], {[target]: mutatedProps})
+            })
+          }) :
+          extend(this.state, {
+            [key]: extend(this.state[key], {[target]: mutatedProps})
+          });
+      };
+
+      // returns entire mutated state for a given childName
+      const getReturnByChild = (childName) => {
+        const mutationKeys = getKeys(childName);
+        return Array.isArray(mutationKeys) ?
+          mutationKeys.reduce((memo, key) => {
+            return assign(memo, getMutationObject(key, childName));
+          }, {}) :
+          getMutationObject(mutationKeys, childName);
+      };
+
+      // returns an entire mutated state for all children
+      return Array.isArray(childNames) ? childNames.reduce((memo, childName) => {
+        return assign(memo, getReturnByChild(childName));
+      }, {}) : getReturnByChild(childNames);
+    };
+
+    // Parses an array of event returns into a single state mutation
+    const parseEventReturn = (eventReturn, eventKey) => {
+      return Array.isArray(eventReturn) ?
+        eventReturn.reduce((memo, props) => {
+          memo = merge({}, memo, parseEvent(props, eventKey));
+          return memo;
+        }, {}) :
+        parseEvent(eventReturn, eventKey);
+    };
+
+    // A function that calls a particular event handler, parses its return
+    // into a state mutation, and calls setState
+    const onEvent = (evt, childProps, eventKey, eventName) => {
+      const eventReturn = events[eventName](evt, childProps, eventKey);
+      if (eventReturn) {
+        this.setState(parseEventReturn(eventReturn, eventKey));
+      }
+    };
+
+    // returns a new events object with enhanced event handlers
+    return Object.keys(events).reduce((memo, event) => {
+      memo[event] = onEvent;
+      return memo;
+    }, {});
+  },
+
+  /* Returns a partially applied event handler for a specific target element
+   * This allows event handlers to have access to props controlling each element
+   */
+  getPartialEvents(events, eventKey, childProps) {
+    return events ?
+      Object.keys(events).reduce((memo, eventName) => {
+        /* eslint max-params: 0 */
+        memo[eventName] = partial(
+          events[eventName],
+          partial.placeholder, // evt will still be the first argument for event handlers
+          childProps, // event handlers will have access to data component props, including data
+          eventKey, // used in setting a unique state property
+          eventName // used in setting a unique state property
+        );
+        return memo;
+      }, {}) :
+      {};
+  },
+
+  /* Returns the property of the state object corresponding to event changes for
+   * a particular element
+   */
   getEventState(eventKey, namespace, childType) {
     if (!childType) {
       return this.state[eventKey] && this.state[eventKey][namespace];
@@ -201,6 +233,7 @@ export default {
       this.state[childType][eventKey][namespace];
   },
 
+  // Returns a data accessor given an eventKey prop
   getEventKey(key) {
     // creates a data accessor function
     // given a property key, path, array index, or null for identity.
@@ -213,6 +246,7 @@ export default {
     return property(key);
   },
 
+  // Returns data with an eventKey prop added to each datum
   addEventKeys(props, data) {
     const eventKeyAccessor = this.getEventKey(props.eventKey);
     return data.map((datum, index) => {
@@ -221,6 +255,9 @@ export default {
     });
   },
 
+  /* Returns an array of defaultEvents from sub-components of a given component.
+   * i.e. any static `defaultEvents` on `labelComponent` will be returned
+  */
   getComponentEvents(props, components) {
     const events = Array.isArray(components) && components.reduce((memo, componentName) => {
       const component = props[componentName];

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -127,50 +127,10 @@ export default {
     return property(key);
   },
 
-  getPartialEvents(events, index, childProps) {
-    return events ?
-      Object.keys(events).reduce((memo, eventName) => {
-        /* eslint max-params: 0 */
-        memo[eventName] = partial(
-          events[eventName],
-          partial.placeholder, // evt will still be the first argument for event handlers
-          childProps, // event handlers will have access to data component props, including data
-          index, // used in setting a unique state property
-          eventName // used in setting a unique state property
-        );
-        return memo;
-      }, {}) :
-      {};
-  },
-
   modifyProps(props, fallbackProps, role) {
     const theme = props.theme && props.theme[role] ? props.theme[role] : {};
     const themeProps = omit(theme, ["style"]);
     const baseProps = defaults({}, props, themeProps, fallbackProps);
     return defaults({}, baseProps, {clipWidth: baseProps.width, clipHeight: baseProps.height});
-  },
-
-  getEvents(events, namespace) {
-    const onEvent = (evt, childProps, index, eventName) => {
-      if (this.props.events[namespace] && this.props.events[namespace][eventName]) {
-        this.setState({
-          [index]: merge(
-            {},
-            this.state[index],
-            this.props.events[namespace][eventName](evt, childProps, index)
-          )
-        });
-      }
-    };
-
-    return events ?
-      Object.keys(this.props.events[namespace]).reduce((memo, event) => {
-        memo[event] = onEvent;
-        return memo;
-      }, {}) : {};
-  },
-
-  getEventState(index, namespace) {
-    return this.state[index] && this.state[index][namespace];
   }
 };

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,4 +1,4 @@
-import { defaults, isFunction, merge, partial, property, omit } from "lodash";
+import { defaults, isFunction, property, omit } from "lodash";
 
 export default {
   getPadding(props) {

--- a/src/victory-util/index.js
+++ b/src/victory-util/index.js
@@ -1,21 +1,29 @@
+import addEvents from "./add-events";
 import Collection from "./collection";
+import Data from "./data";
+import * as DefaultTransitions from "./default-transitions";
+import Domain from "./domain";
+import Events from "./events";
 import Helpers from "./helpers";
 import Log from "./log";
-import Style from "./style";
 import PropTypes from "./prop-types";
-import Events from "./events";
-import * as Transitions from "./transitions";
+import Scale from "./scale";
+import Style from "./style";
 import TextSize from "./textsize";
-import * as DefaultTransitions from "./default-transitions";
+import * as Transitions from "./transitions";
 
 export {
+  addEvents,
   Collection,
+  Data,
+  DefaultTransitions,
+  Domain,
+  Events,
   Helpers,
   Log,
-  Style,
-  Transitions,
-  DefaultTransitions,
   PropTypes,
-  Events,
-  TextSize
+  Scale,
+  Style,
+  TextSize,
+  Transitions
 };

--- a/src/victory-util/scale.js
+++ b/src/victory-util/scale.js
@@ -1,0 +1,93 @@
+import { includes, isFunction } from "lodash";
+import Helpers from "./helpers";
+import Collection from "./collection";
+import * as d3Scale from "d3-scale";
+
+const supportedScaleStrings = ["linear", "time", "log", "sqrt"];
+
+export default {
+
+  getDefaultScale() {
+    return d3Scale.scaleLinear();
+  },
+
+  toNewName(scale) {
+    // d3 scale changed the naming scheme for scale from "linear" -> "scaleLinear" etc.
+    const capitalize = (s) => s && s[0].toUpperCase() + s.slice(1);
+    return `scale${capitalize(scale)}`;
+  },
+
+  validScale(scale) {
+    if (typeof scale === "function") {
+      return (isFunction(scale.copy) && isFunction(scale.domain) && isFunction(scale.range));
+    } else if (typeof scale === "string") {
+      return includes(supportedScaleStrings, scale);
+    }
+    return false;
+  },
+
+  isScaleDefined(props, axis) {
+    if (!props.scale) {
+      return false;
+    } else if (props.scale.x || props.scale.y) {
+      return props.scale[axis] ? true : false;
+    }
+    return true;
+  },
+
+  getScaleTypeFromProps(props, axis) {
+    if (!this.isScaleDefined(props, axis)) {
+      return undefined;
+    }
+    const scale = props.scale[axis] || props.scale;
+    return typeof scale === "string" ? scale : this.getType(scale);
+  },
+
+  getScaleFromProps(props, axis) {
+    if (!this.isScaleDefined(props, axis)) {
+      return undefined;
+    }
+    const scale = props.scale[axis] || props.scale;
+
+    if (this.validScale(scale)) {
+      return isFunction(scale) ? scale : d3Scale[this.toNewName(scale)]();
+    }
+  },
+
+  getScaleTypeFromData(props, axis) {
+    if (!props.data) {
+      return "linear";
+    }
+    const accessor = Helpers.createAccessor(props[axis]);
+    const axisData = props.data.map(accessor);
+    return Collection.containsDates(axisData) ? "time" : "linear";
+  },
+
+  getBaseScale(props, axis) {
+    const scale = this.getScaleFromProps(props, axis);
+    if (scale) {
+      return scale;
+    }
+    const dataScale = this.getScaleTypeFromData(props, axis);
+    return d3Scale[this.toNewName(dataScale)]();
+  },
+
+  getType(scale) {
+    const duckTypes = [
+      {name: "log", method: "base"},
+      {name: "ordinal", method: "unknown"},
+      {name: "pow-sqrt", method: "exponent"},
+      {name: "quantile", method: "quantiles"},
+      {name: "quantize-threshold", method: "invertExtent"}
+    ];
+    const scaleType = duckTypes.filter((type) => {
+      return scale[type.method] !== undefined;
+    })[0];
+    return scaleType ? scaleType.name : undefined;
+  },
+
+  getScaleType(props, axis) {
+    // if the scale was not given in props, it will be set to linear or time depending on data
+    return this.getScaleTypeFromProps(props, axis) || this.getScaleTypeFromData(props, axis);
+  }
+};

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -144,6 +144,7 @@ describe("helpers/data", () => {
       sandbox = sinon.sandbox.create();
       sandbox.spy(Data, "formatData");
       sandbox.spy(Data, "generateData");
+      sandbox.spy(Data, "addEventKeys");
     });
 
     afterEach(() => {
@@ -153,28 +154,42 @@ describe("helpers/data", () => {
     it("formats and returns the data prop", () => {
       const data = [{x: "kittens", y: 3}, {x: "cats", y: 5}];
       const props = {data, x: "x", y: "y"};
-      const expectedReturn = [{x: 1, xName: "kittens", y: 3}, {x: 2, xName: "cats", y: 5}];
+      const expectedReturn = [
+        {x: 1, xName: "kittens", y: 3}, {x: 2, xName: "cats", y: 5}
+      ];
+      const expectedReturnWithEventKeys = [
+        {x: 1, xName: "kittens", y: 3, eventKey: 0}, {x: 2, xName: "cats", y: 5, eventKey: 1}
+      ];
       const returnData = Data.getData(props);
       expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-      expect(returnData).to.eql(expectedReturn);
+      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+      expect(returnData).to.eql(expectedReturnWithEventKeys);
     });
 
     it("generates a dataset from domain", () => {
       const expectedReturn = [{x: 0, y: 0}, {x: 10, y: 10}];
+      const expectedReturnWithEventKeys = [
+        {x: 0, y: 0, eventKey: 0}, {x: 10, y: 10, eventKey: 1}
+      ];
       const props = {x: "x", y: "y", domain: {x: [0, 10], y: [0, 10]}};
       const returnData = Data.getData(props);
       expect(Data.generateData).calledOnce.and.returned(expectedReturn);
       expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-      expect(returnData).to.eql(expectedReturn);
+      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+      expect(returnData).to.eql(expectedReturnWithEventKeys);
     });
 
     it("generates a dataset from domain and samples", () => {
       const expectedReturn = [{x: 0, y: 0}, {x: 5, y: 5}, {x: 10, y: 10}];
+      const expectedReturnWithEventKeys = [
+        {x: 0, y: 0, eventKey: 0}, {x: 5, y: 5, eventKey: 1}, {x: 10, y: 10, eventKey: 2}
+      ];
       const props = {x: "x", y: "y", domain: {x: [0, 10], y: [0, 10]}, samples: 2};
       const returnData = Data.getData(props);
       expect(Data.generateData).calledOnce.and.returned(expectedReturn);
       expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-      expect(returnData).to.eql(expectedReturn);
+      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+      expect(returnData).to.eql(expectedReturnWithEventKeys);
     });
   });
 });

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -1,0 +1,180 @@
+/* eslint no-unused-expressions: 0 */
+/* global sinon */
+
+import { Data } from "src/index";
+
+describe("helpers/data", () => {
+  describe("createStringMap", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Data, "getStringsFromAxes");
+      sandbox.spy(Data, "getStringsFromCategories");
+      sandbox.spy(Data, "getStringsFromData");
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    const tickValues = ["one", "two", "three"];
+    const categories = ["red", "green", "blue"];
+    const data = [{x: "one", y: 1}, {x: "red", y: 2}, {x: "cat", y: 3}];
+    it("returns a string map from strings in tickValues", () => {
+      const props = {tickValues};
+      const stringMap = Data.createStringMap(props, "x");
+      expect(Data.getStringsFromAxes).calledWith(props, "x");
+      expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
+      expect(stringMap).to.eql({ one: 1, two: 2, three: 3 });
+    });
+
+    it("returns a string map from strings in categories", () => {
+      const props = {categories};
+      const stringMap = Data.createStringMap(props, "x");
+      expect(Data.getStringsFromCategories).calledWith(props, "x");
+      expect(Data.getStringsFromCategories).to.have.returned(["red", "green", "blue"]);
+      expect(stringMap).to.eql({ red: 1, green: 2, blue: 3 });
+    });
+
+    it("returns a string map from strings in data", () => {
+      const props = {data};
+      const stringMap = Data.createStringMap(props, "x");
+      expect(Data.getStringsFromData).calledWith(props, "x");
+      expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+      expect(stringMap).to.eql({ one: 1, red: 2, cat: 3 });
+    });
+
+    it("a unique set of values is returned from multiple sources", () => {
+      const props = {tickValues, data};
+      const stringMap = Data.createStringMap(props, "x");
+      expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
+      expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+      expect(stringMap).to.eql({ one: 1, two: 2, three: 3, red: 4, cat: 5 });
+    });
+  });
+
+  describe("getStringsFromData", () => {
+    it("returns an array of strings from a data prop", () => {
+      const props = {data: [{x: "one", y: 1}, {x: "red", y: 2}, {x: "cat", y: 3}]};
+      const dataStrings = Data.getStringsFromData(props, "x");
+      expect(dataStrings).to.eql(["one", "red", "cat"]);
+    });
+
+    it("returns an array of strings from array-type data", () => {
+      const props = {data: [["one", 1], ["red", 2], ["cat", 3]], x: 0, y: 1};
+      const dataStrings = Data.getStringsFromData(props, "x");
+      expect(dataStrings).to.eql(["one", "red", "cat"]);
+    });
+
+    it("only returns strings, if data is mixed", () => {
+      const props = {data: [{x: 1, y: 1}, {x: "three", y: 3}]};
+      expect(Data.getStringsFromData(props, "x")).to.eql(["three"]);
+    });
+
+    it("returns an empty array when no strings are present", () => {
+      const props = {data: [{x: 1, y: 1}, {x: 3, y: 3}]};
+      expect(Data.getStringsFromData(props, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when the data prop is undefined", () => {
+      expect(Data.getStringsFromData({}, "x")).to.eql([]);
+    });
+  });
+
+  describe("getStringsFromAxes", () => {
+    it("returns an array of strings when tickValues is an array", () => {
+      const props = {tickValues: [1, "three", 5]};
+      expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
+    });
+
+    it("returns an array of strings when tickValues is an object", () => {
+      const props = {tickValues: { x: [1, "three", 5] }};
+      expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
+    });
+
+    it("returns an empty array when a given axis is not defined", () => {
+      const props = {tickValues: { y: [1, "three", 5] }};
+      expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when no strings are present", () => {
+      const props = {tickValues: [1, 3, 5]};
+      expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when the tickValues prop is undefined", () => {
+      expect(Data.getStringsFromAxes({}, "x")).to.eql([]);
+    });
+  });
+
+  describe("getStringsFromCategories", () => {
+    it("returns an empty array when no strings are present", () => {
+      const props = {categories: [1, 3, 5]};
+      expect(Data.getStringsFromCategories(props, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when the category prop is undefined", () => {
+      expect(Data.getStringsFromCategories({}, "x")).to.eql([]);
+    });
+  });
+
+  describe("formatData", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Data, "cleanData");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("formats a single dataset", () => {
+      const dataset = [{x: 1, y: 3}, {x: 2, y: 5}];
+      const props = {};
+      const formatted = Data.formatData(dataset, props);
+      expect(Data.cleanData).called.and.returned(dataset);
+      expect(formatted).to.be.an.array;
+      expect(formatted[0]).to.have.keys(["x", "y"]);
+    });
+  });
+
+  describe("getData", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Data, "formatData");
+      sandbox.spy(Data, "generateData");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("formats and returns the data prop", () => {
+      const data = [{x: "kittens", y: 3}, {x: "cats", y: 5}];
+      const props = {data, x: "x", y: "y"};
+      const expectedReturn = [{x: 1, xName: "kittens", y: 3}, {x: 2, xName: "cats", y: 5}];
+      const returnData = Data.getData(props);
+      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+      expect(returnData).to.eql(expectedReturn);
+    });
+
+    it("generates a dataset from domain", () => {
+      const expectedReturn = [{x: 0, y: 0}, {x: 10, y: 10}];
+      const props = {x: "x", y: "y", domain: {x: [0, 10], y: [0, 10]}};
+      const returnData = Data.getData(props);
+      expect(Data.generateData).calledOnce.and.returned(expectedReturn);
+      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+      expect(returnData).to.eql(expectedReturn);
+    });
+
+    it("generates a dataset from domain and samples", () => {
+      const expectedReturn = [{x: 0, y: 0}, {x: 5, y: 5}, {x: 10, y: 10}];
+      const props = {x: "x", y: "y", domain: {x: [0, 10], y: [0, 10]}, samples: 2};
+      const returnData = Data.getData(props);
+      expect(Data.generateData).calledOnce.and.returned(expectedReturn);
+      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+      expect(returnData).to.eql(expectedReturn);
+    });
+  });
+});

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -1,0 +1,200 @@
+/* eslint no-unused-expressions: 0 */
+/* global sinon */
+
+import { Data, Domain, Helpers } from "src/index";
+
+describe("helpers/domain", () => {
+  describe("padDomain", () => {
+    const baseProps = {width: 100, height: 100, padding: 0};
+    it("returns the domain when no domain padding is specified", () => {
+      const domain = [0, 1];
+      const paddedDomain = Domain.padDomain(domain, baseProps, "x");
+      expect(paddedDomain).to.eql(domain);
+    });
+
+    it("pads the domain a particular number of pixels", () => {
+      const domain = [0, 100];
+      const domainPadding = {x: 10};
+      const props = {...baseProps, domainPadding};
+      const paddedDomain = Domain.padDomain(domain, props, "x");
+      expect(paddedDomain).to.eql([0, 110]);
+    });
+  });
+
+  describe("orientDomain", () => {
+    const domain = [0, 10];
+    const reversedDomain = [10, 0];
+    it("returns a domain for standard orientations", () => {
+      const orientations = {x: "bottom", y: "left"};
+      const domainResult = Domain.orientDomain(domain, orientations, "x");
+      expect(domainResult).to.eql(domain);
+    });
+
+    it("reverses a domain for non-standard orientations", () => {
+      const orientations = {x: "top", y: "right"};
+      const domainResult = Domain.orientDomain(domain, orientations, "x");
+      expect(domainResult).to.eql(reversedDomain);
+    });
+
+    it("reverses a domain for flipped axes", () => {
+      const orientations = {x: "right", y: "bottom"};
+      const domainResult = Domain.orientDomain(domain, orientations, "x");
+      expect(domainResult).to.eql(reversedDomain);
+    });
+  });
+
+  describe("getDomain", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Domain, "getDomainFromProps");
+      sandbox.spy(Domain, "getDomainFromData");
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("gets the domain from props if they exist", () => {
+      const props = {domain: [1, 2]};
+      const resultDomain = Domain.getDomain(props, "x");
+      expect(Domain.getDomainFromProps).calledWith(props, "x").and.returned(props.domain);
+      expect(Domain.getDomainFromData).not.called;
+      expect(resultDomain).to.eql(props.domain);
+    });
+
+    it("gets the domain from data if props don't exist for a particular axis", () => {
+      const props = {x: "x", y: "y", domain: {y: [1, 2]}, data: [{x: 1, y: 3}, {x: 3, y: 5}]};
+      const resultDomain = Domain.getDomain(props, "x");
+      const dataset = Data.getData(props);
+      expect(Domain.getDomainFromProps).calledWith(props, "x").and.returned(undefined);
+      expect(Domain.getDomainFromData).calledWith(props, "x", dataset).and.returned([1, 3]);
+      expect(resultDomain).to.eql([1, 3]);
+    });
+  });
+
+  describe("getDomainFromProps", () => {
+    it("gets the domain from a domain array", () => {
+      const props = {domain: [1, 2]};
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).to.eql(props.domain);
+    });
+
+    it("gets the domain from a domain object", () => {
+      const props = {domain: {x: [1, 2]}};
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).to.eql(props.domain.x);
+    });
+
+    it("returns undefined if the domain props is not given", () => {
+      expect(Domain.getDomainFromProps({}, "x")).to.eql(undefined);
+    });
+
+    it("returns undefined if the domain for a given axis is not defined", () => {
+      const props = {domain: {y: [1, 2]}};
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).to.eql(undefined);
+    });
+  });
+
+  describe("getDomainFromData", () => {
+    it("returns a domain from a dataset", () => {
+      const dataset = [{x: 1, y: 3}, {x: 3, y: 5}];
+      const resultDomain = Domain.getDomainFromData({}, "x", dataset);
+      expect(resultDomain).to.eql([1, 3]);
+    });
+  });
+
+  describe("getDomainFromTickValues", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Helpers, "isVertical");
+      sandbox.spy(Helpers, "stringTicks");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("determines a domain from tickValues", () => {
+      const props = {tickValues: [1, 2, 3]};
+      const domainResult = Domain.getDomainFromTickValues(props);
+      expect(Helpers.stringTicks).calledWith(props).and.returned(false);
+      expect(Helpers.isVertical).calledWith(props).and.returned(false);
+      expect(domainResult).to.eql([1, 3]);
+    });
+
+    it("determines a domain from string tick values", () => {
+      const props = {tickValues: ["a", "b", "c", "d"]};
+      const domainResult = Domain.getDomainFromTickValues(props);
+      expect(Helpers.stringTicks).calledWith(props).and.returned(true);
+      expect(Helpers.isVertical).calledWith(props).and.returned(false);
+      expect(domainResult).to.eql([1, 4]);
+    });
+
+    it("reverses a domain from tickValues when the axis is vertical", () => {
+      const props = {tickValues: [1, 2, 3], dependentAxis: true};
+      const domainResult = Domain.getDomainFromTickValues(props);
+      expect(Helpers.stringTicks).calledWith(props).and.returned(false);
+      expect(Helpers.isVertical).calledWith(props).and.returned(true);
+      expect(domainResult).to.eql([3, 1]);
+    });
+  });
+
+  describe("getDomainFromGroupedData", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Domain, "getDomainFromData");
+      sandbox.spy(Domain, "getDomainFromCategories");
+      sandbox.spy(Domain, "getCumulativeData");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    const data = [
+      [{x: 1, y: 0}, {x: 2, y: 0}, {x: 3, y: 0}],
+      [{x: 1, y: 1}, {x: 2, y: 1}, {x: 3, y: 1}],
+      [{x: 1, y: 2}, {x: 2, y: 2}, {x: 3, y: 2}]
+    ];
+
+    it("calculates a domain from categories for the independent axis", () => {
+      const props = {categories: [1, 2, 3], data, x: "x", y: "y"};
+      const domainResultX = Domain.getDomainFromGroupedData(props, "x", data);
+      expect(Domain.getDomainFromCategories).calledWith(props, "x").and.returned([1, 3]);
+      expect(Domain.getDomainFromData).not.called;
+      expect(Domain.getCumulativeData).not.called;
+      expect(domainResultX).to.eql([1, 3]);
+    });
+
+    it("calculates a stacked domain for the dependent axis", () => {
+      const props = {categories: [1, 2, 3], data, x: "x", y: "y"};
+      const domainResultY = Domain.getDomainFromGroupedData(props, "y", data);
+      expect(Domain.getDomainFromData).calledOnce.and.returned([0, 2]);
+      expect(Domain.getCumulativeData).calledOnce;
+      expect(domainResultY).to.eql([0, 3]);
+    });
+  });
+
+  describe("getDomainFromCategories", () => {
+    it("calculates a domain from categories for the independent axis", () => {
+      const props = {categories: [1, 2, 3]};
+      const domainResult = Domain.getDomainFromCategories(props, "x");
+      expect(domainResult).to.eql([1, 3]);
+    });
+
+    it("calculates a domain from categories for the dependent axis", () => {
+      const props = {categories: {y: [ 1, 2, 3]}};
+      const domainResult = Domain.getDomainFromCategories(props, "y");
+      expect(domainResult).to.eql([1, 3]);
+    });
+
+    it("calculates a domain from string categories", () => {
+      const props = {categories: {x: ["cats", "kittens"]}};
+      const domainResult = Domain.getDomainFromCategories(props, "x");
+      expect(domainResult).to.eql([1, 2]);
+    });
+  });
+});

--- a/test/client/spec/victory-util/events.spec.js
+++ b/test/client/spec/victory-util/events.spec.js
@@ -1,9 +1,9 @@
 /* eslint no-unused-expressions: 0 */
 /* global sinon */
 
-import Events from "src/index";
+import { Events } from "src/index";
 
-describe("helpers", () => {
+describe("helpers/events", () => {
   describe("getPartialEvents", () => {
     it("returns a set of new event functions with partially applied arguments", () => {
       const events = {
@@ -47,7 +47,6 @@ describe("helpers", () => {
     it("returns new functions that call set state", () => {
       const getBoundEvents = Events.getEvents.bind(fake);
       const result = getBoundEvents(fake.props.events.data, "data");
-      expect(result).to.have.keys(["onClick"]);
       const index = 0;
       const partialEvents = Events.getPartialEvents(result, index, {});
       expect(partialEvents).to.have.keys(["onClick"]);

--- a/test/client/spec/victory-util/events.spec.js
+++ b/test/client/spec/victory-util/events.spec.js
@@ -28,12 +28,22 @@ describe("helpers/events", () => {
       sandbox = sinon.sandbox.create();
       fake = {
         props: {
-          events: {
-            data: {
-              onClick: () => { return {data: "foo"}; }
+          events: [{
+            target: "data",
+            eventHandlers: {
+              onClick: () => {
+                return {
+                  mutation: () => {
+                    return {foo: "foo"};
+                  }
+                };
+              }
             }
-          }
+          }]
         },
+        baseProps: { 0: {
+          data: {foo: "bar"}
+        }},
         setState: (x) => x,
         state: {}
       };
@@ -45,15 +55,17 @@ describe("helpers/events", () => {
     });
 
     it("returns new functions that call set state", () => {
+      const getScopedEvents = Events.getScopedEvents.bind(fake);
       const getBoundEvents = Events.getEvents.bind(fake);
-      const result = getBoundEvents(fake.props.events.data, "data");
       const index = 0;
+      const result = getBoundEvents(fake.props, "data", index, getScopedEvents);
+      expect(result).to.have.keys(["onClick"]);
       const partialEvents = Events.getPartialEvents(result, index, {});
       expect(partialEvents).to.have.keys(["onClick"]);
       partialEvents.onClick();
-      expect(fake.setState).calledWith({
+      expect(fake.setState).returned({
         [index]: {
-          data: "foo"
+          data: {foo: "foo"}
         }
       });
     });

--- a/test/client/spec/victory-util/events.spec.js
+++ b/test/client/spec/victory-util/events.spec.js
@@ -1,0 +1,62 @@
+/* eslint no-unused-expressions: 0 */
+/* global sinon */
+
+import Events from "src/index";
+
+describe("helpers", () => {
+  describe("getPartialEvents", () => {
+    it("returns a set of new event functions with partially applied arguments", () => {
+      const events = {
+        onClick: (evt, childProps, index) => {
+          return {evt, childProps, index};
+        }
+      };
+      const index = 0;
+      const childProps = {style: {fill: "green"}};
+      const result = Events.getPartialEvents(events, index, childProps);
+      expect(result).to.have.keys(["onClick"]);
+      expect(result.onClick()).to.have.keys(["evt", "childProps", "index"]);
+      expect(result.onClick().index).to.eql(index);
+      expect(result.onClick().childProps).to.eql(childProps);
+    });
+  });
+
+  describe("getEvents", () => {
+    let sandbox;
+    let fake;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      fake = {
+        props: {
+          events: {
+            data: {
+              onClick: () => { return {data: "foo"}; }
+            }
+          }
+        },
+        setState: (x) => x,
+        state: {}
+      };
+      sandbox.spy(fake, "setState");
+    });
+
+    afterEach(() => {
+      sandbox.reset();
+    });
+
+    it("returns new functions that call set state", () => {
+      const getBoundEvents = Events.getEvents.bind(fake);
+      const result = getBoundEvents(fake.props.events.data, "data");
+      expect(result).to.have.keys(["onClick"]);
+      const index = 0;
+      const partialEvents = Events.getPartialEvents(result, index, {});
+      expect(partialEvents).to.have.keys(["onClick"]);
+      partialEvents.onClick();
+      expect(fake.setState).calledWith({
+        [index]: {
+          data: "foo"
+        }
+      });
+    });
+  });
+});

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -1,5 +1,4 @@
 /* eslint no-unused-expressions: 0 */
-/* global sinon */
 
 import Helpers from "src/victory-util/helpers";
 describe("helpers", () => {

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -78,34 +78,6 @@ describe("helpers", () => {
     });
   });
 
-  describe("getStringsFromData", () => {
-    it("returns an array of strings from a data prop", () => {
-      const props = {data: [{x: "one", y: 1}, {x: "red", y: 2}, {x: "cat", y: 3}]};
-      const dataStrings = Helpers.getStringsFromData(props, "x");
-      expect(dataStrings).to.eql(["one", "red", "cat"]);
-    });
-
-    it("returns an array of strings from array-type data", () => {
-      const props = {data: [["one", 1], ["red", 2], ["cat", 3]], x: 0, y: 1};
-      const dataStrings = Helpers.getStringsFromData(props, "x");
-      expect(dataStrings).to.eql(["one", "red", "cat"]);
-    });
-
-    it("only returns strings, if data is mixed", () => {
-      const props = {data: [{x: 1, y: 1}, {x: "three", y: 3}]};
-      expect(Helpers.getStringsFromData(props, "x")).to.eql(["three"]);
-    });
-
-    it("returns an empty array when no strings are present", () => {
-      const props = {data: [{x: 1, y: 1}, {x: 3, y: 3}]};
-      expect(Helpers.getStringsFromData(props, "x")).to.eql([]);
-    });
-
-    it("returns an empty array when the data prop is undefined", () => {
-      expect(Helpers.getStringsFromData({}, "x")).to.eql([]);
-    });
-  });
-
   describe("createAccessor", () => {
     it("creates a valid object accessor from a property key", () => {
       const accessor = Helpers.createAccessor("k");
@@ -130,79 +102,17 @@ describe("helpers", () => {
     });
   });
 
-  describe("formatData", () => {
-    it("formats a single dataset", () => {
-      const dataset = [{x: 1, y: 3}, {x: 2, y: 5}];
-      const props = {};
-      const formatted = Helpers.formatData(dataset, props);
-      expect(formatted).to.be.an.array;
-      expect(formatted[0]).to.have.keys(["x", "y"]);
-    });
-  });
-
-  describe("getData", () => {
-    it("formats and returns the data prop", () => {
-      const data = [{x: "kittens", y: 3}, {x: "cats", y: 5}];
-      const props = {data, x: "x", y: "y"};
-      const expectedReturn = [{x: 1, xName: "kittens", y: 3}, {x: 2, xName: "cats", y: 5}];
-      const returnData = Helpers.getData(props);
-      expect(returnData).to.eql(expectedReturn);
-    });
-  });
-
-  describe("getPartialEvents", () => {
-    it("returns a set of new event functions with partially applied arguments", () => {
-      const events = {
-        onClick: (evt, childProps, index) => {
-          return {evt, childProps, index};
-        }
-      };
-      const index = 0;
-      const childProps = {style: {fill: "green"}};
-      const result = Helpers.getPartialEvents(events, index, childProps);
-      expect(result).to.have.keys(["onClick"]);
-      expect(result.onClick()).to.have.keys(["evt", "childProps", "index"]);
-      expect(result.onClick().index).to.eql(index);
-      expect(result.onClick().childProps).to.eql(childProps);
-    });
-  });
-
-  describe("getEvents", () => {
-    let sandbox;
-    let fake;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      fake = {
-        props: {
-          events: {
-            data: {
-              onClick: () => { return {data: "foo"}; }
-            }
-          }
-        },
-        setState: (x) => x,
-        state: {}
-      };
-      sandbox.spy(fake, "setState");
+  describe("isVertical", () => {
+    it("returns true when the orientation is vertical", () => {
+      const props = {orientation: "left"};
+      const verticalResult = Helpers.isVertical(props);
+      expect(verticalResult).to.equal(true);
     });
 
-    afterEach(() => {
-      sandbox.reset();
-    });
-
-    it("returns new functions that call set state", () => {
-      const getBoundEvents = Helpers.getEvents.bind(fake);
-      const result = getBoundEvents(fake.props.events.data, "data");
-      expect(result).to.have.keys(["onClick"]);
-      const index = 0;
-      const partialEvents = Helpers.getPartialEvents(result, index, {});
-      expect(partialEvents).to.have.keys(["onClick"]);
-      partialEvents.onClick();
-      expect(fake.setState).calledWith({
-        [index]: {
-          data: "foo"
-        }
-      });
+    it("returns false when the orientation is horizontal", () => {
+      const props = {orientation: "bottom"};
+      const verticalResult = Helpers.isVertical(props);
+      expect(verticalResult).to.equal(false);
     });
   });
 });

--- a/test/client/spec/victory-util/scale.spec.js
+++ b/test/client/spec/victory-util/scale.spec.js
@@ -1,0 +1,179 @@
+/* eslint no-unused-expressions: 0 */
+/* global sinon */
+
+import { Scale } from "src/index";
+import * as d3Scale from "d3-scale";
+
+describe("helpers/scale", () => {
+  describe("getBaseScale", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Scale, "getScaleFromProps");
+      sandbox.spy(Scale, "getScaleTypeFromData");
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns a scale from `getScaleFromProps` when string props are provided", () => {
+      const props = {scale: "log"};
+      const baseScale = Scale.getBaseScale(props, "x");
+      expect(Scale.getScaleFromProps).to.be.calledOnce;
+      expect(Scale.getScaleTypeFromData).not.to.be.called;
+      expect(baseScale).to.be.a.function;
+      expect(baseScale.base).to.be.a.function; // This is a unique check for log scales
+    });
+
+    it("returns a scale from `getScaleFromProps` when a d3 scale is provided", () => {
+      const props = {scale: d3Scale.scaleLog()};
+      const baseScale = Scale.getBaseScale(props, "x");
+      expect(Scale.getScaleFromProps).to.be.calledOnce;
+      expect(Scale.getScaleTypeFromData).not.to.be.called;
+      expect(baseScale).to.be.a.function;
+      expect(baseScale.base).to.be.a.function; // This is a unique check for log scales
+    });
+
+    it("returns a default scale when data is provided", () => {
+      const props = {data: [{x: 0, y: 1}]};
+      const baseScale = Scale.getBaseScale(props, "x");
+      expect(Scale.getScaleFromProps).to.be.calledOnce;
+      expect(Scale.getScaleTypeFromData).to.be.calledOnce;
+      expect(baseScale).to.be.a.function;
+      expect(baseScale.domain).to.be.a.function;
+    });
+
+    it("returns a default scale when nothing is provided", () => {
+      const baseScale = Scale.getBaseScale({}, "x");
+      expect(Scale.getScaleFromProps).to.be.calledOnce;
+      expect(Scale.getScaleTypeFromData).to.be.calledOnce;
+      expect(baseScale).to.be.a.function;
+      expect(baseScale.domain).to.be.a.function;
+    });
+  });
+
+  describe("getScaleFromProps", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Scale, "isScaleDefined");
+      sandbox.spy(Scale, "validScale");
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns a scale when a single scale is provided in props", () => {
+      const props = {scale: "log"};
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(Scale.isScaleDefined).calledWith(props, "x").and.returned(true);
+      expect(propsScale).to.be.a.function;
+      expect(propsScale.base).to.be.a.function; // This is a unique check for log scales
+    });
+
+    it("returns a scale when a scale object contains a scale for an axis", () => {
+      const props = {scale: {x: "log"}};
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(Scale.isScaleDefined).calledWith(props, "x").and.returned(true);
+      expect(propsScale).to.be.a.function;
+      expect(propsScale.base).to.be.a.function; // This is a unique check for log scales
+    });
+
+    it("returns undefined when a scale object does not contain a scale for an axis", () => {
+      const props = {scale: {y: "log"}};
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(Scale.isScaleDefined).calledWith(props, "x").and.returned(false);
+      expect(propsScale).to.be.undefined;
+    });
+
+    it("returns undefined when an invalid scale is provided in props", () => {
+      const props = {scale: "foo"};
+      const propsScale = Scale.getScaleFromProps(props, "x");
+      expect(Scale.isScaleDefined).calledWith(props, "x").and.returned(true);
+      expect(Scale.validScale).calledWith(props.scale).and.returned(false);
+      expect(propsScale).to.be.undefined;
+    });
+
+    it("returns undefined when no scale prop is provided", () => {
+      const propsScale = Scale.getScaleFromProps({}, "x");
+      expect(Scale.isScaleDefined).calledWith({}, "x").and.returned(false);
+      expect(propsScale).to.be.undefined;
+    });
+  });
+
+  describe("getScaleType", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Scale, "getScaleTypeFromProps");
+      sandbox.spy(Scale, "getScaleTypeFromData");
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns 'log' for log scales", () => {
+      const props = {scale: {x: d3Scale.scaleLog()}};
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned("log");
+      expect(Scale.getScaleTypeFromData).not.called;
+      expect(scaleType).to.equal("log");
+    });
+
+    it("returns a string value given a string prop", () => {
+      const props = {scale: {x: "linear"}};
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(props.scale.x);
+      expect(Scale.getScaleTypeFromData).not.called;
+      expect(scaleType).to.equal("linear");
+    });
+
+    it("uses data to distinguish between time and linear scales", () => {
+      const props = {scale: {x: d3Scale.scaleLinear()}};
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(undefined);
+      expect(Scale.getScaleTypeFromData).calledWith(props, "x").and.returned("linear");
+      expect(scaleType).to.equal("linear");
+    });
+
+    it("returns 'linear' when no scale is set", () => {
+      const props = {};
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(undefined);
+      expect(Scale.getScaleTypeFromData).calledWith(props, "x").and.returned("linear");
+      expect(scaleType).to.equal("linear");
+    });
+
+    it("returns 'time' when no scale is set, and data contains dates", () => {
+      const props = {x: "x", y: "y", data: [{x: new Date("2016-01-13"), y: 1}]};
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(undefined);
+      expect(Scale.getScaleTypeFromData).calledWith(props, "x").and.returned("time");
+      expect(scaleType).to.equal("time");
+    });
+  });
+
+  describe("validScale", () => {
+    it("returns true for valid scale functions", () => {
+      expect(Scale.validScale(d3Scale.scaleLog())).to.equal(true);
+    });
+
+    it("returns true for strings corresponding to valid scales", () => {
+      expect(Scale.validScale("linear")).to.equal(true);
+    });
+
+    it("returns false for non-scale functions", () => {
+      const badFunction = () => {
+        return {
+          domain: "foo",
+          range: () => "bar"
+        };
+      };
+      expect(Scale.validScale(badFunction)).to.equal(false);
+    });
+
+    it("returns false for strings that dont correspond to scales", () => {
+      expect(Scale.validScale("foo")).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
_merge after #146 and #147_

This PR adds an `addEvents` II HOC to extract shared events logic from Victory components
This PR also moves domain, scale, and data helpers to from victory-chart to victory-core for future components to use _i.e._ victory-force by @nfcampos 
