### PR TITLE
fix(VictoryLabel): apply dx to every tspan

### DIFF
--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -157,7 +157,7 @@ export default class VictoryLabel extends React.Component {
         {content.map((line, i) => {
           const dy = i ? props.lineHeight * fontSize : undefined;
           return (
-            <tspan key={i} x={props.x} dy={dy}>
+            <tspan key={i} x={props.x} dy={dy} dx={props.dx}>
               {line}
             </tspan>
           );


### PR DESCRIPTION
In case of multiline text, `dx` is applied to only the first `tspan` element, causing the text alignment to break.

e.g.
![screen shot 2016-10-18 at 12 17 18](https://cloud.githubusercontent.com/assets/2387240/19475604/ec366d7a-952c-11e6-99ba-779ce5f7ee37.png)
