### PR TITLE
Transitions

### DIFF
--- a/src/victory-animation/victory-animation.js
+++ b/src/victory-animation/victory-animation.js
@@ -61,6 +61,7 @@ export default class VictoryAnimation extends React.Component {
       so we bind functionToBeRunEachFrame to current instance of victory animation class
     */
     this.functionToBeRunEachFrame = this.functionToBeRunEachFrame.bind(this);
+    this.getTimer = this.getTimer.bind(this);
   }
 
   getTimer() {
@@ -74,7 +75,6 @@ export default class VictoryAnimation extends React.Component {
   }
 
   componentDidMount() {
-    this.timer = this.getTimer();
     // Length check prevents us from triggering `onEnd` in `traverseQueue`.
     if (this.queue.length) {
       this.traverseQueue();
@@ -84,7 +84,7 @@ export default class VictoryAnimation extends React.Component {
   /* lifecycle */
   componentWillReceiveProps(nextProps) {
     /* cancel existing loop if it exists */
-    this.timer.unsubscribe(this.loopID);
+    this.getTimer().unsubscribe(this.loopID);
 
     /* If an object was supplied */
     if (!Array.isArray(nextProps.data)) {
@@ -103,9 +103,9 @@ export default class VictoryAnimation extends React.Component {
 
   componentWillUnmount() {
     if (this.loopID) {
-      this.timer.unsubscribe(this.loopID);
+      this.getTimer().unsubscribe(this.loopID);
     } else {
-      this.timer.stop();
+      this.getTimer().stop();
     }
   }
 
@@ -125,12 +125,12 @@ export default class VictoryAnimation extends React.Component {
       /* reset step to zero */
       if (this.props.delay) {
         setTimeout(() => { // eslint-disable-line no-undef
-          this.loopID = this.timer.subscribe(
+          this.loopID = this.getTimer().subscribe(
             this.functionToBeRunEachFrame, this.props.duration
           );
         }, this.props.delay);
       } else {
-        this.loopID = this.timer.subscribe(
+        this.loopID = this.getTimer().subscribe(
           this.functionToBeRunEachFrame, this.props.duration
         );
       }
@@ -155,7 +155,7 @@ export default class VictoryAnimation extends React.Component {
         }
       });
       if (this.loopID) {
-        this.timer.unsubscribe(this.loopID);
+        this.getTimer().unsubscribe(this.loopID);
       }
       this.queue.shift();
       this.traverseQueue();

--- a/src/victory-animation/victory-animation.js
+++ b/src/victory-animation/victory-animation.js
@@ -135,12 +135,13 @@ export default class VictoryAnimation extends React.Component {
     }
   }
   /* every frame we... */
-  functionToBeRunEachFrame(elapsed) {
+  functionToBeRunEachFrame(elapsed, duration) {
     /*
       step can generate imprecise values, sometimes greater than 1
       if this happens set the state to 1 and return, cancelling the timer
     */
-    const step = elapsed / this.props.duration;
+    duration = duration !== undefined ? duration : this.props.duration;
+    const step = duration ? elapsed / duration : 1;
 
     if (step >= 1) {
       this.setState({

--- a/src/victory-primitives/clip-path.js
+++ b/src/victory-primitives/clip-path.js
@@ -63,8 +63,8 @@ export default class ClipPath extends React.Component {
     const clipProps = {
       x: totalPadding("left") + translateX,
       y: totalPadding("top"),
-      width: clipWidth - totalPadding("left") - totalPadding("right"),
-      height: clipHeight - totalPadding("top") - totalPadding("bottom")
+      width: Math.max(clipWidth - totalPadding("left") - totalPadding("right"), 0),
+      height: Math.max(clipHeight - totalPadding("top") - totalPadding("bottom"), 0)
     };
 
     return this.renderClipPath(clipProps, clipId);

--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -16,8 +16,7 @@ export default class VictoryTransition extends React.Component {
     super(props);
     this.state = {
       nodesShouldLoad: false,
-      nodesDoneLoad: false,
-      animating: false
+      nodesDoneLoad: false
     };
     const child = this.props.children;
     this.continuous = child.type && child.type.continuous === true;
@@ -65,15 +64,13 @@ export default class VictoryTransition extends React.Component {
         nodesWillExit,
         nodesWillEnter,
         childrenTransitions,
-        nodesShouldEnter,
-        animating
+        nodesShouldEnter
       } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
       return {
         nodesWillExit,
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter,
-        animating: animating || this.state.animating,
         oldProps: nodesWillExit ? props : null,
         nextProps
       };

--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -59,12 +59,11 @@ export default class VictoryTransition extends React.Component {
 
   animateState(state, forceLoad) {
     const {
-      nodesWillExit, nodesWillEnter, nodesShouldEnter, nodesShouldLoad, nodesDoneLoad,
-      nodesDoneClipPathLoad, nodesDoneClipPathEnter, nodesDoneClipPathExit, animating
+      nodesWillExit, nodesWillEnter, nodesShouldEnter, nodesShouldLoad, nodesDoneLoad, animating
     } = state;
-    const loading = forceLoad || !nodesDoneLoad && (!!nodesShouldLoad || nodesDoneClipPathLoad);
-    const entering = nodesShouldEnter || nodesWillEnter || nodesDoneClipPathEnter;
-    const exiting = nodesWillExit || nodesDoneClipPathExit;
+    const loading = forceLoad || !nodesDoneLoad && !!nodesShouldLoad;
+    const entering = nodesShouldEnter || nodesWillEnter;
+    const exiting = nodesWillExit;
     return (animating || this.state.animating) && (loading || entering || exiting);
   }
 
@@ -106,11 +105,9 @@ export default class VictoryTransition extends React.Component {
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter,
-        nodesDoneClipPathEnter,
-        nodesDoneClipPathExit,
         animating
       } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
-      const transitionState = {
+      return {
         nodesWillExit,
         nodesWillEnter,
         childrenTransitions,
@@ -119,13 +116,6 @@ export default class VictoryTransition extends React.Component {
         oldProps: nodesWillExit ? props : null,
         nextProps
       };
-      return this.continuous ? assign(
-        {
-          nodesDoneClipPathEnter,
-          nodesDoneClipPathExit
-        },
-        transitionState
-      ) : transitionState;
     }
   }
 
@@ -162,7 +152,6 @@ export default class VictoryTransition extends React.Component {
   pickDomainProps(props) {
     const parentState = props.animate && props.animate.parentState;
     if (parentState && parentState.nodesWillExit) {
-      console.log(this.continuous, parentState.continuous)
       return this.continous || parentState.continuous ?
         parentState.nextProps || this.state.nextProps || props : props;
     }

--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -1,6 +1,6 @@
 import React from "react";
 import VictoryAnimation from "../victory-animation/victory-animation";
-import { Transitions, Collection } from "../victory-util/index";
+import { Transitions, Collection, Timer } from "../victory-util/index";
 import { defaults, isFunction, pick } from "lodash";
 
 export default class VictoryTransition extends React.Component {
@@ -22,14 +22,32 @@ export default class VictoryTransition extends React.Component {
     const child = this.props.children;
     this.continuous = child.type && child.type.continuous === true;
     this.getTransitionState = this.getTransitionState.bind(this);
+    this.getTimer = this.getTimer.bind(this);
+  }
+
+  getTimer() {
+    if (this.context.getTimer) {
+      return this.context.getTimer();
+    }
+    if (!this.timer) {
+      this.timer = new Timer();
+    }
+    return this.timer;
   }
 
   componentDidMount() {
     this.setState({nodesShouldLoad: true}); //eslint-disable-line react/no-did-mount-set-state
   }
 
+  componentWillUnmount() {
+    this.getTimer().stop();
+  }
+
   componentWillReceiveProps(nextProps) {
-    this.setState(this.getTransitionState(this.props, nextProps));
+    this.getTimer().bypassAnimation();
+    this.setState(
+      this.getTransitionState(this.props, nextProps), () => this.getTimer().resumeAnimation()
+    );
   }
 
   getTransitionState(props, nextProps) {

--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -1,7 +1,7 @@
 import React from "react";
 import VictoryAnimation from "../victory-animation/victory-animation";
 import { Transitions, Collection } from "../victory-util/index";
-import { assign, defaults, isFunction, pick, identity, isEqual } from "lodash";
+import { defaults, isFunction, pick, identity, isEqual } from "lodash";
 
 export default class VictoryTransition extends React.Component {
   static displayName = "VictoryTransition";
@@ -15,6 +15,8 @@ export default class VictoryTransition extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      nodesShouldLoad: false,
+      nodesDoneLoad: false,
       animating: true
     };
     const child = this.props.children;
@@ -74,6 +76,7 @@ export default class VictoryTransition extends React.Component {
       return true;
     }
     return false;
+    // return true;
   }
 
   componentWillUpdate(nextProps, nextState) {
@@ -105,6 +108,7 @@ export default class VictoryTransition extends React.Component {
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter,
+        nodesDoneLoad,
         animating
       } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
       return {
@@ -112,6 +116,7 @@ export default class VictoryTransition extends React.Component {
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter,
+        nodesDoneLoad,
         animating: animating || this.state.animating,
         oldProps: nodesWillExit ? props : null,
         nextProps
@@ -162,9 +167,10 @@ export default class VictoryTransition extends React.Component {
     if (!this.continuous) {
       return {};
     }
+    const clipWidth = this.transitionProps && this.transitionProps.clipWidth;
     return {
       clipHeight: child.props.height,
-      clipWidth: child.props.width
+      clipWidth: clipWidth !== undefined ? clipWidth : child.props.width
     };
   }
 

--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -17,7 +17,7 @@ export default class VictoryTransition extends React.Component {
     this.state = {
       nodesShouldLoad: false,
       nodesDoneLoad: false,
-      animating: true
+      animating: false
     };
     const child = this.props.children;
     this.continuous = child.type && child.type.continuous === true;
@@ -70,26 +70,13 @@ export default class VictoryTransition extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    if (this.shouldAnimateState(nextProps, nextState)) {
-      return true;
-    } else if (this.shouldAnimateProps(nextProps)) {
-      return true;
-    }
-    return false;
-    // return true;
-  }
-
-  componentWillUpdate(nextProps, nextState) {
-    if (nextState.animating !== this.state.animating && nextState.animating === false) {
-      const onEnd = nextProps && nextProps.animate && nextProps.animate.onEnd || identity;
-      onEnd();
-    }
-  }
-
-  componentDidMount() {
-    if (this.transitionProps && this.transitionProps.cb) {
-      this.transitionProps.cb();
-    }
+    // if (this.shouldAnimateState(nextProps, nextState)) {
+    //   return true;
+    // } else if (this.shouldAnimateProps(nextProps)) {
+    //   return true;
+    // }
+    // return false;
+    return true;
   }
 
   getTransitionState(props, nextProps) {
@@ -108,6 +95,7 @@ export default class VictoryTransition extends React.Component {
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter,
+        nodesShouldLoad,
         nodesDoneLoad,
         animating
       } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
@@ -116,6 +104,7 @@ export default class VictoryTransition extends React.Component {
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter,
+        nodesShouldLoad,
         nodesDoneLoad,
         animating: animating || this.state.animating,
         oldProps: nodesWillExit ? props : null,
@@ -175,6 +164,7 @@ export default class VictoryTransition extends React.Component {
   }
 
   render() {
+    console.log(this.state.nodesShouldLoad, this.state.nodesDoneLoad)
     const props = this.pickProps();
     const getTransitionProps = this.props.animate && this.props.animate.getTransitions ?
       this.props.animate.getTransitions :

--- a/src/victory-util/default-transitions.js
+++ b/src/victory-util/default-transitions.js
@@ -2,7 +2,7 @@
 export function continuousTransitions() {
   return {
     onLoad: {
-      duration: 500
+      duration: 2000
     },
     onExit: {
       duration: 500

--- a/src/victory-util/default-transitions.js
+++ b/src/victory-util/default-transitions.js
@@ -1,75 +1,14 @@
 /* eslint-disable func-style */
-import { filter, max, min, sum } from "lodash";
-import Helpers from "./helpers";
-import Log from "./log";
-
 export function continuousTransitions() {
   return {
     onLoad: {
-      duration: 2000,
-      entrance: "left",
-      beforeClipPathWidth: (data, child, animate) => {
-        // const range = Helpers.getRange(child.props, "x");
-        // const paddingLeft = range[0];
-        // const paddingRight = child.props.width - range[1]; // eslint-disable-line max-len
-        // if (animate.onLoad.entrance === "left") {
-        //   return {
-        //     clipWidth: paddingLeft + paddingRight
-        //   };
-        // } else if (animate.onLoad.entrance === "right") {
-        //   return {
-        //     clipWidth: paddingLeft + paddingRight,
-        //     translateX: child.props.width - paddingLeft - paddingRight
-        //   };
-        // } else {
-        //   Log.warn("onLoad entrance should be one of left or right");
-        //   return {};
-        // }
-      },
-      afterClipPathWidth: (data, child, animate) => {
-      //   const range = Helpers.getRange(child.props, "x");
-      //   if (animate.onLoad.entrance === "left") {
-      //     return {
-      //       clipWidth: sum(range)
-      //     };
-      //   } else if (animate.onLoad.entrance === "right") {
-      //     return {
-      //       clipWidth: sum(range),
-      //       translateX: 0
-      //     };
-      //   } else {
-      //     Log.warn("onLoad entrance should be one of left or right");
-      //     return {};
-      //   }
-      }
+      duration: 2000
     },
     onExit: {
-      duration: 500,
-      beforeClipPathWidth: (data, child, exitingNodes) => {
-        const xVals = data.map((datum) => {
-          return child.type.getScale(child.props).x(datum.x);
-        });
-        const clipPath = min(xVals) + max(xVals);
-        return clipPath;
-      }
+      duration: 500
     },
     onEnter: {
-      duration: 500,
-      beforeClipPathWidth: (data, child) => {
-        const xVals = data.map((datum) => {
-          return child.type.getScale(child.props).x(datum.x);
-        });
-        const clipPath = min(xVals) + max(xVals);
-        return clipPath;
-
-      },
-      afterClipPathWidth: (data, child) => {
-        const xVals = data.map((datum) => {
-          return child.type.getScale(child.props).x(datum.x);
-        });
-        const clipPath = min(xVals) + max(xVals);
-        return clipPath;
-      }
+      duration: 500
     }
   };
 }

--- a/src/victory-util/default-transitions.js
+++ b/src/victory-util/default-transitions.js
@@ -9,45 +9,44 @@ export function continuousTransitions() {
       duration: 2000,
       entrance: "left",
       beforeClipPathWidth: (data, child, animate) => {
-        const range = Helpers.getRange(child.props, "x");
-        const paddingLeft = range[0];
-        const paddingRight = child.props.width - range[1]; // eslint-disable-line max-len
-        if (animate.onLoad.entrance === "left") {
-          return {
-            clipWidth: paddingLeft + paddingRight
-          };
-        } else if (animate.onLoad.entrance === "right") {
-          return {
-            clipWidth: paddingLeft + paddingRight,
-            translateX: child.props.width - paddingLeft - paddingRight
-          };
-        } else {
-          Log.warn("onLoad entrance should be one of left or right");
-          return {};
-        }
+        // const range = Helpers.getRange(child.props, "x");
+        // const paddingLeft = range[0];
+        // const paddingRight = child.props.width - range[1]; // eslint-disable-line max-len
+        // if (animate.onLoad.entrance === "left") {
+        //   return {
+        //     clipWidth: paddingLeft + paddingRight
+        //   };
+        // } else if (animate.onLoad.entrance === "right") {
+        //   return {
+        //     clipWidth: paddingLeft + paddingRight,
+        //     translateX: child.props.width - paddingLeft - paddingRight
+        //   };
+        // } else {
+        //   Log.warn("onLoad entrance should be one of left or right");
+        //   return {};
+        // }
       },
       afterClipPathWidth: (data, child, animate) => {
-        const range = Helpers.getRange(child.props, "x");
-        if (animate.onLoad.entrance === "left") {
-          return {
-            clipWidth: sum(range)
-          };
-        } else if (animate.onLoad.entrance === "right") {
-          return {
-            clipWidth: sum(range),
-            translateX: 0
-          };
-        } else {
-          Log.warn("onLoad entrance should be one of left or right");
-          return {};
-        }
+      //   const range = Helpers.getRange(child.props, "x");
+      //   if (animate.onLoad.entrance === "left") {
+      //     return {
+      //       clipWidth: sum(range)
+      //     };
+      //   } else if (animate.onLoad.entrance === "right") {
+      //     return {
+      //       clipWidth: sum(range),
+      //       translateX: 0
+      //     };
+      //   } else {
+      //     Log.warn("onLoad entrance should be one of left or right");
+      //     return {};
+      //   }
       }
     },
     onExit: {
       duration: 500,
       beforeClipPathWidth: (data, child, exitingNodes) => {
-        const filterExit = filter(data, (datum, index) => !exitingNodes[index]);
-        const xVals = filterExit.map((datum) => {
+        const xVals = data.map((datum) => {
           return child.type.getScale(child.props).x(datum.x);
         });
         const clipPath = min(xVals) + max(xVals);
@@ -56,9 +55,8 @@ export function continuousTransitions() {
     },
     onEnter: {
       duration: 500,
-      beforeClipPathWidth: (data, child, enteringNodes) => {
-        const filterEnter = filter(data, (datum, index) => !enteringNodes[index]);
-        const xVals = filterEnter.map((datum) => {
+      beforeClipPathWidth: (data, child) => {
+        const xVals = data.map((datum) => {
           return child.type.getScale(child.props).x(datum.x);
         });
         const clipPath = min(xVals) + max(xVals);

--- a/src/victory-util/default-transitions.js
+++ b/src/victory-util/default-transitions.js
@@ -2,7 +2,7 @@
 export function continuousTransitions() {
   return {
     onLoad: {
-      duration: 2000
+      duration: 500
     },
     onExit: {
       duration: 500

--- a/src/victory-util/timer.js
+++ b/src/victory-util/timer.js
@@ -18,7 +18,7 @@ export default class Timer {
 
   loop() {
     this.subscribers.forEach((s) => {
-      s.callback(now() - s.startTime);
+      s.callback(now() - s.startTime, s.duration);
     });
   }
 
@@ -31,16 +31,12 @@ export default class Timer {
   }
 
   subscribe(callback, duration) {
-    if (this.shouldAnimate) {
-      return this.subscribers.push({
-        startTime: now(),
-        callback,
-        duration
-      });
-    }
-
-    callback(duration);
-    return null;
+    duration = this.shouldAnimate ? duration : 0;
+    return this.subscribers.push({
+      startTime: now(),
+      callback,
+      duration
+    });
   }
 
   unsubscribe(id) {

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -119,8 +119,6 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
     //       for new nodes. In this case, we wouldn't want a delay before
     //       the new nodes appear.
     nodesShouldEnter: false,
-    nodesShouldLoad: true,
-    nodesDoneLoad: false,
     animating: nodesWillExit || nodesWillEnter || childrenTransitions.length > 0
   };
 }
@@ -254,12 +252,12 @@ export function getTransitionPropsFactory(props, state, setState) {
   const onLoad = (child, data, animate) => {
     if (nodesShouldLoad) {
       return getChildOnLoad(animate, data, () => {
-        setState({ nodesDoneLoad: true, animating: false});
+        setState({ nodesShouldLoad: false, nodesDoneLoad: true, animating: false});
       });
     }
 
     return getChildBeforeLoad(animate, child, data, () => {
-      setState({ nodesShouldLoad: true, nodesDoneLoad: true });
+      setState({ nodesDoneLoad: true });
     });
   };
 

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -385,7 +385,8 @@ export function getTransitionPropsFactory(props, state, setState) {
     );
 
     const childTransitions = childrenTransitions[index] || childrenTransitions[0];
-    if (!nodesDoneLoad) {
+    // if (!nodesDoneLoad) {
+    if (false) {
       // should do onLoad animation
       const load = transitionDurations.load !== undefined ?
         transitionDurations.load : getChildTransitionDuration(child, "onLoad");

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -118,8 +118,7 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
     //       is a perfect match for the previous data and domain except
     //       for new nodes. In this case, we wouldn't want a delay before
     //       the new nodes appear.
-    nodesShouldEnter: false,
-    animating: nodesWillExit || nodesWillEnter || childrenTransitions.length > 0
+    nodesShouldEnter: false
   };
 }
 
@@ -252,7 +251,7 @@ export function getTransitionPropsFactory(props, state, setState) {
   const onLoad = (child, data, animate) => {
     if (nodesShouldLoad) {
       return getChildOnLoad(animate, data, () => {
-        setState({ nodesShouldLoad: false, nodesDoneLoad: true, animating: false});
+        setState({ nodesShouldLoad: false, nodesDoneLoad: true});
       });
     }
 
@@ -263,14 +262,14 @@ export function getTransitionPropsFactory(props, state, setState) {
 
   const onExit = (nodes, child, data, animate) => { // eslint-disable-line max-params
     return getChildPropsOnExit(animate, child, data, nodes, () => {
-      setState({ nodesWillExit: false, animating: false });
+      setState({ nodesWillExit: false });
     });
   };
 
   const onEnter = (nodes, child, data, animate) => { // eslint-disable-line max-params
     if (nodesShouldEnter) {
       return getChildPropsOnEnter(animate, data, nodes, () => {
-        setState({ nodesWillEnter: false, animating: false });
+        setState({ nodesWillEnter: false });
       });
     }
 
@@ -339,8 +338,6 @@ export function getTransitionPropsFactory(props, state, setState) {
       //
       return getInitialChildProps(animate, data);
     }
-
-    animate.onEnd = () => { setState({ animating: false }); };
     return { animate, data };
   };
 }

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -119,7 +119,7 @@ export function getInitialTransitionState(oldChildren, nextChildren) {
     //       for new nodes. In this case, we wouldn't want a delay before
     //       the new nodes appear.
     nodesShouldEnter: false,
-    nodesShouldLoad: false,
+    nodesShouldLoad: true,
     nodesDoneLoad: false,
     animating: nodesWillExit || nodesWillEnter || childrenTransitions.length > 0
   };
@@ -133,17 +133,24 @@ function getInitialChildProps(animate, data) {
 }
 
 function getChildBeforeLoad(animate, child, data, cb) { // eslint-disable-line max-params
+  animate = assign({}, animate, { onEnd: cb });
+  if (animate && animate.onLoad && !animate.onLoad.duration) {
+    return { animate, data };
+  }
   const before = animate.onLoad && animate.onLoad.before ? animate.onLoad.before : identity;
   // If nodes need to exit, transform them with the provided onLoad.before function.
   data = data.map((datum) => {
     return assign({}, datum, before(datum));
   });
 
-  return { animate, data, cb, clipWidth: 0};
+  return { animate, data, clipWidth: 0};
 }
 
 function getChildOnLoad(animate, data, cb) { // eslint-disable-line max-params
   animate = assign({}, animate, { onEnd: cb });
+  if (animate && animate.onLoad && !animate.onLoad.duration) {
+    return { animate, data };
+  }
   const after = animate.onLoad && animate.onLoad.after ? animate.onLoad.after : identity;
   // If nodes need to exit, transform them with the provided onLoad.after function.
   data = data.map((datum) => {
@@ -252,7 +259,7 @@ export function getTransitionPropsFactory(props, state, setState) {
     }
 
     return getChildBeforeLoad(animate, child, data, () => {
-      setState({ nodesShouldLoad: true });
+      setState({ nodesShouldLoad: true, nodesDoneLoad: true });
     });
   };
 

--- a/test/client/spec/victory-util/transitions.spec.js
+++ b/test/client/spec/victory-util/transitions.spec.js
@@ -15,11 +15,6 @@ describe("getInitialTransitionState", () => {
       nodesWillExit: false,
       nodesWillEnter: false,
       nodesShouldEnter: false,
-      nodesDoneClipPathEnter: false,
-      nodesDoneClipPathExit: false,
-      nodesShouldLoad: false,
-      nodesDoneClipPathLoad: false,
-      nodesDoneLoad: false,
       animating: false
     });
   });
@@ -32,11 +27,6 @@ describe("getInitialTransitionState", () => {
       nodesWillExit: false,
       nodesWillEnter: false,
       nodesShouldEnter: false,
-      nodesDoneClipPathEnter: false,
-      nodesDoneClipPathExit: false,
-      nodesShouldLoad: false,
-      nodesDoneClipPathLoad: false,
-      nodesDoneLoad: false,
       animating: true
     });
   });
@@ -50,11 +40,6 @@ describe("getInitialTransitionState", () => {
       nodesWillExit: true,
       nodesWillEnter: false,
       nodesShouldEnter: false,
-      nodesDoneClipPathEnter: false,
-      nodesDoneClipPathExit: false,
-      nodesShouldLoad: false,
-      nodesDoneClipPathLoad: false,
-      nodesDoneLoad: false,
       animating: true
     });
   });
@@ -68,11 +53,6 @@ describe("getInitialTransitionState", () => {
       nodesWillExit: false,
       nodesWillEnter: true,
       nodesShouldEnter: false,
-      nodesDoneClipPathEnter: false,
-      nodesDoneClipPathExit: false,
-      nodesShouldLoad: false,
-      nodesDoneClipPathLoad: false,
-      nodesDoneLoad: false,
       animating: true
     });
   });
@@ -100,10 +80,7 @@ describe("getTransitionPropsFactory", () => {
       nodesWillExit: true,
       nodesWillEnter: false,
       nodesShouldEnter: false,
-      nodesDoneClipPathEnter: false,
-      nodesDoneClipPathExit: true,
       nodesShouldLoad: true,
-      nodesDoneClipPathLoad: true,
       nodesDoneLoad: true,
       animating: false
     };
@@ -123,10 +100,7 @@ describe("getTransitionPropsFactory", () => {
       nodesWillExit: false,
       nodesWillEnter: true,
       nodesShouldEnter: false,
-      nodesDoneClipPathEnter: false,
-      nodesDoneClipPathExit: false,
       nodesShouldLoad: true,
-      nodesDoneClipPathLoad: true,
       nodesDoneLoad: true,
       animating: false
     };

--- a/test/client/spec/victory-util/transitions.spec.js
+++ b/test/client/spec/victory-util/transitions.spec.js
@@ -14,8 +14,7 @@ describe("getInitialTransitionState", () => {
       childrenTransitions: [],
       nodesWillExit: false,
       nodesWillEnter: false,
-      nodesShouldEnter: false,
-      animating: false
+      nodesShouldEnter: false
     });
   });
 
@@ -26,8 +25,7 @@ describe("getInitialTransitionState", () => {
       childrenTransitions: [{entering: false, exiting: false}],
       nodesWillExit: false,
       nodesWillEnter: false,
-      nodesShouldEnter: false,
-      animating: true
+      nodesShouldEnter: false
     });
   });
 
@@ -39,8 +37,7 @@ describe("getInitialTransitionState", () => {
       childrenTransitions: [{entering: false, exiting: {1: true}}],
       nodesWillExit: true,
       nodesWillEnter: false,
-      nodesShouldEnter: false,
-      animating: true
+      nodesShouldEnter: false
     });
   });
 
@@ -52,8 +49,7 @@ describe("getInitialTransitionState", () => {
       childrenTransitions: [{entering: {1: true}, exiting: false}],
       nodesWillExit: false,
       nodesWillEnter: true,
-      nodesShouldEnter: false,
-      animating: true
+      nodesShouldEnter: false
     });
   });
 });
@@ -81,8 +77,7 @@ describe("getTransitionPropsFactory", () => {
       nodesWillEnter: false,
       nodesShouldEnter: false,
       nodesShouldLoad: true,
-      nodesDoneLoad: true,
-      animating: false
+      nodesDoneLoad: true
     };
     const result = Transitions.getTransitionPropsFactory({}, exitingState, callback);
     const child = makeChild([{x: 1, y: 1}, {x: 2, y: 3}]);
@@ -101,8 +96,7 @@ describe("getTransitionPropsFactory", () => {
       nodesWillEnter: true,
       nodesShouldEnter: false,
       nodesShouldLoad: true,
-      nodesDoneLoad: true,
-      animating: false
+      nodesDoneLoad: true
     };
     const result = Transitions.getTransitionPropsFactory({}, enteringState, callback);
     const child = makeChild([{x: 1, y: 1}, {x: 2, y: 3}]);


### PR DESCRIPTION
cc/ @kenwheeler 

I removed all the shouldComponentUpdate stuff in addition to what we had changed, and the animating components are rendering continuously again.  I'd really like to get rid of that because it's expensive. I think this rendering nonsense will prevent the bypass / resume animation stuff we want to add too.

Works with https://github.com/FormidableLabs/victory-chart/pull/415