### PR TITLE
guard for numeric values in clip-path

### DIFF
--- a/src/victory-primitives/clip-path.js
+++ b/src/victory-primitives/clip-path.js
@@ -60,14 +60,17 @@ export default class ClipPath extends React.Component {
 
     const padding = Helpers.getPadding(this.props);
 
-    const totalPadding = (side) => padding[side] - (clipPadding[side] || 0);
+    const totalPadding = (side) => {
+      const total = +padding[side] - (clipPadding[side] || 0);
+      return typeof total === "number" ? total : 0;
+    };
 
     const clipProps = {
       className,
       x: totalPadding("left") + translateX,
       y: totalPadding("top"),
-      width: Math.max(clipWidth - totalPadding("left") - totalPadding("right"), 0),
-      height: Math.max(clipHeight - totalPadding("top") - totalPadding("bottom"), 0)
+      width: Math.max(+clipWidth - totalPadding("left") - totalPadding("right"), 0),
+      height: Math.max(+clipHeight - totalPadding("top") - totalPadding("bottom"), 0)
     };
 
     return this.renderClipPath(clipProps, clipId);


### PR DESCRIPTION
This PR adds a guard for numeric values for `<rect>` attrs in the `ClipPath` component. This should fix https://github.com/FormidableLabs/victory/issues/452 associated errors