### PR TITLE
Container events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,5 +13,5 @@ export {
 } from "./victory-primitives/index";
 export {
   addEvents, Collection, Data, DefaultTransitions, Domain, Events, Helpers, Log,
-  PropTypes, Scale, Style, TextSize, Timer, Transitions
+  PropTypes, Scale, Style, TextSize, Timer, Transitions, Selection
 } from "./victory-util/index";

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import { assign, omit } from "lodash";
 import Portal from "../victory-portal/portal";
-import { Timer } from "../victory-util";
+import { Timer } from "../victory-util/index";
 
 export default class VictoryContainer extends React.Component {
   static displayName = "VictoryContainer";

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -13,6 +13,7 @@ export default class VictoryLabel extends React.Component {
   static displayName = "VictoryLabel";
 
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     angle: PropTypes.oneOfType([
       PropTypes.string,
@@ -82,19 +83,19 @@ export default class VictoryLabel extends React.Component {
   getStyles(props) {
     const style = props.style ? merge({}, defaultStyles, props.style) : defaultStyles;
     const datum = props.datum || props.data;
-    const baseStyles = Helpers.evaluateStyle(style, datum);
+    const baseStyles = Helpers.evaluateStyle(style, datum, props.active);
     return assign({}, baseStyles, {fontSize: this.getFontSize(baseStyles)});
   }
 
   getHeight(props, type) {
     const datum = props.datum || props.data;
-    return Helpers.evaluateProp(props[type], datum);
+    return Helpers.evaluateProp(props[type], datum, props.active);
   }
 
   getContent(props) {
     if (props.text !== undefined) {
       const datum = props.datum || props.data;
-      const child = Helpers.evaluateProp(props.text, datum);
+      const child = Helpers.evaluateProp(props.text, datum, props.active);
       return `${child}`.split("\n");
     }
     return [" "];

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -4,6 +4,7 @@ import * as d3Shape from "d3-shape";
 
 export default class Area extends React.Component {
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     data: PropTypes.array,
     events: PropTypes.object,

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 import { assign } from "lodash";
 import * as d3Shape from "d3-shape";
 
@@ -82,8 +83,8 @@ export default class Area extends React.Component {
   }
 
   render() {
-    const { events, groupComponent } = this.props;
-    const style = assign({fill: "black"}, this.props.style);
+    const { events, groupComponent, data, active } = this.props;
+    const style = Helpers.evaluateStyle(assign({fill: "black"}, this.props.style), data, active);
     const area = this.renderArea(this.getAreaPath(this.props), style, events);
     const line = this.renderLine(this.getLinePath(this.props), style, events);
     return React.cloneElement(groupComponent, {}, area, line);

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 import { assign } from "lodash";
 
 export default class Bar extends React.Component {
 
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     datum: PropTypes.object,
     events: PropTypes.object,
@@ -75,10 +77,13 @@ export default class Bar extends React.Component {
 
   render() {
     // TODO better bar width calculation
+    const {datum, active} = this.props;
     const barWidth = this.getBarWidth(this.props);
     const path = typeof this.props.x === "number" ?
       this.getBarPath(this.props, barWidth) : undefined;
-    const style = assign({fill: "black", stroke: "none"}, this.props.style);
+    const style = Helpers.evaluateStyle(
+      assign({fill: "black", stroke: "none"}, this.props.style), datum, active
+    );
     return this.renderBar(path, style, this.props.events);
   }
 }

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 import { assign } from "lodash";
 
 
 export default class Candle extends React.Component {
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     index: PropTypes.number,
     x: PropTypes.number,
@@ -37,8 +39,8 @@ export default class Candle extends React.Component {
   }
 
   getCandleProps(props) {
-    const { width, candleHeight, x, y, data, events, role, className} = props;
-    const style = assign({stroke: "black"}, props.style);
+    const { width, candleHeight, x, y, data, events, role, className, datum, active} = props;
+    const style = Helpers.evaluateStyle(assign({stroke: "black"}, props.style), datum, active);
     const padding = props.padding.left || props.padding;
     const candleWidth = style.width || 0.5 * (width - 2 * padding) / data.length;
     const candleX = x - candleWidth / 2;
@@ -50,8 +52,8 @@ export default class Candle extends React.Component {
   }
 
   getWickProps(props) {
-    const { x, y1, y2, events, className } = props;
-    const style = assign({stroke: "black"}, props.style);
+    const { x, y1, y2, events, className, datum, active } = props;
+    const style = Helpers.evaluateStyle(assign({stroke: "black"}, props.style), datum, active);
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
     return assign({x1: x, x2: x, y1, y2, style, role, shapeRendering, className}, events);

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 import { assign } from "lodash";
 import * as d3Shape from "d3-shape";
 
 export default class Curve extends React.Component {
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     data: PropTypes.array,
     events: PropTypes.object,
@@ -38,14 +40,16 @@ export default class Curve extends React.Component {
   }
 
   render() {
-    const { data, events, interpolation, scale, style } = this.props;
+    const { data, events, interpolation, scale, style, active } = this.props;
     const xScale = scale.x;
     const yScale = scale.y;
     const lineFunction = d3Shape.line()
       .curve(d3Shape[this.toNewName(interpolation)])
       .x((d) => xScale(d.x1 || d.x))
       .y((d) => yScale(d.y1 || d.y));
-    const lineStyle = assign({fill: "none", stroke: "black"}, style);
+    const lineStyle = Helpers.evaluateStyle(
+      assign({fill: "none", stroke: "black"}, style), data, active
+    );
     return this.renderLine(lineFunction(data), lineStyle, events);
   }
 }

--- a/src/victory-primitives/error-bar.js
+++ b/src/victory-primitives/error-bar.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-statements */
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 import { assign } from "lodash";
 
 export default class ErrorBar extends React.Component {
@@ -8,6 +9,7 @@ export default class ErrorBar extends React.Component {
   }
 
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     index: PropTypes.number,
     datum: PropTypes.object,
@@ -89,7 +91,7 @@ export default class ErrorBar extends React.Component {
   render() {
     const {
       x, y, borderWidth, groupComponent, events, errorX, errorY, scale, role,
-      shapeRendering, style, className
+      shapeRendering, style, className, datum, active
     } = this.props;
     let rangeX;
     let rangeY;
@@ -121,7 +123,7 @@ export default class ErrorBar extends React.Component {
       x, y, borderWidth, groupComponent, events, className,
       role: role || "presentation",
       shapeRendering: shapeRendering || "auto",
-      style: assign({stroke: "black"}, style)
+      style: Helpers.evaluateStyle(assign({stroke: "black"}, style), datum, active)
     };
     return React.cloneElement(
       this.props.groupComponent,

--- a/src/victory-primitives/flyout.js
+++ b/src/victory-primitives/flyout.js
@@ -1,8 +1,10 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 
 export default class Flyout extends React.Component {
 
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     style: PropTypes.object,
     x: PropTypes.number,
@@ -96,6 +98,8 @@ export default class Flyout extends React.Component {
 
   render() {
     const path = this.getFlyoutPath(this.props);
-    return this.renderFlyout(path, this.props.style, this.props.events);
+    const {style, datum, active, events} = this.props;
+    const flyoutStyle = Helpers.evaluateStyle(style, datum, active);
+    return this.renderFlyout(path, flyoutStyle, events);
   }
 }

--- a/src/victory-primitives/line.js
+++ b/src/victory-primitives/line.js
@@ -1,8 +1,10 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 import { assign } from "lodash";
 
 export default class Line extends React.Component {
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     index: PropTypes.number,
     datum: PropTypes.any,
@@ -34,8 +36,8 @@ export default class Line extends React.Component {
   }
 
   render() {
-    const { x1, x2, y1, y2, events} = this.props;
-    const style = assign({stroke: "black"}, this.props.style);
+    const { x1, x2, y1, y2, events, datum, active} = this.props;
+    const style = Helpers.evaluateStyle(assign({stroke: "black"}, this.props.style), datum, active);
     return this.renderAxisLine({x1, x2, y1, y2}, style, events);
   }
 }

--- a/src/victory-primitives/point.js
+++ b/src/victory-primitives/point.js
@@ -1,8 +1,10 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 import pathHelpers from "./path-helpers";
 
 export default class Point extends React.Component {
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     datum: PropTypes.object,
     data: PropTypes.array,
@@ -27,6 +29,7 @@ export default class Point extends React.Component {
   };
 
   getPath(props) {
+    const {datum, active, x, y} = props;
     const pathFunctions = {
       circle: pathHelpers.circle,
       square: pathHelpers.square,
@@ -36,7 +39,9 @@ export default class Point extends React.Component {
       plus: pathHelpers.plus,
       star: pathHelpers.star
     };
-    return pathFunctions[props.symbol].call(null, props.x, props.y, props.size);
+    const symbol = Helpers.evaluateProp(props.symbol, datum, active);
+    const size = Helpers.evaluateProp(props.size, datum, active);
+    return pathFunctions[symbol].call(null, x, y, size);
   }
 
   // Overridden in victory-core-native
@@ -55,6 +60,8 @@ export default class Point extends React.Component {
   }
 
   render() {
-    return this.renderPoint(this.getPath(this.props), this.props.style, this.props.events);
+    const {style, datum, active, events} = this.props;
+    const evaluatedStyle = Helpers.evaluateStyle(style, datum, active);
+    return this.renderPoint(this.getPath(this.props), evaluatedStyle, events);
   }
 }

--- a/src/victory-primitives/slice.js
+++ b/src/victory-primitives/slice.js
@@ -1,7 +1,9 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 
 export default class Slice extends React.Component {
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     index: PropTypes.number,
     slice: PropTypes.object,
@@ -30,8 +32,9 @@ export default class Slice extends React.Component {
   }
 
   render() {
-    const path = this.props.pathFunction(this.props.slice);
-    const { style, events } = this.props;
-    return this.renderSlice(path, style, events);
+    const { style, events, datum, active, slice } = this.props;
+    const path = this.props.pathFunction(slice);
+    const evaluatedStyle = Helpers.evaluateStyle(style, datum, active);
+    return this.renderSlice(path, evaluatedStyle, events);
   }
 }

--- a/src/victory-primitives/voronoi.js
+++ b/src/victory-primitives/voronoi.js
@@ -1,7 +1,9 @@
 import React, { PropTypes } from "react";
+import Helpers from "../victory-util/helpers";
 
 export default class Voronoi extends React.Component {
   static propTypes = {
+    active: PropTypes.bool,
     className: PropTypes.string,
     datum: PropTypes.object,
     data: PropTypes.array,
@@ -22,7 +24,8 @@ export default class Voronoi extends React.Component {
   }
 
   getCirclePath(props) {
-    const {x, y, size} = props;
+    const { x, y, datum, active } = props;
+    const size = Helpers.evaluateProp(props.size, datum, active);
     return `M ${x}, ${y} m ${-size}, 0
       a ${size}, ${size} 0 1,0 ${size * 2},0
       a ${size}, ${size} 0 1,0 ${-size * 2},0`;
@@ -63,7 +66,8 @@ export default class Voronoi extends React.Component {
       circle: this.props.size && this.getCirclePath(this.props),
       voronoi: this.getVoronoiPath(this.props)
     };
-    const { style, events } = this.props;
-    return this.renderPoint(paths, style, events);
+    const { style, events, datum, active } = this.props;
+    const evaluatedStyle = Helpers.evaluateStyle(style, datum, active);
+    return this.renderPoint(paths, evaluatedStyle, events);
   }
 }

--- a/src/victory-shared-events/victory-shared-events.js
+++ b/src/victory-shared-events/victory-shared-events.js
@@ -42,7 +42,7 @@ export default class VictorySharedEvents extends React.Component {
 
   constructor() {
     super();
-    this.state = {};
+    this.state = this.state || {};
     this.getScopedEvents = Events.getScopedEvents.bind(this);
     this.getEventState = Events.getEventState.bind(this);
   }
@@ -56,10 +56,21 @@ export default class VictorySharedEvents extends React.Component {
   }
 
   setUpChildren(props) {
+    this.componentEvents = props.container.type && props.container.type.defaultEvents;
     this.childComponents = React.Children.toArray(props.children);
     const childBaseProps = this.getBasePropsFromChildren(this.childComponents);
     const parentBaseProps = props.container ? { parent: props.container.props } : {};
     this.baseProps = assign({}, childBaseProps, {parent: parentBaseProps});
+    this.hasEvents = props.events || this.componentEvents;
+    this.events = this.getAllEvents(props);
+  }
+
+  getAllEvents(props) {
+    if (Array.isArray(this.componentEvents)) {
+      return Array.isArray(props.events) ?
+        this.componentEvents.concat(...props.events) : this.componentEvents;
+    }
+    return props.events;
   }
 
   getBasePropsFromChildren(childComponents) {
@@ -121,8 +132,8 @@ export default class VictorySharedEvents extends React.Component {
   }
 
   getContainer(props, children) {
-    const parents = Array.isArray(props.events) &&
-      props.events.filter((event) => event.target === "parent");
+    const parents = Array.isArray(this.events) &&
+      this.events.filter((event) => event.target === "parent");
     const sharedEvents = parents.length > 0 ?
       {
         events: parents,

--- a/src/victory-shared-events/victory-shared-events.js
+++ b/src/victory-shared-events/victory-shared-events.js
@@ -145,7 +145,7 @@ export default class VictorySharedEvents extends React.Component {
         getEvents: partialRight(this.getScopedEvents, null, this.baseProps),
         getEventState: partialRight(this.getEventState, null)
       } : null;
-    const container = this.props.container || this.props.groupComponent;
+    const container = this.props.container;
     const boundGetEvents = Events.getEvents.bind(this);
     const parentEvents = sharedEvents && boundGetEvents({sharedEvents}, "parent");
     const parentProps = defaults(

--- a/src/victory-shared-events/victory-shared-events.js
+++ b/src/victory-shared-events/victory-shared-events.js
@@ -55,22 +55,24 @@ export default class VictorySharedEvents extends React.Component {
     this.setUpChildren(newProps);
   }
 
-  setUpChildren(props) {
-    this.componentEvents = props.container.type && props.container.type.defaultEvents;
-    this.childComponents = React.Children.toArray(props.children);
-    const childBaseProps = this.getBasePropsFromChildren(this.childComponents);
-    const parentBaseProps = props.container ? { parent: props.container.props } : {};
-    this.baseProps = assign({}, childBaseProps, {parent: parentBaseProps});
-    this.hasEvents = props.events || this.componentEvents;
-    this.events = this.getAllEvents(props);
-  }
-
   getAllEvents(props) {
+    const components = ["container", "groupComponent"];
+    this.componentEvents = Events.getComponentEvents(props, components);
     if (Array.isArray(this.componentEvents)) {
       return Array.isArray(props.events) ?
         this.componentEvents.concat(...props.events) : this.componentEvents;
     }
     return props.events;
+  }
+
+  setUpChildren(props) {
+    this.events = this.getAllEvents(props);
+    if (this.events) {
+      this.childComponents = React.Children.toArray(props.children);
+      const childBaseProps = this.getBasePropsFromChildren(this.childComponents);
+      const parentBaseProps = props.container ? props.container.props : {};
+      this.baseProps = assign({}, childBaseProps, {parent: parentBaseProps});
+    }
   }
 
   getBasePropsFromChildren(childComponents) {
@@ -142,7 +144,7 @@ export default class VictorySharedEvents extends React.Component {
       } : null;
     const container = this.props.container || this.props.groupComponent;
     const boundGetEvents = Events.getEvents.bind(this);
-    const parentEvents = boundGetEvents({sharedEvents}, "parent");
+    const parentEvents = sharedEvents && boundGetEvents({sharedEvents}, "parent");
     const parentProps = defaults(
       {},
       this.getEventState("parent", "parent"),
@@ -159,7 +161,10 @@ export default class VictorySharedEvents extends React.Component {
   }
 
   render() {
-    const children = this.getNewChildren(this.props);
-    return this.getContainer(this.props, children);
+    if (this.events) {
+      const children = this.getNewChildren(this.props);
+      return this.getContainer(this.props, children);
+    }
+    return React.cloneElement(this.props.container, {}, this.props.children);
   }
 }

--- a/src/victory-shared-events/victory-shared-events.js
+++ b/src/victory-shared-events/victory-shared-events.js
@@ -105,6 +105,9 @@ export default class VictorySharedEvents extends React.Component {
           const name = child.props.name || childNames.shift() || index;
           const childEvents = Array.isArray(events) &&
             events.filter((event) => {
+              if (event.target === "parent") {
+                return false;
+              }
               return Array.isArray(event.childName) ?
                 event.childName.indexOf(name) > -1 :
                 event.childName === name || event.childName === "all";
@@ -149,14 +152,14 @@ export default class VictorySharedEvents extends React.Component {
       {},
       this.getEventState("parent", "parent"),
       container.props,
-      this.baseProps.parent
+      this.baseProps.parent,
+      { children }
     );
     return React.cloneElement(
       container,
       assign(
         {}, parentProps, {events: Events.getPartialEvents(parentEvents, "parent", parentProps)}
-      ),
-      children
+      )
     );
   }
 
@@ -165,6 +168,6 @@ export default class VictorySharedEvents extends React.Component {
       const children = this.getNewChildren(this.props);
       return this.getContainer(this.props, children);
     }
-    return React.cloneElement(this.props.container, {}, this.props.children);
+    return React.cloneElement(this.props.container, { children: this.props.children });
   }
 }

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -117,8 +117,8 @@ export default class VictoryTooltip extends React.Component {
       horizontal, datum, pointerLength, pointerWidth, cornerRadius,
       width, height, orientation, dx, dy, text, active
     } = props;
-    const style = Helpers.evaluateStyle(props.style, datum);
-    const flyoutStyle = Helpers.evaluateStyle(props.flyoutStyle, datum);
+    const style = Helpers.evaluateStyle(props.style, datum, active);
+    const flyoutStyle = Helpers.evaluateStyle(props.flyoutStyle, datum, active);
     const padding = flyoutStyle && flyoutStyle.padding || 0;
     const defaultDx = horizontal ? padding : 0;
     const defaultDy = horizontal ? 0 : padding;
@@ -133,16 +133,16 @@ export default class VictoryTooltip extends React.Component {
       {
         style,
         flyoutStyle,
-        dx: dx !== undefined ? Helpers.evaluateProp(dx, datum) : defaultDx,
-        dy: dy !== undefined ? Helpers.evaluateProp(dy, datum) : defaultDy,
-        cornerRadius: Helpers.evaluateProp(cornerRadius, datum),
-        pointerLength: Helpers.evaluateProp(pointerLength, datum),
-        pointerWidth: Helpers.evaluateProp(pointerWidth, datum),
-        orientation: Helpers.evaluateProp(orientation, datum) || getDefaultOrientation(),
-        width: Helpers.evaluateProp(width, datum),
-        height: Helpers.evaluateProp(height, datum),
-        active: Helpers.evaluateProp(active, datum),
-        text: Helpers.evaluateProp(text, datum)
+        dx: dx !== undefined ? Helpers.evaluateProp(dx, datum, active) : defaultDx,
+        dy: dy !== undefined ? Helpers.evaluateProp(dy, datum, active) : defaultDy,
+        cornerRadius: Helpers.evaluateProp(cornerRadius, datum, active),
+        pointerLength: Helpers.evaluateProp(pointerLength, datum, active),
+        pointerWidth: Helpers.evaluateProp(pointerWidth, datum, active),
+        orientation: Helpers.evaluateProp(orientation, datum, active) || getDefaultOrientation(),
+        width: Helpers.evaluateProp(width, datum, active),
+        height: Helpers.evaluateProp(height, datum, active),
+        active: Helpers.evaluateProp(active, datum, active),
+        text: Helpers.evaluateProp(text, datum, active)
       }
     );
   }
@@ -151,10 +151,9 @@ export default class VictoryTooltip extends React.Component {
     const { style, text, datum } = props;
     const baseLabelStyle = style ?
       defaults({}, style, defaultLabelStyles) : defaultLabelStyles;
-    const baseFlyoutStyle = props.flyoutStyle ?
+    const flyoutStyle = props.flyoutStyle ?
       defaults({}, props.flyoutStyle, defaultStyles) : defaultStyles;
     const labelStyle = Helpers.evaluateStyle(baseLabelStyle, datum);
-    const flyoutStyle = Helpers.evaluateStyle(baseFlyoutStyle, datum);
     const labelSize = TextSize.approximateTextSize(text, labelStyle);
     const flyoutDimensions = this.getDimensions(props, labelSize, labelStyle);
     const flyoutCenter = this.getFlyoutCenter(props, flyoutDimensions);

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -94,20 +94,26 @@ export default class VictoryTooltip extends React.Component {
     target: "data",
     eventHandlers: {
       onMouseOver: () => {
-        return {
-          target: "labels",
-          mutation: () => {
-            return { active: true };
+        return [
+          {
+            target: "labels",
+            mutation: () => ({ active: true })
+          }, {
+            target: "data",
+            mutation: () => ({ active: true })
           }
-        };
+        ];
       },
       onMouseOut: () => {
-        return {
-          target: "labels",
-          mutation: () => {
-            return { active: false };
+        return [
+          {
+            target: "labels",
+            mutation: () => ({ active: false })
+          }, {
+            target: "data",
+            mutation: () => ({ active: false })
           }
-        };
+        ];
       }
     }
   }];

--- a/src/victory-util/add-events.js
+++ b/src/victory-util/add-events.js
@@ -26,11 +26,21 @@ export default (WrappedComponent) => {
       const { sharedEvents } = props;
       const components = WrappedComponent.expectedComponents;
       this.componentEvents = Events.getComponentEvents(props, components);
-      this.baseProps = WrappedComponent.getBaseProps(props);
+      this.baseProps = isFunction(WrappedComponent.getBaseProps) ?
+        WrappedComponent.getBaseProps(props) : {};
       this.dataKeys = Object.keys(this.baseProps).filter((key) => key !== "parent");
       this.getSharedEventState = sharedEvents && isFunction(sharedEvents.getEventState) ?
         sharedEvents.getEventState : () => undefined;
       this.hasEvents = props.events || props.sharedEvents || this.componentEvents;
+      this.events = this.getAllEvents(props);
+    }
+
+    getAllEvents(props) {
+      if (Array.isArray(this.componentEvents)) {
+        return Array.isArray(props.events) ?
+          this.componentEvents.concat(...props.events) : this.componentEvents;
+      }
+      return props.events;
     }
 
     getComponentProps(component, type, index) {

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -92,7 +92,8 @@ export default {
           return "all";
         } else if (eventReturn.eventKey === "all") {
           return baseProps[childName] ?
-            Object.keys(baseProps[childName]) : Object.keys(baseProps);
+            without(Object.keys(baseProps[childName]), "parent") :
+            without(Object.keys(baseProps), "parent");
         } else if (eventReturn.eventKey === undefined && eventKey === "parent") {
           return baseProps[childName] ?
             Object.keys(baseProps[childName]) : Object.keys(baseProps);

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -74,7 +74,8 @@ export default {
     const getTargetProps = (identifier, type) => {
       const { childName, target, key } = identifier;
       const baseType = type === "props" ? baseProps : this.state;
-      const base = (!childName || !baseType[childName]) ? baseType : baseType[childName];
+      const base = (childName === undefined || childName === null || !baseType[childName]) ?
+        baseType : baseType[childName];
       return key === "parent" ? base.parent : base[key] && base[key][target];
     };
 
@@ -113,7 +114,7 @@ export default {
           return target === "parent" ?
             extend(state[key], mutatedProps) : extend(state[key], {[target]: mutatedProps});
         };
-        return childName ?
+        return childName !== undefined && childName !== null ?
           extend(this.state, {[childName]: extend(childState, {[key]: extendState(childState)})}) :
           extend(this.state, {[key]: extendState(this.state)});
       };

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -1,4 +1,4 @@
-import { assign, extend, merge, partial, isEmpty, isFunction } from "lodash";
+import { assign, extend, merge, partial, isEmpty, isFunction, without } from "lodash";
 
 export default {
   /* Returns all own and shared events that should be attached to a single target element,
@@ -129,9 +129,11 @@ export default {
       };
 
       // returns an entire mutated state for all children
-      return Array.isArray(childNames) ? childNames.reduce((memo, childName) => {
+      const allChildNames = childNames === "all" ?
+        without(Object.keys(baseProps), "parent") : childNames;
+      return Array.isArray(allChildNames) ? allChildNames.reduce((memo, childName) => {
         return assign(memo, getReturnByChild(childName));
-      }, {}) : getReturnByChild(childNames);
+      }, {}) : getReturnByChild(allChildNames);
     };
 
     // Parses an array of event returns into a single state mutation

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -29,16 +29,16 @@ export default {
     };
   },
 
-  evaluateProp(prop, data, index) {
-    return isFunction(prop) ? prop(data, index) : prop;
+  evaluateProp(prop, data, active) {
+    return isFunction(prop) ? prop(data, active) : prop;
   },
 
-  evaluateStyle(style, data, index) {
+  evaluateStyle(style, data, active) {
     if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
       return style;
     }
     return Object.keys(style).reduce((prev, curr) => {
-      prev[curr] = this.evaluateProp(style[curr], data, index);
+      prev[curr] = this.evaluateProp(style[curr], data, active);
       return prev;
     }, {});
   },

--- a/src/victory-util/index.js
+++ b/src/victory-util/index.js
@@ -8,6 +8,7 @@ import Helpers from "./helpers";
 import Log from "./log";
 import PropTypes from "./prop-types";
 import Scale from "./scale";
+import Selection from "./selection";
 import Style from "./style";
 import TextSize from "./textsize";
 import Timer from "./timer";
@@ -24,6 +25,7 @@ export {
   Log,
   PropTypes,
   Scale,
+  Selection,
   Style,
   TextSize,
   Timer,

--- a/src/victory-util/selection.js
+++ b/src/victory-util/selection.js
@@ -1,0 +1,21 @@
+
+
+export default {
+  getParentSVG(target) {
+    if (target.nodeName === "svg") {
+      return target;
+    } else {
+      return this.getParentSVG(target.parentNode);
+    }
+  },
+
+  (evt) {
+    const svg = this.getParentSVG(evt.target);
+    const matrix = svg.getScreenCTM().inverse();
+    const {a, d, e, f} = matrix;
+    return {
+      x: a * evt.clientX + e,
+      y: d * evt.clientY + f
+    };
+  }
+};

--- a/src/victory-util/selection.js
+++ b/src/victory-util/selection.js
@@ -1,4 +1,7 @@
-
+import React from "react";
+import { isFunction } from "lodash";
+import Data from "./data";
+import Collection from "./collection";
 
 export default {
   getParentSVG(target) {
@@ -17,5 +20,95 @@ export default {
       x: a * evt.clientX + e,
       y: d * evt.clientY + f
     };
+  },
+
+  getDataCoordinates(scale, x, y) {
+    return {
+      x: scale.x.invert(x),
+      y: scale.y.invert(y)
+    };
+  },
+
+  getBounds(props) {
+    const {x1, x2, y1, y2, scale} = props;
+    const point1 = this.getDataCoordinates(scale, x1, y1);
+    const point2 = this.getDataCoordinates(scale, x2, y2);
+    const makeBound = (a, b) => {
+      return [ Collection.getMinValue([a, b]), Collection.getMaxValue([a, b]) ];
+    };
+
+    return {
+      x: makeBound(point1.x, point2.x),
+      y: makeBound(point1.y, point2.y)
+    };
+  },
+
+  getDatasets(props) { // eslint-disable-line max-statements
+    if (props.data) {
+      return [{data: props.data}];
+    }
+    const getData = (childProps) => {
+      const data = Data.getData(childProps);
+      return Array.isArray(data) && data.length > 0 ? data : undefined;
+    };
+
+    // Reverse the child array to maintain correct order when looping over
+    // children starting from the end of the array.
+    const children = React.Children.toArray(props.children).reverse();
+    let childrenLength = children.length;
+    const dataArr = [];
+    let dataArrLength = 0;
+    let childIndex = 0;
+    while (childrenLength > 0) {
+      const child = children[--childrenLength];
+      const childName = child.props.name || childIndex;
+      childIndex++;
+      if (child.type && child.type.role === "axis") {
+        childIndex++;
+      } else if (child.type && isFunction(child.type.getData)) {
+        dataArr[dataArrLength++] = {childName, data: child.type.getData(child.props)};
+      } else if (child.props && child.props.children) {
+        const newChildren = React.Children.toArray(child.props.children);
+        const newChildrenLength = newChildren.length;
+        for (let index = 0; index < newChildrenLength; index++) {
+          children[childrenLength++] = newChildren[index];
+        }
+      } else {
+        dataArr[dataArrLength++] = {childName, data: getData(child.props)};
+      }
+    }
+    return dataArr;
+  },
+
+  filterDatasets(datasets, bounds) {
+    const filtered = datasets.reduce((memo, dataset) => {
+      const selectedData = this.getSelectedData(dataset.data, bounds);
+      memo = selectedData ?
+        memo.concat({
+          childName: dataset.childName, eventKey: selectedData.eventKey, data: selectedData.data
+        }) :
+        memo;
+      return memo;
+    }, []);
+    return filtered.length ? filtered : null;
+  },
+
+  getSelectedData(dataset, bounds) {
+    const {x, y} = bounds;
+    const withinBounds = (d) => {
+      return d.x >= x[0] && d.x <= x[1] && d.y >= y[0] && d.y <= y[1];
+    };
+    const eventKey = [];
+    const data = [];
+    let count = 0;
+    for (let index = 0, len = dataset.length; index < len; index++) {
+      const datum = dataset[index];
+      if (withinBounds(datum)) {
+        data[count] = datum;
+        eventKey[count] = datum.eventKey === undefined ? index : datum.eventKey;
+        count++;
+      }
+    }
+    return count > 0 ? {eventKey, data} : null;
   }
 };

--- a/src/victory-util/selection.js
+++ b/src/victory-util/selection.js
@@ -9,7 +9,7 @@ export default {
     }
   },
 
-  (evt) {
+  getSVGEventCoordinates(evt) {
     const svg = this.getParentSVG(evt.target);
     const matrix = svg.getScreenCTM().inverse();
     const {a, d, e, f} = matrix;

--- a/test/client/spec/victory-util/selection.spec.js
+++ b/test/client/spec/victory-util/selection.spec.js
@@ -1,0 +1,97 @@
+/* eslint no-unused-expressions: 0 */
+/* eslint max-nested-callbacks: 0 */
+/* global sinon */
+
+import { Data, Selection, VictoryLabel } from "src/index";
+import React from "react";
+
+describe("helpers/selection", () => {
+  describe("getDatasets", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Data, "getData");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns data from props", () => {
+      const data = [{x: 1, y: 3}, {x: 2, y: 5}];
+      const props = {data};
+      const dataset = Selection.getDatasets(props);
+      expect(Data.getData).not.called;
+      expect(dataset).to.eql([{data}]);
+    });
+
+    it("returns data from children", () => {
+      const data = [{eventKey: 0, x: 1, y: 3}, {eventKey: 1, x: 2, y: 5}];
+      const name = "points";
+      const children = [React.createElement(VictoryLabel, {name, data})];
+      const props = {children};
+      const dataset = Selection.getDatasets(props);
+      expect(Data.getData).calledOnce.and.returned(data);
+      expect(dataset).to.eql([{childName: name, data}]);
+    });
+  });
+
+  describe("getBounds", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(Selection, "getDataCoordinates", (scale, x, y) => {
+        return {x, y};
+      });
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns min / max bounds", () => {
+      const x1 = 10;
+      const x2 = 5;
+      const y1 = 0;
+      const y2 = 1;
+      const props = {x1, x2, y1, y2};
+      const bounds = Selection.getBounds(props);
+      expect(Selection.getDataCoordinates).calledTwice.and.returned({x: x1, y: y1});
+      expect(bounds).to.eql({x: [x2, x1], y: [y1, y2]});
+    });
+  });
+
+  describe("filterDatasets", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Selection, "getSelectedData");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns null when no datasets are within bounds", () => {
+      const datasets = [
+        {childName: "a", data: [{eventKey: 0, x: 1, y: 3}, {eventKey: 1, x: 2, y: 5}]}
+      ];
+      const bounds = { x: [0, 1], y: [10, 15]};
+      const filteredData = Selection.filterDatasets(datasets, bounds);
+      expect(Selection.getSelectedData).calledWith(datasets[0].data, bounds).and.returned(null);
+      expect(filteredData).to.equal(null);
+    });
+
+    it("returns data points within bounds", () => {
+      const data = [{eventKey: 0, x: 1, y: 3}, {eventKey: 1, x: 2, y: 5}];
+      const childName = "a";
+      const datasets = [{childName, data}];
+      const bounds = {x: [0, 1], y: [0, 10]};
+      const filteredData = Selection.filterDatasets(datasets, bounds);
+      const expected = {eventKey: [0], data: [data[0]]};
+      expect(Selection.getSelectedData).calledWith(datasets[0].data, bounds)
+        .and.returned(expected);
+      expect(filteredData).to.eql([Object.assign({childName}, expected)]);
+    });
+  });
+});


### PR DESCRIPTION
This PR supports automatic events from `containerComponents` supplied to Victory components. This PR also adds an `active` prop to all primitive components, and changes when functional styles and props are evaluated, so that changing the active component on primitive components can alter styles and props. This PR also alters the behavior of tooltips so that triggering the tooltip sets `active` on both data and labels