### PR TITLE
retain x, y, attributes in data for user convenience

### DIFF
--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -82,7 +82,7 @@ export default {
       const x = evaluatedX !== undefined ? evaluatedX : index;
       const y = evaluatedY !== undefined ? evaluatedY : datum;
       return assign(
-          {},
+          {x, y},
           datum,
           { _x: x, _y: y },
           // map string data to numeric values, and add names

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -129,12 +129,12 @@ describe("helpers/data", () => {
     });
 
     it("formats a single dataset", () => {
-      const dataset = [{_x: 1, _y: 3}, {_x: 2, _y: 5}];
-      const props = {data: dataset, x: "_x", y: "_y"};
+      const dataset = [{_x: 1, _y: 3, x: 1, y: 3}, {_x: 2, _y: 5, x: 2, y: 5}];
+      const props = {data: dataset};
       const formatted = Data.formatData(dataset, props);
       expect(Data.cleanData).called.and.returned(dataset);
       expect(formatted).to.be.an.array;
-      expect(formatted[0]).to.have.keys(["_x", "_y"]);
+      expect(formatted[0]).to.have.keys(["_x", "_y", "x", "y"]);
     });
   });
 


### PR DESCRIPTION
The formatted data now uses "_x" and "_y" to represent data for calculating values / positions etc. This PR adds "x" and "y" properties back, but in such a way that they will be overridden by "x" and "y" values if they exist in the data. This will cause fewer breaking changes for users working with data accessors, but also relying on functional props like `size={(d) => d.y > 2}`.  So, formatted data will always have "x", "_x", "y", and "_y" where "_x" and "_y" are guaranteed to be in a format that Victory expects when working with x, y, data. "x" and "y" will be identical to "_x" and "_y" except in cases where "x" and "y" already exist in user data. In this case, user "x" and "y" will remain unchanged, allowing users to make assertions like `size={(d) => d.x === "cats"}` (`_x` will have been mapped to an integer corresponding to a string map)