### PR TITLE
Update legend styles

### DIFF
--- a/demo/victory-legend-demo.js
+++ b/demo/victory-legend-demo.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { VictoryLegend } from "../src/index";
 
-const svgStyle = { border: "1px solid #ccc" };
+const svgStyle = { border: "1px solid darkgray" };
 const data = [{
   name: "Series 1",
   symbol: {
@@ -22,12 +22,17 @@ const data = [{
   }
 }, {
   name: "Series 4",
-  symbol: { type: "plus" }
+  symbol: {
+    type: "plus"
+  }
 }, {
   name: "Series 5",
   symbol: {
     type: "star",
     fill: "red"
+  },
+  labels: {
+    fill: "purple"
   }
 }];
 
@@ -44,7 +49,7 @@ const LegendDemo = () => (
         padding={20}
         standalone={false}
         orientation="horizontal"
-        style={{ labels: { fill: "#ccc" }}}
+        style={{ labels: { fill: "darkgray" } }}
       />
     </svg>
   </div>

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -20,7 +20,7 @@ export default class VictoryLegend extends React.Component {
     colorScale: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.oneOf([
-        "greyscale", "qualitative", "heatmap", "warm", "cool", "red", "green", "blue"
+        "grayscale", "qualitative", "heatmap", "warm", "cool", "red", "green", "blue"
       ])
     ]),
     containerComponent: PropTypes.element,

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -145,7 +145,7 @@ export default class VictoryLegend extends React.Component {
       width = this.calculateLegendWidth(textSizes, padding, isHorizontal);
     }
 
-    return merge({},
+    return Object.assign({},
       this.props,
       { isHorizontal, height, labelStyles, padding, parentStyles, symbolStyles, textSizes, width }
     );
@@ -248,7 +248,7 @@ export default class VictoryLegend extends React.Component {
     let groupProps = { role: "presentation" };
 
     if (!standalone) {
-      groupProps = merge(groupProps, { height, width, x, y, style: parentStyles });
+      groupProps = Object.assign(groupProps, { height, width, x, y, style: parentStyles });
     }
 
     return React.cloneElement(groupComponent, groupProps, children);

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -51,8 +51,9 @@ export default class VictoryLegend extends React.Component {
     ]),
     standalone: PropTypes.bool,
     style: PropTypes.shape({
-      symbol: PropTypes.object,
-      label: PropTypes.object
+      data: PropTypes.object,
+      labels: PropTypes.object,
+      parent: PropTypes.object
     }),
     symbolSpacer: PropTypes.number,
     theme: PropTypes.object,
@@ -60,8 +61,8 @@ export default class VictoryLegend extends React.Component {
       CustomPropTypes.nonNegative,
       PropTypes.func
     ]),
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired
+    x: PropTypes.number,
+    y: PropTypes.number
   };
 
   static defaultProps = {
@@ -112,7 +113,9 @@ export default class VictoryLegend extends React.Component {
     const { role } = this.constructor;
     const { data, orientation, theme } = this.props;
     let { height, padding, width } = this.props;
+
     const legendTheme = theme && theme[role] ? theme[role] : {};
+    const parentStyles = this.getStyles({}, legendTheme, "parent");
     const colorScale = this.getColorScale(legendTheme);
     const isHorizontal = orientation === "horizontal";
     const symbolStyles = [];
@@ -142,15 +145,18 @@ export default class VictoryLegend extends React.Component {
       width = this.calculateLegendWidth(textSizes, padding, isHorizontal);
     }
 
-    return Object.assign({},
+    return merge({},
       this.props,
-      { isHorizontal, height, labelStyles, padding, symbolStyles, textSizes, width }
+      { isHorizontal, height, labelStyles, padding, parentStyles, symbolStyles, textSizes, width }
     );
   }
 
   getStyles(datum, theme, key, color) { // eslint-disable-line max-params
-    const colorScale = color ? { fill: color } : {};
-    return merge({}, theme.style[key], colorScale, this.props.style[key], datum[key]);
+    const { style } = this.props;
+    const styleKey = key === "symbol" ? "data" : key;
+    const colorScaleStyle = color ? { fill: color } : {};
+    const styles = merge({}, theme.style[styleKey], colorScaleStyle, style[styleKey], datum[key]);
+    return Helpers.evaluateStyle(styles, datum);
   }
 
   getSymbolSize(datum, fontSize) {
@@ -159,7 +165,8 @@ export default class VictoryLegend extends React.Component {
 
   getSymbolProps(datum, props, i) {
     const {
-      gutter, labelStyles, isHorizontal, padding, symbolSpacer, symbolStyles, textSizes
+      dataComponent, gutter, labelStyles, isHorizontal,
+      padding, symbolSpacer, symbolStyles, textSizes
     } = props;
     const { leftOffset } = textSizes[i];
     const { fontSize } = labelStyles[i];
@@ -174,17 +181,22 @@ export default class VictoryLegend extends React.Component {
       y: padding.top + symbolShift + (fontSize + gutter) * i
     };
 
-    return {
-      key: `symbol-${i}`,
-      style,
-      size: this.getSymbolSize(datum, fontSize),
-      symbol: style.type,
-      ...symbolCoords
-    };
+    return defaults({},
+      dataComponent.props,
+      {
+        key: `symbol-${i}`,
+        style,
+        size: this.getSymbolSize(datum, fontSize),
+        symbol: style.type,
+        ...symbolCoords
+      }
+    );
   }
 
   getLabelProps(datum, props, i) {
-    const { gutter, isHorizontal, symbolSpacer, labelStyles, textSizes, padding } = props;
+    const {
+      gutter, isHorizontal, symbolSpacer, labelComponent, labelStyles, textSizes, padding
+    } = props;
     const style = labelStyles[i];
     const { fontSize } = style;
     const symbolShift = fontSize / 2;
@@ -197,12 +209,15 @@ export default class VictoryLegend extends React.Component {
       y: padding.top + symbolShift + (fontSize + gutter) * i
     };
 
-    return {
-      key: `label-${i}`,
-      style,
-      text: datum.name,
-      ...labelCoords
-    };
+    return defaults({},
+      labelComponent.props,
+      {
+        key: `label-${i}`,
+        style,
+        text: datum.name,
+        ...labelCoords
+      }
+    );
   }
 
   renderLegendItems(props) {
@@ -229,22 +244,22 @@ export default class VictoryLegend extends React.Component {
   }
 
   renderGroup(props, children) {
-    const { groupComponent, height, width, standalone, x, y } = props;
-    const groupProps = { role: "presentation" };
+    const { groupComponent, height, parentStyles, standalone, width, x, y } = props;
+    let groupProps = { role: "presentation" };
 
     if (!standalone) {
-      Object.assign(groupProps, { height, width, x, y });
+      groupProps = merge(groupProps, { height, width, x, y, style: parentStyles });
     }
 
     return React.cloneElement(groupComponent, groupProps, children);
   }
 
   renderContainer(props, children) {
-    const { containerComponent, height, width, x, y, style } = props;
+    const { containerComponent, height, parentStyles, width, x, y } = props;
 
     return React.cloneElement(
       containerComponent,
-      { x, y, height, width, style: defaults({}, style) },
+      { height, width, x, y, style: parentStyles },
       children
     );
   }

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -120,8 +120,8 @@ export default class VictoryLegend extends React.Component {
     let leftOffset = 0;
 
     padding = Helpers.getPadding({ padding: padding || theme.padding });
-    height = height || theme.height;
-    width = width || theme.width;
+    height = Helpers.evaluateProp(height || theme.height, data);
+    width = Helpers.evaluateProp(width || theme.width, data);
 
     const textSizes = data.map((datum, i) => {
       const labelStyle = this.getStyles(datum, legendTheme, "labels");

--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -194,12 +194,13 @@ export default {
       }
     }
   }, baseProps),
-  legend: assign({
+  legend: {
+    colorScale: colors,
     style: {
-      symbol: {
+      data: {
         type: "circle"
       },
       labels: baseLabelStyles
     }
-  }, baseProps)
+  }
 };

--- a/src/victory-theme/material.js
+++ b/src/victory-theme/material.js
@@ -219,12 +219,13 @@ export default {
       }
     }
   }, baseProps),
-  legend: assign({
+  legend: {
+    colorScale: colors,
     style: {
-      symbol: {
+      data: {
         type: "circle"
       },
       labels: baseLabelStyles
     }
-  }, baseProps)
+  }
 };

--- a/test/client/spec/victory-legend/victory-legend.spec.js
+++ b/test/client/spec/victory-legend/victory-legend.spec.js
@@ -116,7 +116,7 @@ describe("components/victory-legend", () => {
     }];
 
     const styleObject = {
-      symbol: {
+      data: {
         type: "triangleUp",
         fill: "green"
       },


### PR DESCRIPTION
this PR fixes some style issues i found in the legend component while writing docs:
- refactors style prop to allow for styling of the parent component/container
- removes some extraneous legend theme base props
- fixes a bug where height and width props weren't getting evaluated properly to allow for functional styles