### PR TITLE
feature/voronoi-container

### DIFF
--- a/demo/victory-label-demo.js
+++ b/demo/victory-label-demo.js
@@ -35,7 +35,8 @@ export default class App extends React.Component {
             text={"Victory is awesome.\nThis is (end, start) anchoring.\nOK?"}
           />
           <circle cx="300" cy="300" r="2" fill="blue"/>
-          <VictoryLabel x={300} y={300} lineHeight={2} textAnchor="middle" verticalAnchor="start"
+          <VictoryLabel x={300} y={300} textAnchor="middle" verticalAnchor="start"
+            style={{padding: 15}}
             text={"Victory is awesome.\nThis is (middle, start) anchoring.\nGot it?"}
           />
 

--- a/demo/victory-label-demo.js
+++ b/demo/victory-label-demo.js
@@ -27,55 +27,55 @@ export default class App extends React.Component {
 
           <circle cx="300" cy="150" r="2" fill="green"/>
           <VictoryLabel x={300} y={150} textAnchor="end" verticalAnchor="start"
-            style={{ fill: "blue" }}
-          >
-            {"Victory is awesome.\nThis is (end, start) anchoring.\nOK?"}
-          </VictoryLabel>
-
+            style={[
+              { fill: "tomato", fontSize: 20 },
+              { fill: "blue", fontSize: 15, angle: 45 },
+              { fill: "black", fontSize: 10, padding: 10, textAnchor: "middle" }
+            ]}
+            text={"Victory is awesome.\nThis is (end, start) anchoring.\nOK?"}
+          />
           <circle cx="300" cy="300" r="2" fill="blue"/>
-          <VictoryLabel x={300} y={300} lineHeight={2} textAnchor="middle" verticalAnchor="start">
-            {"Victory is awesome.\nThis is (middle, start) anchoring.\nGot it?"}
-          </VictoryLabel>
+          <VictoryLabel x={300} y={300} lineHeight={2} textAnchor="middle" verticalAnchor="start"
+            text={"Victory is awesome.\nThis is (middle, start) anchoring.\nGot it?"}
+          />
+
 
           <circle cx="300" cy="450" r="2" fill="red"/>
-          <VictoryLabel x={300} y={450} textAnchor="start" verticalAnchor="start">
-            {"Victory is awesome.\nThis is (start, start) anchoring.\nCapisce?"}
-          </VictoryLabel>
+          <VictoryLabel x={300} y={450} textAnchor="start" verticalAnchor="start"
+            text={"Victory is awesome.\nThis is (start, start) anchoring.\nCapisce?"}
+          />
 
           <circle cx="300" cy="600" r="2" fill="green"/>
-          <VictoryLabel x={300} y={600} textAnchor="end" verticalAnchor="end">
-            {"Victory is awesome.\nThis is (end, end) anchoring.\nOK?"}
-          </VictoryLabel>
+          <VictoryLabel x={300} y={600} textAnchor="end" verticalAnchor="end"
+            text={"Victory is awesome.\nThis is (end, end) anchoring.\nOK?"}
+          />
 
           <circle cx="300" cy="750" r="2" fill="blue"/>
           <VictoryLabel x={300} y={750} lineHeight={2}
             textAnchor="middle" verticalAnchor="end"
-          >
-            {"Victory is awesome.\nThis is (middle, end) anchoring.\nGot it?"}
-          </VictoryLabel>
+            text={"Victory is awesome.\nThis is (middle, end) anchoring.\nGot it?"}
+          />
 
           <circle cx="300" cy="900" r="2" fill="red"/>
-          <VictoryLabel x={300} y={900} textAnchor="start" verticalAnchor="end">
-            {"Victory is awesome.\nThis is (start, end) anchoring.\nCapisce?"}
-          </VictoryLabel>
+          <VictoryLabel x={300} y={900} textAnchor="start" verticalAnchor="end"
+            text={"Victory is awesome.\nThis is (start, end) anchoring.\nCapisce?"}
+          />
 
           <circle cx="300" cy="1050" r="2" fill="green"/>
-          <VictoryLabel x={300} y={1050} textAnchor="end" verticalAnchor="middle">
-            {"Victory is awesome.\nThis is (end, middle) anchoring.\nOK?"}
-          </VictoryLabel>
+          <VictoryLabel x={300} y={1050} textAnchor="end" verticalAnchor="middle"
+            text={"Victory is awesome.\nThis is (end, middle) anchoring.\nOK?"}
+          />
 
           <circle cx="300" cy="1200" r="2" fill="blue"/>
           <VictoryLabel x={300} y={1200} lineHeight={2}
             textAnchor="middle" verticalAnchor="middle"
-          >
-            {"Victory is awesome.\nThis is (middle, middle) anchoring.\nGot it?"}
-          </VictoryLabel>
+            text={"Victory is awesome.\nThis is (middle, middle) anchoring.\nGot it?"}
+          />
 
           <circle cx="300" cy="1350" r="2" fill="red"/>
-          <VictoryLabel x={300} y={1350} textAnchor="start" verticalAnchor="middle">
-            {"Victory is awesome.\nThis is (start, middle) anchoring.\nCapisce?"}
-          </VictoryLabel>
-
+          <VictoryLabel x={300} y={1350} textAnchor="start" verticalAnchor="middle"
+            text={"Victory is awesome.\nThis is (start, middle) anchoring.\nCapisce?"}
+          />
         </svg>
       </div>
     );

--- a/demo/victory-tooltip-demo.js
+++ b/demo/victory-tooltip-demo.js
@@ -21,7 +21,7 @@ export default class App extends React.Component {
     };
 
     const baseTooltipProps = {
-      x: 75, y: 75, cornerRadius: 3, active: true
+      x: 75, y: 75, cornerRadius: 3, active: true, style: {padding: 5}
     };
 
     return (

--- a/demo/victory-tooltip-demo.js
+++ b/demo/victory-tooltip-demo.js
@@ -37,7 +37,11 @@ export default class App extends React.Component {
         </svg>
 
         <svg {...svgProps}>
-          <VictoryTooltip {...baseTooltipProps} text={"o shit\nwaddup"} orientation="bottom"/>
+          <VictoryTooltip {...baseTooltipProps}
+            text={["o shit", "waddup"]}
+            style={[{fill: "red"}, {fill: "blue"}]}
+            orientation="bottom"
+          />
           <circle cx="75" cy="75" r="2" fill="red"/>
         </svg>
 

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import { assign, omit } from "lodash";
 import Portal from "../victory-portal/portal";
 import { Timer } from "../victory-util/index";
-import { VictoryTheme } from "../victory-theme/victory-theme";
+import { default as VictoryTheme } from "../victory-theme/victory-theme";
 
 export default class VictoryContainer extends React.Component {
   static displayName = "VictoryContainer";

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -24,8 +24,6 @@ export default class VictoryContainer extends React.Component {
   }
 
   static defaultProps = {
-    title: "Victory Chart",
-    desc: "",
     portalComponent: <Portal/>,
     responsive: true
   }
@@ -90,8 +88,8 @@ export default class VictoryContainer extends React.Component {
     return standalone !== false ?
       (
         <svg {...svgProps} style={style} className={className}>
-          <title id="title">{title}</title>
-          <desc id="desc">{desc}</desc>
+          {title ? <title id="title">{title}</title> : null}
+          {desc ? <desc id="desc">{desc}</desc> : null}
           {this.getChildren(props)}
           {React.cloneElement(portalComponent, {ref: this.savePortalRef})}
         </svg>

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from "react";
 import { assign, omit } from "lodash";
 import Portal from "../victory-portal/portal";
 import { Timer } from "../victory-util/index";
+import { VictoryTheme } from "../victory-theme/victory-theme";
 
 export default class VictoryContainer extends React.Component {
   static displayName = "VictoryContainer";
@@ -20,12 +21,14 @@ export default class VictoryContainer extends React.Component {
     desc: PropTypes.string,
     portalComponent: PropTypes.element,
     responsive: PropTypes.bool,
-    standalone: PropTypes.bool
+    standalone: PropTypes.bool,
+    theme: PropTypes.object
   }
 
   static defaultProps = {
     portalComponent: <Portal/>,
-    responsive: true
+    responsive: true,
+    theme: VictoryTheme.grayscale
   }
 
   static contextTypes = {

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -222,11 +222,10 @@ export default class VictoryLabel extends React.Component {
       >
         {this.content.map((line, i) => {
           const style = this.style[i] || this.style[0];
-          const padding = style.padding || 0;
           const lastStyle = this.style[i - 1] || this.style[0];
           const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
           const textAnchor = style.textAnchor || this.textAnchor;
-          const dy = i ? (this.lineHeight * fontSize) + padding : undefined;
+          const dy = i ? (this.lineHeight * fontSize) : undefined;
           return (
             <tspan key={i} x={props.x} dy={dy} dx={this.dx} style={style} textAnchor={textAnchor}>
               {line}

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -19,18 +19,18 @@ export default class Area extends React.Component {
   };
 
   componentWillMount() {
-    const {style, areaPath, linePath} = this.calculateAttributes(this.props);
+    const {style, areaPaths, linePaths} = this.calculateAttributes(this.props);
     this.style = style;
-    this.areaPath = areaPath;
-    this.linePath = linePath;
+    this.areaPaths = areaPaths;
+    this.linePaths = linePaths;
   }
 
   shouldComponentUpdate(nextProps) {
-    const {style, areaPath, linePath} = this.calculateAttributes(nextProps);
-    if (areaPath !== this.areaPath || !isEqual(style, this.style)) {
+    const {style, areaPaths, linePaths} = this.calculateAttributes(nextProps);
+    if (!isEqual(linePaths, this.linePaths) || !isEqual(style, this.style)) {
       this.style = style;
-      this.areaPath = areaPath;
-      this.linePath = linePath;
+      this.areaPaths = areaPaths;
+      this.linePaths = linePaths;
       return true;
     }
     return false;
@@ -38,6 +38,7 @@ export default class Area extends React.Component {
 
   calculateAttributes(props) {
     const {style, data, active, scale} = props;
+    const dataSegments = this.getDataSegments(data);
     const xScale = scale.x;
     const yScale = scale.y;
     const interpolation = this.toNewName(props.interpolation);
@@ -52,9 +53,27 @@ export default class Area extends React.Component {
       .y((d) => yScale(d._y1));
     return {
       style: Helpers.evaluateStyle(assign({fill: "black"}, style), data, active),
-      areaPath: areaFunction(data),
-      linePath: lineFunction(data)
+      areaPaths: dataSegments.map((segment) => areaFunction(segment)),
+      linePaths: dataSegments.map((segment) => lineFunction(segment))
     };
+  }
+
+  getDataSegments(data) {
+    let segmentStartIndex = 0;
+    const segments = data.reduce((memo, datum, index) => {
+      const yDatum = datum.y1 !== undefined ? datum._y1 : datum._y;
+      if (yDatum === null || typeof yDatum === "undefined") {
+        memo = memo.concat([data.slice(segmentStartIndex, index)]);
+        segmentStartIndex = index + 1;
+      } else if (index === data.length - 1) {
+        memo = memo.concat([data.slice(segmentStartIndex, data.length)]);
+      }
+      return memo;
+    }, []);
+
+    return segments.filter((segment) => {
+      return Array.isArray(segment) && segment.length > 0;
+    });
   }
 
   toNewName(interpolation) {
@@ -64,47 +83,52 @@ export default class Area extends React.Component {
   }
 
   // Overridden in victory-core-native
-  renderArea(path, style, events) {
+  renderArea(paths, style, events) {
     const areaStroke = style.stroke ? "none" : style.fill;
     const areaStyle = assign({}, style, {stroke: areaStroke});
     const { role, shapeRendering, className } = this.props;
-    return (
-      <path
-        key="area"
-        style={areaStyle}
-        shapeRendering={shapeRendering || "auto"}
-        role={role || "presentation"}
-        d={path}
-        className={className}
-        {...events}
-      />
-    );
+    return paths.map((path, index) => {
+      return (
+        <path
+          key={`area-${index}`}
+          style={areaStyle}
+          shapeRendering={shapeRendering || "auto"}
+          role={role || "presentation"}
+          d={path}
+          className={className}
+          {...events}
+        />
+      );
+    });
   }
 
   // Overridden in victory-core-native
-  renderLine(path, style, events) {
+  renderLine(paths, style, events) {
     if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
-      return undefined;
+      return [];
     }
     const { role, shapeRendering, className } = this.props;
     const lineStyle = assign({}, style, {fill: "none"});
-    return (
-      <path
-        key="area-stroke"
-        shapeRendering={shapeRendering || "auto"}
-        style={lineStyle}
-        role={role || "presentation"}
-        d={path}
-        className={className}
-        {...events}
-      />
-    );
+    return paths.map((path, index) => {
+      return (
+        <path
+          key={`area-stroke-${index}`}
+          style={lineStyle}
+          shapeRendering={shapeRendering || "auto"}
+          role={role || "presentation"}
+          d={path}
+          className={className}
+          {...events}
+        />
+      );
+    });
   }
 
   render() {
     const { events, groupComponent } = this.props;
-    const area = this.renderArea(this.areaPath, this.style, events);
-    const line = this.renderLine(this.linePath, this.style, events);
-    return line ? React.cloneElement(groupComponent, {}, area, line) : area;
+    const areas = this.renderArea(this.areaPaths, this.style, events);
+    const lines = this.renderLine(this.linePaths, this.style, events);
+    const children = [...lines, ...areas];
+    return children.length === 1 ? children[0] : React.cloneElement(groupComponent, {}, children);
   }
 }

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -72,7 +72,7 @@ export default class Area extends React.Component {
     }, []);
 
     return segments.filter((segment) => {
-      return Array.isArray(segment) && segment.length > 0;
+      return Array.isArray(segment) && segment.length > 1;
     });
   }
 

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -6,6 +6,7 @@ import * as d3Shape from "d3-shape";
 export default class Area extends React.Component {
   static propTypes = {
     active: PropTypes.bool,
+    index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     className: PropTypes.string,
     data: PropTypes.array,
     events: PropTypes.object,

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -6,6 +6,7 @@ import * as d3Shape from "d3-shape";
 export default class Curve extends React.Component {
   static propTypes = {
     active: PropTypes.bool,
+    index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     className: PropTypes.string,
     data: PropTypes.array,
     events: PropTypes.object,

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -63,7 +63,7 @@ export default class Curve extends React.Component {
         memo = memo.concat([data.slice(segmentStartIndex, index)]);
         segmentStartIndex = index + 1;
       } else if (index === data.length - 1) {
-        memo = memo.concat([data.slice(segmentStartIndex, data.length)])
+        memo = memo.concat([data.slice(segmentStartIndex, data.length)]);
       }
       return memo;
     }, []);

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -69,7 +69,7 @@ export default class Curve extends React.Component {
     }, []);
 
     return segments.filter((segment) => {
-      return Array.isArray(segment) && segment.length > 0;
+      return Array.isArray(segment) && segment.length > 1;
     });
   }
 
@@ -82,6 +82,9 @@ export default class Curve extends React.Component {
 
   // Overridden in victory-core-native
   renderLine(path, style, events, index) { // eslint-disable-line max-params
+    if (!path) {
+      return null;
+    }
     const { role, shapeRendering, className } = this.props;
     return (
       <path

--- a/src/victory-shared-events/victory-shared-events.js
+++ b/src/victory-shared-events/victory-shared-events.js
@@ -1,4 +1,4 @@
-import { assign, isFunction, partialRight, defaults, fromPairs, reduce } from "lodash";
+import { assign, isFunction, partialRight, defaults, fromPairs } from "lodash";
 import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Events, Timer, Helpers } from "../victory-util/index";
 
@@ -119,7 +119,7 @@ export default class VictorySharedEvents extends React.Component {
     const {events, eventKey} = props;
     const childNames = Object.keys(this.baseProps);
     const alterChildren = (children) => {
-      return reduce(children, (memo, child, index) => {
+      return children.reduce((memo, child, index) => {
         if (child.props.children) {
           return memo.concat(React.cloneElement(
             child,

--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -127,9 +127,7 @@ export default {
         stroke: charcoal,
         strokeWidth: 2
       },
-      labels: assign({}, baseLabelStyles, {
-        textAnchor: "start"
-      })
+      labels: centeredLabelStyles
     }
   }, baseProps),
   pie: {
@@ -139,9 +137,7 @@ export default {
         stroke: "transparent",
         strokeWidth: 1
       },
-      labels: assign({}, baseLabelStyles, {
-        padding: 20
-      })
+      labels: assign({}, baseLabelStyles, { padding: 20 })
     },
     colorScale: colors,
     width: 400,
@@ -162,10 +158,7 @@ export default {
     colorScale: colors
   }, baseProps),
   tooltip: {
-    style: assign({}, centeredLabelStyles, {
-      padding: 5,
-      pointerEvents: "none"
-    }),
+    style: assign({}, centeredLabelStyles, { padding: 5, pointerEvents: "none" }),
     flyoutStyle: {
       stroke: charcoal,
       strokeWidth: 1,
@@ -182,10 +175,7 @@ export default {
         stroke: "transparent",
         strokeWidth: 0
       },
-      labels: assign({}, centeredLabelStyles, {
-        padding: 5,
-        pointerEvents: "none"
-      }),
+      labels: assign({}, centeredLabelStyles, { padding: 5, pointerEvents: "none" }),
       flyout: {
         stroke: charcoal,
         strokeWidth: 1,

--- a/src/victory-theme/material.js
+++ b/src/victory-theme/material.js
@@ -44,7 +44,9 @@ const baseLabelStyles = {
   fontSize,
   letterSpacing,
   padding,
-  fill: blueGrey700
+  fill: blueGrey700,
+  stroke: "transparent",
+  strokeWidth: 0
 };
 
 const centeredLabelStyles = assign({ textAnchor: "middle" }, baseLabelStyles);
@@ -93,8 +95,7 @@ export default {
         strokeLinejoin
       },
       tickLabels: assign({}, baseLabelStyles, {
-        fill: blueGrey700,
-        stroke: "transparent"
+        fill: blueGrey700
       })
     }
   }, baseProps),
@@ -131,10 +132,7 @@ export default {
         stroke: blueGrey700,
         strokeWidth: 2
       },
-      labels: assign({}, centeredLabelStyles, {
-        stroke: "transparent",
-        strokeWidth: 0
-      })
+      labels: centeredLabelStyles
     }
   }, baseProps),
   group: assign({
@@ -148,11 +146,7 @@ export default {
         stroke: blueGrey700,
         strokeWidth: 2
       },
-      labels: assign({}, baseLabelStyles, {
-        stroke: "transparent",
-        strokeWidth: 0,
-        textAnchor: "start"
-      })
+      labels: centeredLabelStyles
     }
   }, baseProps),
   pie: assign({
@@ -163,11 +157,7 @@ export default {
         stroke: blueGrey50,
         strokeWidth: 1
       },
-      labels: assign({}, baseLabelStyles, {
-        padding: 20,
-        stroke: "transparent",
-        strokeWidth: 0
-      })
+      labels: assign({}, baseLabelStyles, { padding: 20 })
     }
   }, baseProps),
   scatter: assign({
@@ -178,19 +168,14 @@ export default {
         stroke: "transparent",
         strokeWidth: 0
       },
-      labels: assign({}, centeredLabelStyles, {
-        stroke: "transparent"
-      })
+      labels: centeredLabelStyles
     }
   }, baseProps),
   stack: assign({
     colorScale: colors
   }, baseProps),
   tooltip: {
-    style: assign({}, centeredLabelStyles, {
-      padding: 5,
-      pointerEvents: "none"
-    }),
+    style: assign({}, centeredLabelStyles, { padding: 5, pointerEvents: "none" }),
     flyoutStyle: {
       stroke: grey900,
       strokeWidth: 1,
@@ -207,10 +192,7 @@ export default {
         stroke: "transparent",
         strokeWidth: 0
       },
-      labels: assign({}, centeredLabelStyles, {
-        padding: 5,
-        pointerEvents: "none"
-      }),
+      labels: assign({}, centeredLabelStyles, { padding: 5, pointerEvents: "none" }),
       flyout: {
         stroke: grey900,
         strokeWidth: 1,

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -20,6 +20,7 @@ export default class VictoryTooltip extends React.Component {
       PropTypes.bool,
       PropTypes.func
     ]),
+    activateData: PropTypes.bool,
     datum: PropTypes.object,
     data: PropTypes.array,
     events: PropTypes.object,
@@ -85,14 +86,14 @@ export default class VictoryTooltip extends React.Component {
   static defaultEvents = [{
     target: "data",
     eventHandlers: {
-      onMouseOver: () => {
+      onMouseOver: (targetProps) => {
         return [
           {
             target: "labels",
             mutation: () => ({ active: true })
           }, {
             target: "data",
-            mutation: () => ({ active: true })
+            mutation: () => targetProps.activateData ? ({ active: true }) : ({active: undefined})
           }
         ];
       },
@@ -100,10 +101,10 @@ export default class VictoryTooltip extends React.Component {
         return [
           {
             target: "labels",
-            mutation: () => null
+            mutation: () => ({active: undefined})
           }, {
             target: "data",
-            mutation: () => null
+            mutation: () => ({active: undefined})
           }
         ];
       }

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -222,7 +222,6 @@ export default class VictoryTooltip extends React.Component {
       const sign = textAnchor === "end" ? -1 : 1;
       return flyoutCenter.x - sign * (flyoutDimensions.width - labelSize.width);
     };
-    const padding = this.getLabelPadding(labelStyle);
     return defaults(
       {},
       labelComponent.props,
@@ -232,7 +231,7 @@ export default class VictoryTooltip extends React.Component {
         style: labelStyle,
         x: !labelStyle.textAnchor || labelStyle.textAnchor === "middle" ?
           flyoutCenter.x : getLabelX(),
-        y: flyoutCenter.y - padding,
+        y: flyoutCenter.y,
         verticalAnchor: "middle",
         angle: labelStyle.angle
       }

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -27,9 +27,13 @@ export default class VictoryTooltip extends React.Component {
     text: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
-      PropTypes.func
+      PropTypes.func,
+      PropTypes.array
     ]),
-    style: PropTypes.object,
+    style: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array
+    ]),
     flyoutStyle: PropTypes.object,
     x: PropTypes.number,
     y: PropTypes.number,

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -100,10 +100,10 @@ export default class VictoryTooltip extends React.Component {
         return [
           {
             target: "labels",
-            mutation: () => ({ active: false })
+            mutation: () => null
           }, {
             target: "data",
-            mutation: () => ({ active: false })
+            mutation: () => null
           }
         ];
       }

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -88,9 +88,7 @@ export default {
 
       // returns all eventKeys to modify for a targeted childName
       const getKeys = (childName) => {
-        if (baseProps.all || baseProps[childName] && baseProps[childName].all) {
-          return "all";
-        } else if (eventReturn.eventKey === "all") {
+        if (eventReturn.eventKey === "all") {
           return baseProps[childName] ?
             without(Object.keys(baseProps[childName]), "parent") :
             without(Object.keys(baseProps), "parent");

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -1,6 +1,4 @@
-import {
-  assign, extend, merge, partial, isEmpty, isFunction, without, reduce, map, keys
-} from "lodash";
+import { assign, extend, merge, partial, isEmpty, isFunction, without } from "lodash";
 
 export default {
   /* Returns all own and shared events that should be attached to a single target element,
@@ -13,7 +11,7 @@ export default {
     // Returns all events that apply to a particular target element
     const getEventsByTarget = (events) => {
       const getSelectedEvents = () => {
-        const targetEvents = reduce(events, (memo, event) => {
+        const targetEvents = events.reduce((memo, event) => {
           if (event.target !== undefined) {
             return `${event.target}` === `${target}` ? memo.concat(event) : memo;
           }
@@ -32,7 +30,7 @@ export default {
       };
 
       const selectedEvents = getSelectedEvents();
-      return Array.isArray(selectedEvents) && reduce(selectedEvents, (memo, event) => {
+      return Array.isArray(selectedEvents) && selectedEvents.reduce((memo, event) => {
         return event ? assign(memo, event.eventHandlers) : memo;
       }, {});
     };
@@ -94,11 +92,11 @@ export default {
           return "all";
         } else if (eventReturn.eventKey === "all") {
           return baseProps[childName] ?
-            without(keys(baseProps[childName]), "parent") :
-            without(keys(baseProps), "parent");
+            without(Object.keys(baseProps[childName]), "parent") :
+            without(Object.keys(baseProps), "parent");
         } else if (eventReturn.eventKey === undefined && eventKey === "parent") {
           return baseProps[childName] ?
-            keys(baseProps[childName]) : keys(baseProps);
+            Object.keys(baseProps[childName]) : Object.keys(baseProps);
         }
         return eventReturn.eventKey !== undefined ? eventReturn.eventKey : eventKey;
       };
@@ -126,7 +124,7 @@ export default {
       const getReturnByChild = (childName) => {
         const mutationKeys = getKeys(childName);
         return Array.isArray(mutationKeys) ?
-          reduce(mutationKeys, (memo, key) => {
+          mutationKeys.reduce((memo, key) => {
             return assign(memo, getMutationObject(key, childName));
           }, {}) :
           getMutationObject(mutationKeys, childName);
@@ -134,8 +132,8 @@ export default {
 
       // returns an entire mutated state for all children
       const allChildNames = childNames === "all" ?
-        without(keys(baseProps), "parent") : childNames;
-      return Array.isArray(allChildNames) ? reduce(allChildNames, (memo, childName) => {
+        without(Object.keys(baseProps), "parent") : childNames;
+      return Array.isArray(allChildNames) ? allChildNames.reduce((memo, childName) => {
         return assign(memo, getReturnByChild(childName));
       }, {}) : getReturnByChild(allChildNames);
     };
@@ -143,7 +141,7 @@ export default {
     // Parses an array of event returns into a single state mutation
     const parseEventReturn = (eventReturn, eventKey) => {
       return Array.isArray(eventReturn) ?
-        reduce(eventReturn, (memo, props) => {
+        eventReturn.reduce((memo, props) => {
           memo = merge({}, memo, parseEvent(props, eventKey));
           return memo;
         }, {}) :
@@ -153,7 +151,7 @@ export default {
     const compileCallbacks = (eventReturn) => {
       const getCallback = (obj) => isFunction(obj.callback) && obj.callback;
       const callbacks = Array.isArray(eventReturn) ?
-        map(eventReturn, (evtObj) => getCallback(evtObj)) : [getCallback(eventReturn)];
+        eventReturn.map((evtObj) => getCallback(evtObj)) : [getCallback(eventReturn)];
       const callbackArray = callbacks.filter((callback) => callback !== false);
       return callbackArray.length ?
         () => callbackArray.forEach((callback) => callback()) : undefined;
@@ -170,7 +168,7 @@ export default {
     };
 
     // returns a new events object with enhanced event handlers
-    return reduce(keys(events), (memo, event) => {
+    return Object.keys(events).reduce((memo, event) => {
       memo[event] = onEvent;
       return memo;
     }, {});
@@ -181,7 +179,7 @@ export default {
    */
   getPartialEvents(events, eventKey, childProps) {
     return events ?
-      reduce(keys(events), (memo, eventName) => {
+      Object.keys(events).reduce((memo, eventName) => {
         /* eslint max-params: 0 */
         memo[eventName] = partial(
           events[eventName],
@@ -214,7 +212,7 @@ export default {
    * i.e. any static `defaultEvents` on `labelComponent` will be returned
   */
   getComponentEvents(props, components) {
-    const events = Array.isArray(components) && reduce(components, (memo, componentName) => {
+    const events = Array.isArray(components) && components.reduce((memo, componentName) => {
       const component = props[componentName];
       const componentEvents = component && component.type && component.type.defaultEvents;
       memo = Array.isArray(componentEvents) ? memo.concat(...componentEvents) : memo;

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -106,14 +106,14 @@ export default {
   },
 
   /**
-   * @param {Object} props: axis component props
+   * @param {Array} children: an array of child components
    * @param {Function} iteratee: a function with arguments "child", "childName", and "parent"
    * @returns {Array} returns an array of results from calling the iteratee on all nested children
    */
-  reduceChildren(props, iteratee) {
+  reduceChildren(children, iteratee) {
     let childIndex = 0;
-    const traverseChildren = (children, parent) => {
-      return reduce(children, (memo, child) => {
+    const traverseChildren = (childArray, parent) => {
+      return reduce(childArray, (memo, child) => {
         const childName = child.props.name || childIndex;
         childIndex++;
         if (child.props && child.props.children) {
@@ -127,6 +127,6 @@ export default {
         return memo;
       }, []);
     };
-    return traverseChildren(React.Children.toArray(props.children));
+    return traverseChildren(children);
   }
 };

--- a/src/victory-util/prop-types.js
+++ b/src/victory-util/prop-types.js
@@ -76,7 +76,7 @@ export default {
       if (process.env.NODE_ENV !== "production") {
         /* eslint-disable no-console */
         if (typeof console !== "undefined" && console.error) {
-          if (props[propName] !== null) {
+          if (props[propName] !== null && props[propName] !== undefined) {
             console.error(false,
               `"${propName}" property of "${componentName}" has been deprecated ${explanation}`);
           }

--- a/src/victory-util/textsize.js
+++ b/src/victory-util/textsize.js
@@ -93,7 +93,7 @@ const convertLengthToPixels = (length, fontSize) => {
 
 const _prepareParams = (inputStyle, index) => {
   const lineStyle = Array.isArray(inputStyle) ? inputStyle[index] : inputStyle;
-  const style = defaults(lineStyle, defaultStyle);
+  const style = defaults({}, lineStyle, defaultStyle);
   return merge({}, style, {
     characterConstant: style.characterConstant || _getFontCharacterConstant(style.fontFamily),
     letterSpacing: convertLengthToPixels(style.letterSpacing, style.fontSize),

--- a/src/victory-util/textsize.js
+++ b/src/victory-util/textsize.js
@@ -53,37 +53,21 @@ const defaultStyle = {
   fontFamily: ""
 };
 
-const degreeToRadian = (angle) => angle * Math.PI / 180;
+const _degreeToRadian = (angle) => angle * Math.PI / 180;
 
-const getFontCharacterConstant = (fontFamily) => {
+const _getFontCharacterConstant = (fontFamily) => {
   const firstFont = fontFamily.split(",")[0].replace(/'|"/g, "");
   return fontDictionary[firstFont] || coefficients.averageFontConstant;
 };
 
-const splitToLines = (text) => text.toString().split(/\r\n|\r|\n/g);
+const _splitToLines = (text) => {
+  return Array.isArray(text) ? text : text.toString().split(/\r\n|\r|\n/g);
+};
 
-const getWidestString = (strings) => strings.reduce((max, elem) =>
-  max.length >= elem.length ? max : elem
-);
-
-const getSizeWithRotate = (axisSize, dependentSize, angle) => {
-  const angleInRadian = degreeToRadian(angle);
+const _getSizeWithRotate = (axisSize, dependentSize, angle) => {
+  const angleInRadian = _degreeToRadian(angle);
   return Math.abs(Math.cos(angleInRadian) * axisSize)
     + Math.abs(Math.sin(angleInRadian) * dependentSize);
-};
-
-const approximateTextWidthInternal = (text, style) => {
-  const strLength = getWidestString(splitToLines(text.toString())).length;
-  return (strLength * style.fontSize / style.characterConstant)
-    + style.letterSpacing * (Math.max(strLength - 1, 0));
-};
-
-const approximateTextHeightInternal = (text, style) => {
-  const splittedTextArray = splitToLines(text);
-  const lineCount = splittedTextArray.length;
-  const lineHeightNumber = style.fontSize * coefficients.lineCapitalCoef;
-  const emptySpace = style.fontSize * coefficients.lineSpaceHeightCoef;
-  return style.lineHeight * (lineHeightNumber * lineCount + emptySpace * (lineCount - 1));
 };
 
 /**
@@ -107,15 +91,34 @@ const convertLengthToPixels = (length, fontSize) => {
   return result;
 };
 
-const prepareParams = (inputStyle) => {
-  const style = defaults(inputStyle, defaultStyle);
+const _prepareParams = (inputStyle, index) => {
+  const lineStyle = Array.isArray(inputStyle) ? inputStyle[index] : inputStyle;
+  const style = defaults(lineStyle, defaultStyle);
   return merge({}, style, {
-    characterConstant: style.characterConstant || getFontCharacterConstant(style.fontFamily),
+    characterConstant: style.characterConstant || _getFontCharacterConstant(style.fontFamily),
     letterSpacing: convertLengthToPixels(style.letterSpacing, style.fontSize),
     fontSize: typeof (style.fontSize) === "number"
       ? style.fontSize
       : convertLengthToPixels(String(style.fontSize))
   });
+};
+
+const _approximateTextWidthInternal = (text, style) => {
+  const widths = _splitToLines(text).map((line, index) => {
+    const len = line.toString().length;
+    const {fontSize, characterConstant, letterSpacing} = _prepareParams(style, index);
+    return (len * fontSize / characterConstant) + letterSpacing * (Math.max(len - 1, 0));
+  });
+  return Math.max(...widths);
+};
+
+const _approximateTextHeightInternal = (text, style) => {
+  return _splitToLines(text).reduce((total, line, index) => {
+    const lineStyle = _prepareParams(style, index);
+    const height = lineStyle.fontSize * coefficients.lineCapitalCoef;
+    const emptySpace = index === 0 ? 0 : lineStyle.fontSize * coefficients.lineSpaceHeightCoef;
+    return total + lineStyle.lineHeight * (height + emptySpace);
+  }, 0);
 };
 
 /**
@@ -131,11 +134,11 @@ const prepareParams = (inputStyle) => {
  * @returns {number} Approximate text label height.
 */
 const approximateTextSize = (text, style) => {
-  const params = prepareParams(style);
-  const height = approximateTextHeightInternal(text, params);
-  const width = approximateTextWidthInternal(text, params);
-  const widthWithRotate = getSizeWithRotate(width, height, params.angle);
-  const heightWithRotate = getSizeWithRotate(height, width, params.angle);
+  const angle = Array.isArray(style) ? style[0] && style[0].angle : style && style.angle;
+  const height = _approximateTextHeightInternal(text, style);
+  const width = _approximateTextWidthInternal(text, style);
+  const widthWithRotate = angle ? _getSizeWithRotate(width, height, angle) : width;
+  const heightWithRotate = angle ? _getSizeWithRotate(height, width, angle) : height;
   return {
     width: widthWithRotate * coefficients.widthOverlapCoef,
     height: heightWithRotate * coefficients.heightOverlapCoef

--- a/test/client/spec/victory-container/victory-container.spec.js
+++ b/test/client/spec/victory-container/victory-container.spec.js
@@ -18,9 +18,9 @@ describe("components/victory-container", () => {
     expect(output.prop("role")).to.contain("img");
   });
 
-  it("renders an svg with a default title node", () => {
+  it("renders an svg with a title node", () => {
     const wrapper = shallow(
-      <VictoryContainer />
+      <VictoryContainer title="Victory Chart"/>
     );
     const output = wrapper.find("title");
     expect(output.html()).to.contain("Victory Chart");

--- a/test/client/spec/victory-label/victory-label.spec.js
+++ b/test/client/spec/victory-label/victory-label.spec.js
@@ -28,7 +28,7 @@ describe("components/victory-label", () => {
     const wrapper = shallow(
       <VictoryLabel style={{fontSize: "10px"}} text={"such text, wow"}/>
     );
-    const output = wrapper.find("text");
+    const output = wrapper.find("tspan");
     expect(output.prop("style")).to.contain({fontSize: 10});
   });
 
@@ -36,8 +36,37 @@ describe("components/victory-label", () => {
     const wrapper = shallow(
       <VictoryLabel style={{fontSize: "foo"}} text={"such text, wow"}/>
     );
-    const output = wrapper.find("text");
+    const output = wrapper.find("tspan");
     expect(output.prop("style")).to.contain({fontSize: 14});
+  });
+
+  it("renders an array of text as seperate tspans", () => {
+    const wrapper = shallow(
+      <VictoryLabel text={["one", "two", "three"]}/>
+    );
+    const output = wrapper.find("tspan");
+    expect(output.length).to.equal(3);
+  });
+
+  it("renders splits newlines into tspans", () => {
+    const wrapper = shallow(
+      <VictoryLabel text={"one\ntwo\nthree"}/>
+    );
+    const output = wrapper.find("tspan");
+    expect(output.length).to.equal(3);
+  });
+
+  it("renders styles tspand independently when `style` is an array", () => {
+    const fill = ["red", "green", "blue"];
+    const wrapper = shallow(
+      <VictoryLabel text={"one\ntwo\nthree"}
+        style={[{fill: fill[0]}, {fill: fill[1]}, {fill: fill[2]}]}
+      />
+    );
+    const output = wrapper.find("tspan");
+    output.forEach((tspan, index) => {
+      expect(tspan.prop("style")).to.contain({fill: fill[index]});
+    });
   });
 
   describe("event handling", () => {


### PR DESCRIPTION
This PR supports https://github.com/FormidableLabs/victory-chart/pull/432

This PR:

- Adds a `theme` prop to `VictoryContainer` so that custom containers may pick up themes from their parents
- Removes default `title` and `desc` props from `VictoryContainer`
- Adds support for providing `text` as an array for `VictoryLabel`
- Adds support for providing `style` as an array for `VictoryLabel` so that each line of a multi-line label may be styled independently
- Changes how null data values are handled by `Area` and `Curve` primitives
- Adds a `reduceChildren` method to `Helpers` to ensure order consistency when working with nested children
- `VictoryTooltip` no longer automatically adds the `active` prop to data when hovered. To turn this behavior on, set the new `activateData` boolean prop on `VictoryTooltip`


