### PR TITLE
Feature/data sorting prop

### DIFF
--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -90,7 +90,25 @@ export default {
           typeof y === "string" ? { _y: stringMap.y[y], yName: y } : {}
         );
     });
-    return this.cleanData(data, props);
+
+    const sortedData = this.sortData(data, props.dataSort);
+
+    return this.cleanData(sortedData, props);
+  },
+
+  /**
+   * Returns sorted data. If no sort function is provided, dataset is returned unaltered.
+   *
+   * @param {Array} dataset: the original domain
+   * @param {Function} sortFn: the sort function
+   * @returns {Array} the sorted data
+   */
+  sortData(dataset, sortFn) {
+    if (!sortFn || !isFunction(sortFn)) {
+      return dataset;
+    }
+
+    return dataset.sort(sortFn);
   },
 
   /**

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -97,18 +97,18 @@ export default {
   },
 
   /**
-   * Returns sorted data. If no sort function is provided, dataset is returned unaltered.
-   *
+   * Returns sorted data. If no comparator is provided, dataset is returned unaltered.
+   * Comparator function must conform to the standard javascript comparator.
    * @param {Array} dataset: the original domain
-   * @param {Function} sortFn: the sort function
+   * @param {Function} comparator: the sort function
    * @returns {Array} the sorted data
    */
-  sortData(dataset, sortFn) {
-    if (!sortFn || !isFunction(sortFn)) {
+  sortData(dataset, comparator) {
+    if (!comparator || !isFunction(comparator)) {
       return dataset;
     }
 
-    return dataset.sort(sortFn);
+    return dataset.sort(comparator);
   },
 
   /**

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -1,4 +1,4 @@
-import { assign, uniq, range, last, isFunction, property } from "lodash";
+import { assign, uniq, range, last, isFunction, property, sortBy } from "lodash";
 import Helpers from "./helpers";
 import Collection from "./collection";
 import Log from "./log";
@@ -97,18 +97,18 @@ export default {
   },
 
   /**
-   * Returns sorted data. If no comparator is provided, dataset is returned unaltered.
-   * Comparator function must conform to the standard javascript comparator.
+   * Returns sorted data. If no sort keys are provided, data is returned unaltered.
+   * Sort keys should correspond to the `iteratees` argument in lodash `sortBy` function.
    * @param {Array} dataset: the original domain
-   * @param {Function} comparator: the sort function
+   * @param {Function} sortKeys: the sort keys
    * @returns {Array} the sorted data
    */
-  sortData(dataset, comparator) {
-    if (!comparator || !isFunction(comparator)) {
+  sortData(dataset, sortKeys) {
+    if (!sortKeys) {
       return dataset;
     }
 
-    return dataset.sort(comparator);
+    return sortBy(dataset, sortKeys);
   },
 
   /**

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -91,24 +91,24 @@ export default {
         );
     });
 
-    const sortedData = this.sortData(data, props.dataSort);
+    const sortedData = this.sortData(data, props.sortKey);
 
     return this.cleanData(sortedData, props);
   },
 
   /**
    * Returns sorted data. If no sort keys are provided, data is returned unaltered.
-   * Sort keys should correspond to the `iteratees` argument in lodash `sortBy` function.
+   * Sort key should correspond to the `iteratees` argument in lodash `sortBy` function.
    * @param {Array} dataset: the original domain
-   * @param {Function} sortKeys: the sort keys
+   * @param {Function} sortKey: the sort key
    * @returns {Array} the sorted data
    */
-  sortData(dataset, sortKeys) {
-    if (!sortKeys) {
+  sortData(dataset, sortKey) {
+    if (!sortKey) {
       return dataset;
     }
 
-    return sortBy(dataset, sortKeys);
+    return sortBy(dataset, sortKey);
   },
 
   /**

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -168,6 +168,33 @@ describe("helpers/data", () => {
       expect(returnData).to.eql(expectedReturnWithEventKeys);
     });
 
+    it("does not sort data when function not passed", () => {
+      const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
+      const props = {data};
+
+      const returnData = Data.getData(props);
+
+      expect(returnData).to.eql([
+        {_x: 2, x: 2, _y: 2, y: 2, eventKey: 0},
+        {_x: 1, x: 1, _y: 3, y: 3, eventKey: 1},
+        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2},
+      ]);
+    });
+
+    it("sorts data according to passed function", () => {
+      const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
+      const sortFn = (datumA, datumB) => { return datumA._x - datumB._x; };
+      const props = {data, dataSort: sortFn};
+
+      const returnData = Data.getData(props);
+
+      expect(returnData).to.eql([
+        {_x: 1, x: 1, _y: 3, y: 3, eventKey: 0},
+        {_x: 2, x: 2, _y: 2, y: 2, eventKey: 1},
+        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2},
+      ]);
+    });
+
     it("generates a dataset from domain", () => {
       const generatedReturn = [{x: 0, y: 0}, {x: 10, y: 10}];
       const expectedReturn = [{_x: 0, x: 0, _y: 0, y: 0}, {_x: 10, x: 10, _y: 10, y: 10}];

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -183,8 +183,8 @@ describe("helpers/data", () => {
 
     it("sorts data according to passed function", () => {
       const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
-      const sortFn = (datumA, datumB) => { return datumA._x - datumB._x; };
-      const props = {data, dataSort: sortFn};
+      const comparator = (datumA, datumB) => { return datumA._x - datumB._x; };
+      const props = {data, dataSort: comparator};
 
       const returnData = Data.getData(props);
 

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -183,8 +183,8 @@ describe("helpers/data", () => {
 
     it("sorts data according to passed function", () => {
       const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
-      const sortKeys = ["_x"];
-      const props = {data, dataSort: sortKeys};
+      const sortKey = ["_x"];
+      const props = {data, sortKey};
 
       const returnData = Data.getData(props);
 

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -177,7 +177,7 @@ describe("helpers/data", () => {
       expect(returnData).to.eql([
         {_x: 2, x: 2, _y: 2, y: 2, eventKey: 0},
         {_x: 1, x: 1, _y: 3, y: 3, eventKey: 1},
-        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2},
+        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2}
       ]);
     });
 
@@ -191,7 +191,7 @@ describe("helpers/data", () => {
       expect(returnData).to.eql([
         {_x: 1, x: 1, _y: 3, y: 3, eventKey: 0},
         {_x: 2, x: 2, _y: 2, y: 2, eventKey: 1},
-        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2},
+        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2}
       ]);
     });
 

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -183,8 +183,8 @@ describe("helpers/data", () => {
 
     it("sorts data according to passed function", () => {
       const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
-      const comparator = (datumA, datumB) => { return datumA._x - datumB._x; };
-      const props = {data, dataSort: comparator};
+      const sortKeys = ["_x"];
+      const props = {data, dataSort: sortKeys};
 
       const returnData = Data.getData(props);
 


### PR DESCRIPTION
https://github.com/FormidableLabs/victory/issues/254

Supports:
https://github.com/FormidableLabs/victory-pie/pull/129
https://github.com/FormidableLabs/victory-docs/pull/256

Implements access to a `dataSort` prop which resorts data according to a comparator function. 

General thought - it might be a good idea for us to start marking private methods with `_privateMethod`. Being new to the project, I end up having to do a lot of `grep`ing to find out what the actual public interface of a module is intended to be. 