### PR TITLE
Feature/ensure consistent api

### DIFF
--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -72,6 +72,7 @@ export default {
       x: this.createStringMap(props, "x"),
       y: this.createStringMap(props, "y")
     };
+
     const accessor = {
       x: Helpers.createAccessor(props.x !== undefined ? props.x : "x"),
       y: Helpers.createAccessor(props.y !== undefined ? props.y : "y")
@@ -108,10 +109,9 @@ export default {
       return dataset;
     }
 
-    if (!Array.isArray(sortKey)) {
-      sortKey = [sortKey];
+    if (sortKey === "x" || sortKey === "y") {
+      sortKey = `_${sortKey}`;
     }
-
 
     return sortBy(dataset, sortKey);
   },

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -108,7 +108,10 @@ export default {
       return dataset;
     }
 
-    sortKey = Array(sortKey);
+    if (!Array.isArray(sortKey)) {
+      sortKey = [sortKey];
+    }
+
 
     return sortBy(dataset, sortKey);
   },

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -100,13 +100,15 @@ export default {
    * Returns sorted data. If no sort keys are provided, data is returned unaltered.
    * Sort key should correspond to the `iteratees` argument in lodash `sortBy` function.
    * @param {Array} dataset: the original domain
-   * @param {Function} sortKey: the sort key
+   * @param {Array} sortKey: the sort key
    * @returns {Array} the sorted data
    */
   sortData(dataset, sortKey) {
     if (!sortKey) {
       return dataset;
     }
+
+    sortKey = Array(sortKey);
 
     return sortBy(dataset, sortKey);
   },

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -100,8 +100,8 @@ export default {
   /**
    * Returns sorted data. If no sort keys are provided, data is returned unaltered.
    * Sort key should correspond to the `iteratees` argument in lodash `sortBy` function.
-   * @param {Array} dataset: the original domain
-   * @param {Array} sortKey: the sort key
+   * @param {Array} dataset: the original dataset
+   * @param {mixed} sortKey: the sort key. Type is whatever lodash permits for `sortBy`
    * @returns {Array} the sorted data
    */
   sortData(dataset, sortKey) {

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -109,6 +109,7 @@ export default {
       return dataset;
     }
 
+    // Ensures previous VictoryLine api for sortKey prop stays consistent
     if (sortKey === "x" || sortKey === "y") {
       sortKey = `_${sortKey}`;
     }

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -72,7 +72,6 @@ export default {
       x: this.createStringMap(props, "x"),
       y: this.createStringMap(props, "y")
     };
-
     const accessor = {
       x: Helpers.createAccessor(props.x !== undefined ? props.x : "x"),
       y: Helpers.createAccessor(props.y !== undefined ? props.y : "y")

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -168,7 +168,7 @@ describe("helpers/data", () => {
       expect(returnData).to.eql(expectedReturnWithEventKeys);
     });
 
-    it("does not sort data when function not passed", () => {
+    it("does not sort data when sort key not passed", () => {
       const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
       const props = {data};
 
@@ -181,9 +181,9 @@ describe("helpers/data", () => {
       ]);
     });
 
-    it("sorts data according to passed function", () => {
+    it("sorts data according to sort key", () => {
       const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
-      const sortKey = ["_x"];
+      const sortKey = "_x";
       const props = {data, sortKey};
 
       const returnData = Data.getData(props);

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -207,9 +207,9 @@ describe("helpers/data", () => {
       const returnDataX = Data.getData({data, sortKey: "x"});
 
       expect(returnDataX).to.eql([
-        {_x: 1, x: 20, _y: 3, y: 3, y: 20, eventKey: 0},
-        {_x: 2, x: 10, _y: 2, y: 2, y: 10, eventKey: 1},
-        {_x: 3, x: 30, _y: 1, y: 1, y: 30, eventKey: 2}
+        {_x: 1, x: 20, _y: 3, y: 20, eventKey: 0},
+        {_x: 2, x: 10, _y: 2, y: 10, eventKey: 1},
+        {_x: 3, x: 30, _y: 1, y: 30, eventKey: 2}
       ]);
 
       const returnDataY = Data.getData({data, sortKey: "y"});

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -170,9 +170,8 @@ describe("helpers/data", () => {
 
     it("does not sort data when sort key not passed", () => {
       const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
-      const props = {data};
 
-      const returnData = Data.getData(props);
+      const returnData = Data.getData({data});
 
       expect(returnData).to.eql([
         {_x: 2, x: 2, _y: 2, y: 2, eventKey: 0},
@@ -182,30 +181,42 @@ describe("helpers/data", () => {
     });
 
     it("sorts data according to sort key", () => {
-      const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
-      const sortKey = ["_x"];
-      const props = {data, sortKey};
+      const data = [
+        {x: 1, y: 1, order: 2},
+        {x: 3, y: 3, order: 1},
+        {x: 2, y: 2, order: 3}
+      ];
 
-      const returnData = Data.getData(props);
+      const returnData = Data.getData({data, sortKey: "order"});
 
       expect(returnData).to.eql([
-        {_x: 1, x: 1, _y: 3, y: 3, eventKey: 0},
-        {_x: 2, x: 2, _y: 2, y: 2, eventKey: 1},
-        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2}
+        {_x: 3, x: 3, _y: 3, y: 3, order: 1, eventKey: 0},
+        {_x: 1, x: 1, _y: 1, y: 1, order: 2, eventKey: 1},
+        {_x: 2, x: 2, _y: 2, y: 2, order: 3, eventKey: 2}
       ]);
     });
 
-    it("sorts data according to sort key when sort key is not array", () => {
-      const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
-      const sortKey = "_x";
-      const props = {data, sortKey};
+    it("sorts data according to evaluated sort key when sort key is x or y", () => {
+      const data = [
+        {_x: 2, x: 10, _y: 2, y: 10},
+        {_x: 1, x: 20, _y: 3, y: 20},
+        {_x: 3, x: 30, _y: 1, y: 30}
+      ];
 
-      const returnData = Data.getData(props);
+      const returnDataX = Data.getData({data, sortKey: "x"});
 
-      expect(returnData).to.eql([
-        {_x: 1, x: 1, _y: 3, y: 3, eventKey: 0},
-        {_x: 2, x: 2, _y: 2, y: 2, eventKey: 1},
-        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2}
+      expect(returnDataX).to.eql([
+        {_x: 1, x: 20, _y: 3, y: 3, y: 20, eventKey: 0},
+        {_x: 2, x: 10, _y: 2, y: 2, y: 10, eventKey: 1},
+        {_x: 3, x: 30, _y: 1, y: 1, y: 30, eventKey: 2}
+      ]);
+
+      const returnDataY = Data.getData({data, sortKey: "y"});
+
+      expect(returnDataY).to.eql([
+        {_x: 3, x: 30, _y: 1, y: 30, eventKey: 0},
+        {_x: 2, x: 10, _y: 2, y: 10, eventKey: 1},
+        {_x: 1, x: 20, _y: 3, y: 20, eventKey: 2}
       ]);
     });
 

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -196,6 +196,7 @@ describe("helpers/data", () => {
       ]);
     });
 
+    // Ensures previous VictoryLine api for sortKey prop stays consistent
     it("sorts data according to evaluated sort key when sort key is x or y", () => {
       const data = [
         {_x: 2, x: 10, _y: 2, y: 10},

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -183,6 +183,20 @@ describe("helpers/data", () => {
 
     it("sorts data according to sort key", () => {
       const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
+      const sortKey = ["_x"];
+      const props = {data, sortKey};
+
+      const returnData = Data.getData(props);
+
+      expect(returnData).to.eql([
+        {_x: 1, x: 1, _y: 3, y: 3, eventKey: 0},
+        {_x: 2, x: 2, _y: 2, y: 2, eventKey: 1},
+        {_x: 3, x: 3, _y: 1, y: 1, eventKey: 2}
+      ]);
+    });
+
+    it("sorts data according to sort key when sort key is not array", () => {
+      const data = [{x: 2, y: 2}, {x: 1, y: 3}, {x: 3, y: 1}];
       const sortKey = "_x";
       const props = {data, sortKey};
 


### PR DESCRIPTION
`sortKey` already existing on `VictoryLine` was causing a problem for integrating `sortKey` consistently across all components. Changing the api slightly to allow all sorting logic to go through `Data.getData`

https://github.com/FormidableLabs/victory/issues/254