### PR TITLE
Feature/add point specs

### DIFF
--- a/test/client/spec/victory-primitives/point.spec.js
+++ b/test/client/spec/victory-primitives/point.spec.js
@@ -1,12 +1,13 @@
+/* global sinon */
+
 import React from "react";
 import { shallow } from "enzyme";
 import Point from "src/victory-primitives/point";
 import pathHelpers from "src/victory-primitives/path-helpers";
-import { keys } from "lodash";
 
 describe("victory-primitives/point", () => {
-  var sandbox;
-  var baseProps;
+  let sandbox;
+  let baseProps;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -31,14 +32,14 @@ describe("victory-primitives/point", () => {
       "plus",
       "star"
     ].forEach((symbol) => {
-      const stub = sandbox.stub(pathHelpers, symbol).returns(symbol + " symbol");
+      const stub = sandbox.stub(pathHelpers, symbol).returns(`${symbol} symbol`);
       const props = Object.assign({}, baseProps, {symbol});
       const wrapper = shallow(<Point {...props}/>);
       const directions = wrapper.render().find("path").attr("d");
 
       expect(stub.callCount).to.eql(1);
       expect(stub.getCall(0).args).to.eql([5, 10, 1]);
-      expect(directions).to.eql(symbol + " symbol");
+      expect(directions).to.eql(`${symbol} symbol`);
     });
   });
 });

--- a/test/client/spec/victory-primitives/point.spec.js
+++ b/test/client/spec/victory-primitives/point.spec.js
@@ -21,24 +21,24 @@ describe("victory-primitives/point", () => {
     sandbox.restore();
   });
 
-  it.only("should render the appropriate symbol", () => {
-    const circleStub = sandbox.stub(pathHelpers, "circle").returns("circle symbol");
-    const squareStub = sandbox.stub(pathHelpers, "square").returns("square symbol");
-    const circleProps = Object.assign({}, baseProps, {symbol: "circle"});
-    const squareProps = Object.assign({}, baseProps, {symbol: "square"});
+  it("should render the appropriate symbol", () => {
+    [
+      "circle",
+      "square",
+      "diamond",
+      "triangleDown",
+      "triangleUp",
+      "plus",
+      "star"
+    ].forEach((symbol) => {
+      const stub = sandbox.stub(pathHelpers, symbol).returns(symbol + " symbol");
+      const props = Object.assign({}, baseProps, {symbol});
+      const wrapper = shallow(<Point {...props}/>);
+      const directions = wrapper.render().find("path").attr("d");
 
-    const circleWrapper = shallow(<Point {...circleProps}/>);
-    const squareWrapper = shallow(<Point {...squareProps}/>);
-    const circleDirections = circleWrapper.render().find("path").attr("d");
-    const squareDirections = squareWrapper.render().find("path").attr("d");
-
-    expect(circleStub.callCount).to.eql(1);
-    expect(circleStub.getCall(0).args).to.eql([5, 10, 1]);
-    expect(circleDirections).to.eql("circle symbol");
-
-    expect(squareStub.callCount).to.eql(1);
-    expect(squareStub.getCall(0).args).to.eql([5, 10, 1]);
-    expect(squareDirections).to.eql("square symbol");
-
+      expect(stub.callCount).to.eql(1);
+      expect(stub.getCall(0).args).to.eql([5, 10, 1]);
+      expect(directions).to.eql(symbol + " symbol");
+    });
   });
 });

--- a/test/client/spec/victory-primitives/point.spec.js
+++ b/test/client/spec/victory-primitives/point.spec.js
@@ -1,0 +1,44 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Point from "src/victory-primitives/point";
+import pathHelpers from "src/victory-primitives/path-helpers";
+import { keys } from "lodash";
+
+describe("victory-primitives/point", () => {
+  var sandbox;
+  var baseProps;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    baseProps = {
+      x: 5,
+      y: 10,
+      size: 1
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it.only("should render the appropriate symbol", () => {
+    const circleStub = sandbox.stub(pathHelpers, "circle").returns("circle symbol");
+    const squareStub = sandbox.stub(pathHelpers, "square").returns("square symbol");
+    const circleProps = Object.assign({}, baseProps, {symbol: "circle"});
+    const squareProps = Object.assign({}, baseProps, {symbol: "square"});
+
+    const circleWrapper = shallow(<Point {...circleProps}/>);
+    const squareWrapper = shallow(<Point {...squareProps}/>);
+    const circleDirections = circleWrapper.render().find("path").attr("d");
+    const squareDirections = squareWrapper.render().find("path").attr("d");
+
+    expect(circleStub.callCount).to.eql(1);
+    expect(circleStub.getCall(0).args).to.eql([5, 10, 1]);
+    expect(circleDirections).to.eql("circle symbol");
+
+    expect(squareStub.callCount).to.eql(1);
+    expect(squareStub.getCall(0).args).to.eql([5, 10, 1]);
+    expect(squareDirections).to.eql("square symbol");
+
+  });
+});


### PR DESCRIPTION
Adds basic coverage for point rendering (part of this was already covered by path helper specs so these can be stubbed for simplicity). 