### PR TITLE
Clip container

### DIFF
--- a/src/victory-clip-container/victory-clip-container.js
+++ b/src/victory-clip-container/victory-clip-container.js
@@ -1,5 +1,7 @@
 import React, { PropTypes } from "react";
+import { defaults } from "lodash";
 import { ClipPath } from "../victory-primitives/index";
+import { Helpers } from "../victory-util/index";
 
 export default class VictoryClipContainer extends React.Component {
   static displayName = "VictoryClipContainer";
@@ -16,6 +18,8 @@ export default class VictoryClipContainer extends React.Component {
         right: PropTypes.number
       })
     ]),
+    width: PropTypes.number,
+    height: PropTypes.number,
     clipPadding: PropTypes.shape({
       top: PropTypes.number,
       bottom: PropTypes.number,
@@ -89,11 +93,42 @@ export default class VictoryClipContainer extends React.Component {
     );
   }
 
-  render() {
-    const { clipWidth } = this.props;
-    if (clipWidth || clipWidth === 0) {
-      return this.renderClippedGroup(this.props, this.clipId);
+  getClipValue(props, axis) {
+    const clipValues = {x: props.clipWidth, y: props.clipHeight};
+    if (clipValues[axis] !== undefined) {
+      return clipValues[axis];
     }
-    return this.renderGroup(this.props);
+    const range = this.getRange(props, axis);
+    return range ? Math.abs(range[0] - range[1]) : undefined;
+  }
+
+  getTranslateValue(props, axis) {
+    const translateValues = {x: props.translateX, y: props.translateY};
+    if (translateValues[axis] !== undefined) {
+      return translateValues[axis];
+    }
+    const range = this.getRange(props, axis);
+    return range ? Math.min(...range) : undefined;
+  }
+
+  getRange(props, axis) {
+    const {width, height} = props;
+    if ((axis === "x" && width === "undefined") || (axis === "y" && height === "undefined")) {
+      return undefined;
+    }
+    return Helpers.getRange(props, axis);
+  }
+
+  render() {
+    const clipHeight = this.getClipValue(this.props, "x");
+    const clipWidth = this.getClipValue(this.props, "y");
+    if (clipWidth === undefined || clipHeight === undefined) {
+      return this.renderGroup(this.props);
+    }
+    const translateX = this.getTranslateValue(this.props, "x");
+    const translateY = this.getTranslateValue(this.props, "y");
+    console.log(clipHeight, clipWidth, translateX, translateY)
+    const clipProps = defaults({}, this.props, {clipHeight, clipWidth, translateX, translateY});
+    return this.renderClippedGroup(clipProps, this.clipId);
   }
 }

--- a/src/victory-clip-container/victory-clip-container.js
+++ b/src/victory-clip-container/victory-clip-container.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from "react";
-import { defaults } from "lodash";
+import { defaults, isFunction } from "lodash";
 import { ClipPath } from "../victory-primitives/index";
-import { Helpers } from "../victory-util/index";
 
 export default class VictoryClipContainer extends React.Component {
   static displayName = "VictoryClipContainer";
@@ -18,8 +17,6 @@ export default class VictoryClipContainer extends React.Component {
         right: PropTypes.number
       })
     ]),
-    width: PropTypes.number,
-    height: PropTypes.number,
     clipPadding: PropTypes.shape({
       top: PropTypes.number,
       bottom: PropTypes.number,
@@ -112,22 +109,21 @@ export default class VictoryClipContainer extends React.Component {
   }
 
   getRange(props, axis) {
-    const {width, height} = props;
-    if ((axis === "x" && width === "undefined") || (axis === "y" && height === "undefined")) {
+    const scale = props.scale || {};
+    if (!scale[axis]) {
       return undefined;
     }
-    return Helpers.getRange(props, axis);
+    return isFunction(scale[axis].range) ? scale[axis].range() : undefined;
   }
 
   render() {
-    const clipHeight = this.getClipValue(this.props, "x");
-    const clipWidth = this.getClipValue(this.props, "y");
+    const clipHeight = this.getClipValue(this.props, "y");
+    const clipWidth = this.getClipValue(this.props, "x");
     if (clipWidth === undefined || clipHeight === undefined) {
       return this.renderGroup(this.props);
     }
     const translateX = this.getTranslateValue(this.props, "x");
     const translateY = this.getTranslateValue(this.props, "y");
-    console.log(clipHeight, clipWidth, translateX, translateY)
     const clipProps = defaults({}, this.props, {clipHeight, clipWidth, translateX, translateY});
     return this.renderClippedGroup(clipProps, this.clipId);
   }

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { assign, omit } from "lodash";
+import { assign, omit, defaults } from "lodash";
 import Portal from "../victory-portal/portal";
 import { Timer } from "../victory-util/index";
 import { default as VictoryTheme } from "../victory-theme/victory-theme";
@@ -88,20 +88,19 @@ export default class VictoryContainer extends React.Component {
   // Overridden in victory-core-native
   renderContainer(props, svgProps, style) {
     const { title, desc, portalComponent, className, standalone } = props;
+    const children = this.getChildren(props);
+    const parentProps = defaults({style, className}, svgProps);
+    const groupComponent = props.groupComponent || <g/>;
     return standalone !== false ?
       (
-        <svg {...svgProps} style={style} className={className}>
+        <svg {...parentProps}>
           {title ? <title id="title">{title}</title> : null}
           {desc ? <desc id="desc">{desc}</desc> : null}
-          {this.getChildren(props)}
+          {children}
           {React.cloneElement(portalComponent, {ref: this.savePortalRef})}
         </svg>
       ) :
-      (
-        <g {...svgProps} style={style} className={className}>
-          {this.getChildren(props)}
-        </g>
-      );
+      React.cloneElement(groupComponent, parentProps, children);
   }
 
   render() {

--- a/src/victory-primitives/clip-path.js
+++ b/src/victory-primitives/clip-path.js
@@ -29,8 +29,6 @@ export default class ClipPath extends React.Component {
   };
 
   static defaultProps = {
-    translateX: 0,
-    translateY: 0,
     clipPadding: {
       top: 0,
       bottom: 0,
@@ -75,8 +73,8 @@ export default class ClipPath extends React.Component {
       return typeof total === "number" ? total : 0;
     };
     return {
-      x: totalPadding("left") + translateX,
-      y: totalPadding("top") + translateY,
+      x: totalPadding("left") + (translateX || 0),
+      y: totalPadding("top") + (translateY || 0),
       width: Math.max(+clipWidth - totalPadding("left") - totalPadding("right"), 0),
       height: Math.max(+clipHeight - totalPadding("top") - totalPadding("bottom"), 0)
     };

--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -71,8 +71,6 @@ function getChildData(child) {
  *                                    - nodesWillEnter
  *                                    - childrenTransitions
  *                                    - nodesShouldEnter
- *                                    - nodesDoneClipPathEnter
- *                                    - nodesDoneClipPathExit
  */
 export function getInitialTransitionState(oldChildren, nextChildren) {
   let nodesWillExit = false;


### PR DESCRIPTION
This PR makes `VictoryClipPath` work automatically for any x, y component.

- `VictoryClipPath` calculates default clipPath props from a range
- `VictoryTransition` is simplified now that `VictoryClipPath` can calculate its own `clipWidth`