### PR TITLE
Feature/add curve specs

### DIFF
--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -56,23 +56,42 @@ export default class Curve extends React.Component {
   }
 
   getDataSegments(data) {
-    let segmentStartIndex = 0;
-    const segments = data.reduce((memo, datum, index) => {
+    return this.splitArray(data, (datum) => {
       const yDatum = datum.y1 !== undefined ? datum._y1 : datum._y;
-      if (yDatum === null || typeof yDatum === "undefined") {
-        memo = memo.concat([data.slice(segmentStartIndex, index)]);
+
+      return yDatum === null || typeof yDatum === "undefined";
+    }).filter((segment) => segment.length > 1);
+  }
+
+  /**
+   * Split array into subarrays using a delimiter function. Items qualifying as
+   * delimiters are excluded from the subarrays. Functions similarly to String.split
+   *
+   * Example:
+   * const array = [1, 2, 3, "omit", 4, 5, "omit", 6]
+   * splitArray(array, (item) => item === "omit");
+   * => [[1, 2, 3], [4, 5], [6]]
+   *
+   * @param {Array}    array        An array of items
+   * @param {Function} delimiterFn  A function indicating values to be used as delimiters
+   * @returns {Object}              Array of subarrays
+   */
+  splitArray(array, splitValueFn) {
+    let segmentStartIndex = 0;
+    const segments = array.reduce((memo, item, index) => {
+      if (splitValueFn(item)) {
+        memo = memo.concat([array.slice(segmentStartIndex, index)]);
         segmentStartIndex = index + 1;
-      } else if (index === data.length - 1) {
-        memo = memo.concat([data.slice(segmentStartIndex, data.length)]);
+      } else if (index === array.length - 1) {
+        memo = memo.concat([array.slice(segmentStartIndex, array.length)]);
       }
       return memo;
     }, []);
 
     return segments.filter((segment) => {
-      return Array.isArray(segment) && segment.length > 1;
+      return Array.isArray(segment) && segment.length > 0;
     });
   }
-
 
   toNewName(interpolation) {
     // d3 shape changed the naming scheme for interpolators from "basis" -> "curveBasis" etc.

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -76,10 +76,10 @@ export default class Curve extends React.Component {
    * @param {Function} delimiterFn  A function indicating values to be used as delimiters
    * @returns {Object}              Array of subarrays
    */
-  splitArray(array, splitValueFn) {
+  splitArray(array, delimiterFn) {
     let segmentStartIndex = 0;
     const segments = array.reduce((memo, item, index) => {
-      if (splitValueFn(item)) {
+      if (delimiterFn(item)) {
         memo = memo.concat([array.slice(segmentStartIndex, index)]);
         segmentStartIndex = index + 1;
       } else if (index === array.length - 1) {

--- a/test/client/spec/victory-primitives/curve.spec.js
+++ b/test/client/spec/victory-primitives/curve.spec.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Curve from "src/victory-primitives/curve";
+import { merge } from "lodash";
+
+describe("victory-primitives/curve", () => {
+  const baseProps = {
+    data: [
+      {_x1: 1, x1: 1, _y1: 4, y1: 4, eventKey: 0},
+      {_x1: 2, x1: 2, _y1: 5, y1: 5, eventKey: 1},
+      {_x1: 3, x1: 3, _y1: 7, y1: 7, eventKey: 2},
+      {_x1: 4, x1: 4, _y1: 10, y1: 10, eventKey: 3},
+      {_x1: 5, x1: 5, _y1: 15, y1: 15, eventKey: 4}
+    ],
+    scale: {
+      x: (x) => x,
+      y: (y) => y
+    },
+    interpolation: "basis"
+  };
+
+  it("should render a single curve for consecutive data", () => {
+    const wrapper = shallow(<Curve {...baseProps}/>);
+
+    // single curves should not be grouped
+    expect(wrapper.render().find("g").find("path").length).to.eql(0);
+    expect(wrapper.render().find("path").length).to.eql(1);
+  });
+
+  it("should render multiple curves in a group when data has gaps", () => {
+    const props = merge({}, baseProps, {
+      data: [
+        {_x1: 1, x1: 1, _y1: 4, y1: 4, eventKey: 0},
+        {_x1: 2, x1: 2, _y1: 5, y1: 5, eventKey: 1},
+        {_x1: 3, x1: 3, _y1: null, y1: null, eventKey: 2},
+        {_x1: 4, x1: 4, _y1: 10, y1: 10, eventKey: 3},
+        {_x1: 5, x1: 5, _y1: 15, y1: 15, eventKey: 4}
+      ]
+    });
+
+    const wrapper = shallow(<Curve {...props}/>);
+
+    expect(wrapper.render().find("g").find("path").length).to.eql(2);
+  });
+
+  it("should not render isolated data points", () => {
+    const props = merge({}, baseProps, {
+      data: [
+        {_x1: 1, x1: 1, _y1: 4, y1: 4, eventKey: 0},
+        {_x1: 2, x1: 2, _y1: 5, y1: 5, eventKey: 1},
+        {_x1: 3, x1: 3, _y1: null, y1: null, eventKey: 2},
+        {_x1: 4, x1: 4, _y1: 10, y1: 10, eventKey: 3},
+        {_x1: 5, x1: 5, _y1: null, y1: null, eventKey: 4},
+        {_x1: 6, x1: 6, _y1: 15, y1: 15, eventKey: 5}
+      ]
+    });
+
+    const wrapper = shallow(<Curve {...props}/>);
+
+    expect(wrapper.render().find("path").length).to.eql(1);
+  });
+});


### PR DESCRIPTION
`"data.stuff.things".split(".")` is the same as `["data", "stuff", "things]`, which is basically what our data segmentation does with arrays, so I went ahead and started extracting that logic into a generalized `splitArray` function to make the algorithm's intent more clear. Curve and Area primitives re-use the exact same logic so I can extract it formally once Area is also covered by tests. 