### PR TITLE
round path values

### DIFF
--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -52,24 +52,30 @@ export default class Bar extends React.Component {
   }
 
   getVerticalBarPath(props, width) {
-    const {x, y0, y} = props;
     const size = width / 2;
-    return `M ${x - size}, ${y0}
-      L ${x - size}, ${y}
-      L ${x + size}, ${y}
-      L ${x + size}, ${y0}
-      L ${x - size}, ${y0}
+    const y0 = Math.round(props.y0);
+    const y1 = Math.round(props.y);
+    const x0 = Math.round(props.x - size);
+    const x1 = Math.round(props.x + size);
+    return `M ${x0}, ${y0}
+      L ${x0}, ${y1}
+      L ${x1}, ${y1}
+      L ${x1}, ${y0}
+      L ${x0}, ${y0}
       z`;
   }
 
   getHorizontalBarPath(props, width) {
-    const {x, y0, y} = props;
     const size = width / 2;
-    return `M ${y0}, ${x - size}
-      L ${y0}, ${x + size}
-      L ${y}, ${x + size}
-      L ${y}, ${x - size}
-      L ${y0}, ${x - size}
+    const y0 = Math.round(props.y0);
+    const y1 = Math.round(props.y);
+    const x0 = Math.round(props.x - size);
+    const x1 = Math.round(props.x + size);
+    return `M ${y0}, ${x0}
+      L ${y0}, ${x1}
+      L ${y1}, ${x1}
+      L ${y1}, ${x0}
+      L ${y0}, ${x0}
       z`;
   }
 

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -44,7 +44,8 @@ export default class Bar extends React.Component {
 
   calculateAttributes(props) {
     const {datum, active, x, y} = props;
-    const style = Helpers.evaluateStyle(assign({fill: "black"}, props.style), datum, active);
+    const stroke = props.style && props.style.fill;
+    const style = Helpers.evaluateStyle(assign({fill: "black", stroke}, props.style), datum, active);
     const width = this.getBarWidth(props, style);
     const path = typeof x === "number" && typeof y === "number" ?
       this.getBarPath(props, width) : undefined;

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -44,8 +44,9 @@ export default class Bar extends React.Component {
 
   calculateAttributes(props) {
     const {datum, active, x, y} = props;
-    const stroke = props.style && props.style.fill;
-    const style = Helpers.evaluateStyle(assign({fill: "black", stroke}, props.style), datum, active);
+    const stroke = props.style && props.style.fill || "black";
+    const baseStyle = {fill: "black", stroke};
+    const style = Helpers.evaluateStyle(assign(baseStyle, props.style), datum, active);
     const width = this.getBarWidth(props, style);
     const path = typeof x === "number" && typeof y === "number" ?
       this.getBarPath(props, width) : undefined;

--- a/src/victory-primitives/path-helpers.js
+++ b/src/victory-primitives/path-helpers.js
@@ -56,22 +56,19 @@ export default {
   },
 
   plus(x, y, size) {
-    const baseSize = Math.round(1.1 * size);
-    const halfSize = Math.round(1.1 * size / 3.5);
-    x = Math.round(x);
-    y = Math.round(y);
-    return `M ${x - baseSize / 2.5}, ${y + baseSize}
-      L ${x + halfSize}, ${y + baseSize}
-      L ${x + halfSize}, ${y + halfSize}
-      L ${x + baseSize}, ${y + halfSize}
-      L ${x + baseSize}, ${y - halfSize}
-      L ${x + halfSize}, ${y - halfSize}
-      L ${x + halfSize}, ${y - baseSize}
-      L ${x - halfSize}, ${y - baseSize}
-      L ${x - halfSize}, ${y - halfSize}
-      L ${x - baseSize}, ${y - halfSize}
-      L ${x - baseSize}, ${y + halfSize}
-      L ${x - halfSize}, ${y + halfSize}
+    const baseSize = 1.1 * size;
+    return `M ${Math.round(x - baseSize / 2.5)}, ${Math.round(y + baseSize)}
+      L ${Math.round(x + baseSize / 2.5)}, ${Math.round(y + baseSize)}
+      L ${Math.round(x + baseSize / 2.5)}, ${Math.round(y + baseSize / 2.5)}
+      L ${Math.round(x + baseSize)}, ${Math.round(y + baseSize / 2.5)}
+      L ${Math.round(x + baseSize)}, ${Math.round(y - baseSize / 2.5)}
+      L ${Math.round(x + baseSize / 2.5)}, ${Math.round(y - baseSize / 2.5)}
+      L ${Math.round(x + baseSize / 2.5)}, ${Math.round(y - baseSize)}
+      L ${Math.round(x - baseSize / 2.5)}, ${Math.round(y - baseSize)}
+      L ${Math.round(x - baseSize / 2.5)}, ${Math.round(y - baseSize / 2.5)}
+      L ${Math.round(x - baseSize)}, ${Math.round(y - baseSize / 2.5)}
+      L ${Math.round(x - baseSize)}, ${Math.round(y + baseSize / 2.5)}
+      L ${Math.round(x - baseSize / 2.5)}, ${Math.round(y + baseSize / 2.5)}
       z`;
   },
 

--- a/src/victory-primitives/path-helpers.js
+++ b/src/victory-primitives/path-helpers.js
@@ -2,60 +2,76 @@ import { range } from "lodash";
 
 export default {
   circle(x, y, size) {
-    return `M ${x}, ${y} m ${-size}, 0
-      a ${size}, ${size} 0 1,0 ${size * 2},0
-      a ${size}, ${size} 0 1,0 ${-size * 2},0`;
+    const s = Math.round(size);
+    return `M ${Math.round(x)}, ${Math.round(y)} m ${-s}, 0
+      a ${s}, ${s} 0 1,0 ${s * 2},0
+      a ${s}, ${s} 0 1,0 ${-s * 2},0`;
   },
 
   square(x, y, size) {
     const baseSize = 0.87 * size;
-    return `M ${x - baseSize}, ${y + baseSize}
-      L ${x + baseSize}, ${y + baseSize}
-      L ${x + baseSize}, ${y - baseSize}
-      L ${x - baseSize}, ${y - baseSize}
+    const x0 = Math.round(x - baseSize);
+    const x1 = Math.round(x + baseSize);
+    const y0 = Math.round(y - baseSize);
+    const y1 = Math.round(y + baseSize);
+    return `M ${x0}, ${y1}
+      L ${x1}, ${y1}
+      L ${x1}, ${y0}
+      L ${x0}, ${y0}
       z`;
   },
 
   diamond(x, y, size) {
     const baseSize = 0.87 * size;
     const length = Math.sqrt(2 * (baseSize * baseSize));
-    return `M ${x}, ${y + length}
-      L ${x + length}, ${y}
-      L ${x}, ${y - length}
-      L ${x - length}, ${y}
+    return `M ${Math.round(x)}, ${Math.round(y + length)}
+      L ${Math.round(x + length)}, ${Math.round(y)}
+      L ${Math.round(x)}, ${Math.round(y - length)}
+      L ${Math.round(x - length)}, ${Math.round(y)}
       z`;
   },
 
   triangleDown(x, y, size) {
     const height = (size / 2 * Math.sqrt(3));
-    return `M ${x - size}, ${y - size}
-      L ${x + size}, ${y - size}
-      L ${x}, ${y + height}
+    const x0 = Math.round(x - size);
+    const x1 = Math.round(x + size);
+    const y0 = Math.round(y - size);
+    const y1 = Math.round(y + height);
+    return `M ${x0}, ${y0}
+      L ${x1}, ${y0}
+      L ${Math.round(x)}, ${y1}
       z`;
   },
 
   triangleUp(x, y, size) {
     const height = (size / 2 * Math.sqrt(3));
-    return `M ${x - size}, ${y + size}
-      L ${x + size}, ${y + size}
-      L ${x}, ${y - height}
+    const x0 = Math.round(x - size);
+    const x1 = Math.round(x + size);
+    const y0 = Math.round(y - height);
+    const y1 = Math.round(y + size);
+    return `M ${x0}, ${y1}
+      L ${x1}, ${y1}
+      L ${Math.round(x)}, ${y0}
       z`;
   },
 
   plus(x, y, size) {
-    const baseSize = 1.1 * size;
+    const baseSize = Math.round(1.1 * size);
+    const halfSize = Math.round(1.1 * size / 3.5);
+    x = Math.round(x);
+    y = Math.round(y);
     return `M ${x - baseSize / 2.5}, ${y + baseSize}
-      L ${x + baseSize / 2.5}, ${y + baseSize}
-      L ${x + baseSize / 2.5}, ${y + baseSize / 2.5}
-      L ${x + baseSize}, ${y + baseSize / 2.5}
-      L ${x + baseSize}, ${y - baseSize / 2.5}
-      L ${x + baseSize / 2.5}, ${y - baseSize / 2.5}
-      L ${x + baseSize / 2.5}, ${y - baseSize}
-      L ${x - baseSize / 2.5}, ${y - baseSize}
-      L ${x - baseSize / 2.5}, ${y - baseSize / 2.5}
-      L ${x - baseSize}, ${y - baseSize / 2.5}
-      L ${x - baseSize}, ${y + baseSize / 2.5}
-      L ${x - baseSize / 2.5}, ${y + baseSize / 2.5}
+      L ${x + halfSize}, ${y + baseSize}
+      L ${x + halfSize}, ${y + halfSize}
+      L ${x + baseSize}, ${y + halfSize}
+      L ${x + baseSize}, ${y - halfSize}
+      L ${x + halfSize}, ${y - halfSize}
+      L ${x + halfSize}, ${y - baseSize}
+      L ${x - halfSize}, ${y - baseSize}
+      L ${x - halfSize}, ${y - halfSize}
+      L ${x - baseSize}, ${y - halfSize}
+      L ${x - baseSize}, ${y + halfSize}
+      L ${x - halfSize}, ${y + halfSize}
       z`;
   },
 

--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -87,7 +87,6 @@ export default {
       data: {
         fill: charcoal,
         padding: 10,
-        stroke: "transparent",
         strokeWidth: 0,
         width: 8
       },

--- a/src/victory-theme/material.js
+++ b/src/victory-theme/material.js
@@ -105,7 +105,6 @@ export default {
       data: {
         fill: blueGrey700,
         padding,
-        stroke: "transparent",
         strokeWidth: 0,
         width: 5
       },

--- a/test/client/spec/victory-primitives/path-helper.spec.js
+++ b/test/client/spec/victory-primitives/path-helper.spec.js
@@ -16,7 +16,7 @@ describe("path-helpers", () => {
     it("draws a path for a square at the correct location", () => {
       const pathResult = PathHelpers.square(x, y, size);
       const baseSize = 0.87 * size;
-      expect(pathResult).to.contain(`M ${x - baseSize}, ${y + baseSize}`);
+      expect(pathResult).to.contain(`M ${Math.round(x - baseSize)}, ${Math.round(y + baseSize)}`);
     });
   });
 
@@ -25,7 +25,7 @@ describe("path-helpers", () => {
       const pathResult = PathHelpers.diamond(0, 0, 1);
       const baseSize = 0.87 * size;
       const length = Math.sqrt(2 * (baseSize * baseSize));
-      expect(pathResult).to.contain(`M ${x}, ${y + length}`);
+      expect(pathResult).to.contain(`M ${Math.round(x)}, ${Math.round(y + length)}`);
     });
   });
 
@@ -47,7 +47,9 @@ describe("path-helpers", () => {
     it("draws a path for a plus at the correct location", () => {
       const pathResult = PathHelpers.plus(0, 0, 1);
       const baseSize = 1.1 * size;
-      expect(pathResult).to.contain(`M ${x - baseSize / 2.5}, ${y + baseSize}`);
+      expect(pathResult).to.contain(
+        `M ${Math.round(x - baseSize / 2.5)}, ${Math.round(y + baseSize)}`
+      );
     });
   });
 


### PR DESCRIPTION
Addresses https://github.com/FormidableLabs/victory/issues/345

This PR round all values in manually calculated paths, and gives `Bar` components a default `stroke` color that matches the `fill`. There is still occasionally one pixel of space between stacked bars depending on rounding, but this can now be easily addressed by adding `strokeWidth: 1` to styles for stacked bars. I didn't want to add this as a default theme for bars, as it has a noticeable affect on entrance animations and grouped bars. 