### PR TITLE
Feature add candle specs

### DIFF
--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import { Helpers, Collection } from "../victory-util";
-import { assign, isEqual } from "lodash";
+import { assign } from "lodash";
 
 export default class Candle extends React.Component {
   static propTypes = {

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -27,6 +27,10 @@ export default class Candle extends React.Component {
     role: PropTypes.string
   }
 
+  static defaultProps = {
+    groupComponent: <div/>
+  };
+
   componentWillMount() {
     const {style, candleWidth } = this.calculateAttributes(this.props);
     this.style = style;

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -28,7 +28,7 @@ export default class Candle extends React.Component {
   }
 
   static defaultProps = {
-    groupComponent: <div/>
+    groupComponent: <g/>
   };
 
   componentWillMount() {

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from "react";
-import Helpers from "../victory-util/helpers";
+import { Helpers, Collection } from "../victory-util";
 import { assign, isEqual } from "lodash";
-
 
 export default class Candle extends React.Component {
   static propTypes = {
@@ -37,12 +36,15 @@ export default class Candle extends React.Component {
   shouldComponentUpdate(nextProps) {
     const {x, y, y1, y2} = this.props;
     const {style, candleWidth} = this.calculateAttributes(nextProps);
-    if (x !== nextProps.x || y !== nextProps.y || y1 !== nextProps.y1 || y2 !== nextProps.y2) {
-      this.style = style;
-      this.candleWidth = candleWidth;
-      return true;
-    }
-    if (candleWidth !== this.candleWidth || !isEqual(style, this.style)) {
+
+    if (!Collection.allEqual([
+      [x, nextProps.x],
+      [y, nextProps.y],
+      [y1, nextProps.y1],
+      [y2, nextProps.y2],
+      [candleWidth, this.candleWidth],
+      [style, this.style]
+    ])) {
       this.style = style;
       this.candleWidth = candleWidth;
       return true;

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -88,12 +88,18 @@ export default {
    * @returns {Boolean}             Whether all item comparisons are equal
    */
   allSetsEqual(itemSets) {
-    const length = itemSets.length;
-    let equality;
+    return this.all(itemSets, (comparisonSet) => {
+      return isEqual(comparisonSet[0], comparisonSet[1]);
+    });
+  },
+
+  all(array, assertionFn) {
+    const length = array.length;
+    let assertionPassed;
 
     for (let i = 0; i < length; i++) {
-      equality = isEqual(itemSets[i][0], itemSets[i][1]);
-      if (equality === false) {
+      assertionPassed = assertionFn(array[i]);
+      if (assertionPassed === false) {
         return false;
       }
     }

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -88,22 +88,8 @@ export default {
    * @returns {Boolean}             Whether all item comparisons are equal
    */
   allSetsEqual(itemSets) {
-    return this.all(itemSets, (comparisonSet) => {
+    return itemSets.every((comparisonSet) => {
       return isEqual(comparisonSet[0], comparisonSet[1]);
     });
   },
-
-  all(array, assertionFn) {
-    const length = array.length;
-    let assertionPassed;
-
-    for (let i = 0; i < length; i++) {
-      assertionPassed = assertionFn(array[i]);
-      if (assertionPassed === false) {
-        return false;
-      }
-    }
-
-    return true;
-  }
 };

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -91,7 +91,7 @@ export default {
     const length = itemSets.length;
     let equality;
 
-    for (i = 0; i < length; i++) {
+    for (let i = 0; i < length; i++) {
       equality = isEqual(itemSets[i][0], itemSets[i][1]);
       if (equality === false) {
         return false;

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -91,5 +91,5 @@ export default {
     return itemSets.every((comparisonSet) => {
       return isEqual(comparisonSet[0], comparisonSet[1]);
     });
-  },
+  }
 };

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -1,3 +1,5 @@
+import { isEqual } from "lodash";
+
 export default {
   isNonEmptyArray(collection) {
     return Array.isArray(collection) && collection.length > 0;
@@ -66,5 +68,36 @@ export default {
     return segments.filter((segment) => {
       return Array.isArray(segment) && segment.length > 0;
     });
+  },
+
+  /**
+   * Takes an array of arrays. Returns whether each subarray has equivalent items.
+   * Each subarray should have two items. Used for componentShouldUpdate functions.
+   *
+   * Example:
+   * const propComparisons = [
+   *   [x, nextProps.x],
+   *   [y, nextProps.y],
+   *   [style, this.style]
+   * ];
+   *
+   * allSetsEqual(propComparisons);
+   * => true
+   *
+   * @param {Array}    itemSets     An array of item sets
+   * @returns {Boolean}             Whether all item comparisons are equal
+   */
+  allSetsEqual(itemSets) {
+    const length = itemSets.length;
+    let equality;
+
+    for (i = 0; i < length; i++) {
+      equality = isEqual(itemSets[i][0], itemSets[i][1]);
+      if (equality === false) {
+        return false;
+      }
+    }
+
+    return true;
   }
 };

--- a/test/client/spec/victory-primitives/area.spec.js
+++ b/test/client/spec/victory-primitives/area.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Area from "src/victory-primitives/area";
+import { Area } from "src/victory-primitives";
 import { merge } from "lodash";
 
 describe("victory-primitives/area", () => {

--- a/test/client/spec/victory-primitives/bar.spec.js
+++ b/test/client/spec/victory-primitives/bar.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Bar from "src/victory-primitives/bar";
+import { Bar } from "src/victory-primitives";
 import SvgTestHelper from "../svg-test-helper";
 import { merge } from "lodash";
 

--- a/test/client/spec/victory-primitives/candle.spec.js
+++ b/test/client/spec/victory-primitives/candle.spec.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Bar from "src/victory-primitives/bar";
+import SvgTestHelper from "../svg-test-helper";
+import { merge } from "lodash";
+
+describe("victory-primitives/bar", () => {
+  const baseProps = {
+    data: [
+      {_x: 2, x: 2, _y: 4, y: 4, eventKey: 0},
+      {_x: 3, x: 3, _y: 5, y: 5, eventKey: 1}
+    ],
+    datum: {_x: 2, x: 2, _y: 4, y: 4, eventKey: 0},
+    x: 2,
+    y: 10,
+    y0: 0,
+    width: 5,
+    padding: 2
+  };
+
+  it("should render a vertical bar", () => {
+    const wrapper = shallow(<Bar {...baseProps}/>);
+    const barShape = SvgTestHelper.getBarShape(wrapper);
+
+    expect(barShape.height).to.eql(10);
+  });
+
+  it("should render a horizontal bar", () => {
+    const props = merge({}, baseProps, {horizontal: true});
+
+    const wrapper = shallow(<Bar {...props}/>);
+    const barShape = SvgTestHelper.getBarShape(wrapper);
+
+    expect(barShape.width).to.eql(10);
+  });
+
+  it("should render a default bar width when one is not provided", () => {
+    // defaultWidth = (width - (2 * padding)) / data.length
+
+    const props = merge({}, baseProps, {
+      width: 10,
+      padding: 1,
+      data: Array(4)
+    });
+
+    const wrapper = shallow(<Bar {...props}/>);
+    const barShape = SvgTestHelper.getBarShape(wrapper);
+
+    expect(barShape.width).to.eql(2);
+  });
+
+  it("should allow override of width by passing a style", () => {
+    const props = Object.assign({}, baseProps, {style: {width: 1}});
+
+    const wrapper = shallow(<Bar {...props}/>);
+    const barShape = SvgTestHelper.getBarShape(wrapper);
+
+    expect(barShape.width).to.eql(1);
+  });
+});

--- a/test/client/spec/victory-primitives/candle.spec.js
+++ b/test/client/spec/victory-primitives/candle.spec.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
 import Candle from "src/victory-primitives/candle";
-import SvgTestHelper from "../svg-test-helper";
 import { merge } from "lodash";
 
 describe("victory-primitives/candle", () => {

--- a/test/client/spec/victory-primitives/candle.spec.js
+++ b/test/client/spec/victory-primitives/candle.spec.js
@@ -1,60 +1,62 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Bar from "src/victory-primitives/bar";
+import Candle from "src/victory-primitives/candle";
 import SvgTestHelper from "../svg-test-helper";
 import { merge } from "lodash";
 
-describe("victory-primitives/bar", () => {
+describe("victory-primitives/candle", () => {
   const baseProps = {
     data: [
-      {_x: 2, x: 2, _y: 4, y: 4, eventKey: 0},
-      {_x: 3, x: 3, _y: 5, y: 5, eventKey: 1}
+      {x: 1, open: 10, close: 30, high: 50, low: 5, eventKey: 0},
+      {x: 2, open: 40, close: 80, high: 100, low: 10, eventKey: 1}
     ],
-    datum: {_x: 2, x: 2, _y: 4, y: 4, eventKey: 0},
-    x: 2,
-    y: 10,
-    y0: 0,
-    width: 5,
-    padding: 2
+    datum: {x: 1, open: 10, close: 30, high: 50, low: 5, eventKey: 0},
+    x: 5,
+    y: 30,
+    y1: 50,
+    y2: 5,
+    candleHeight: 20,
+    width: 10,
+    padding: 1
   };
 
-  it("should render a vertical bar", () => {
-    const wrapper = shallow(<Bar {...baseProps}/>);
-    const barShape = SvgTestHelper.getBarShape(wrapper);
+  it("should render a wick line", () => {
+    const wrapper = shallow(<Candle {...baseProps}/>);
+    const wick = wrapper.render().find("line");
 
-    expect(barShape.height).to.eql(10);
+    expect(wick.attr("x1")).to.eql("5");
+    expect(wick.attr("x2")).to.eql("5");
+    expect(wick.attr("y1")).to.eql("50");
+    expect(wick.attr("y2")).to.eql("5");
   });
 
-  it("should render a horizontal bar", () => {
-    const props = merge({}, baseProps, {horizontal: true});
+  it("should render a candle rectangle", () => {
+    const wrapper = shallow(<Candle {...baseProps}/>);
+    const rect = wrapper.render().find("rect");
 
-    const wrapper = shallow(<Bar {...props}/>);
-    const barShape = SvgTestHelper.getBarShape(wrapper);
+    // width = style.width || 0.5 * (width - 2 * padding) / data.length;
 
-    expect(barShape.width).to.eql(10);
+    expect(rect.attr("width")).to.eql("2");
+    expect(rect.attr("height")).to.eql("20");
+    // x = x - width / 2
+    expect(rect.attr("x")).to.eql("4");
+    expect(rect.attr("y")).to.eql("30");
   });
 
-  it("should render a default bar width when one is not provided", () => {
-    // defaultWidth = (width - (2 * padding)) / data.length
-
+  it("should allow style to override width", () => {
     const props = merge({}, baseProps, {
-      width: 10,
-      padding: 1,
-      data: Array(4)
+      style: {
+        width: 5
+      }
     });
 
-    const wrapper = shallow(<Bar {...props}/>);
-    const barShape = SvgTestHelper.getBarShape(wrapper);
+    const wrapper = shallow(<Candle {...props}/>);
+    const rect = wrapper.render().find("rect");
 
-    expect(barShape.width).to.eql(2);
-  });
-
-  it("should allow override of width by passing a style", () => {
-    const props = Object.assign({}, baseProps, {style: {width: 1}});
-
-    const wrapper = shallow(<Bar {...props}/>);
-    const barShape = SvgTestHelper.getBarShape(wrapper);
-
-    expect(barShape.width).to.eql(1);
+    expect(rect.attr("width")).to.eql("5");
+    expect(rect.attr("height")).to.eql("20");
+    // x = x - width / 2
+    expect(rect.attr("x")).to.eql("2.5");
+    expect(rect.attr("y")).to.eql("30");
   });
 });

--- a/test/client/spec/victory-primitives/candle.spec.js
+++ b/test/client/spec/victory-primitives/candle.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Candle from "src/victory-primitives/candle";
+import { Candle } from "src/victory-primitives";
 import { merge } from "lodash";
 
 describe("victory-primitives/candle", () => {

--- a/test/client/spec/victory-primitives/curve.spec.js
+++ b/test/client/spec/victory-primitives/curve.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Curve from "src/victory-primitives/curve";
+import { Curve } from "src/victory-primitives";
 import { merge } from "lodash";
 
 describe("victory-primitives/curve", () => {

--- a/test/client/spec/victory-primitives/flyout.spec.js
+++ b/test/client/spec/victory-primitives/flyout.spec.js
@@ -1,7 +1,7 @@
 /*eslint-disable max-nested-callbacks,no-unused-expressions,max-len */
 import React from "react";
 import { shallow } from "enzyme";
-import Flyout from "src/victory-primitives/flyout";
+import { Flyout } from "src/victory-primitives";
 import SvgTestHelper from "../svg-test-helper";
 
 describe("victory-primitives/slice", () => {

--- a/test/client/spec/victory-primitives/line.spec.js
+++ b/test/client/spec/victory-primitives/line.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Line from "src/victory-primitives/line";
+import { Line } from "src/victory-primitives";
 
 describe("victory-primitives/line", () => {
   const baseProps = {

--- a/test/client/spec/victory-primitives/point.spec.js
+++ b/test/client/spec/victory-primitives/point.spec.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { shallow } from "enzyme";
-import Point from "src/victory-primitives/point";
+import { Point } from "src/victory-primitives";
 import pathHelpers from "src/victory-primitives/path-helpers";
 
 describe("victory-primitives/point", () => {

--- a/test/client/spec/victory-primitives/slice.spec.js
+++ b/test/client/spec/victory-primitives/slice.spec.js
@@ -1,7 +1,7 @@
 /*eslint-disable max-nested-callbacks,no-unused-expressions,max-len */
 import React from "react";
 import { shallow } from "enzyme";
-import Slice from "src/victory-primitives/slice";
+import { Slice } from "src/victory-primitives";
 
 describe("victory-primitives/slice", () => {
   describe("rendering", () => {

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -151,4 +151,27 @@ describe("collections", () => {
       expect(Collection.getMinValue(array, 1, 20)).to.eql(1);
     });
   });
+
+  describe("allSetsEqual", () => {
+
+    it("returns true when all sets are equal", () => {
+      const comparisons = [
+        [1, 1],
+        ["wow", "wow"],
+        [{ stuff: 43 }, { stuff: 43 }],
+      ];
+
+      expect(Collection.allSetsEqual(comparisons)).to.eql(true);
+    });
+
+    it("returns false when not all sets are equal", () => {
+      const comparisons = [
+        [1, 1],
+        ["wow", "wow"],
+        [{ stuff: 1 }, { stuff: 43 }]
+      ];
+
+      expect(Collection.allSetsEqual(comparisons)).to.eql(false);
+    });
+  });
 });

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -158,7 +158,7 @@ describe("collections", () => {
       const comparisons = [
         [1, 1],
         ["wow", "wow"],
-        [{ stuff: 43 }, { stuff: 43 }],
+        [{ stuff: 43 }, { stuff: 43 }]
       ];
 
       expect(Collection.allSetsEqual(comparisons)).to.eql(true);


### PR DESCRIPTION
Adds specs and a little bit of refactoring to `shouldComponentUpdate`. We have pretty similar requirements in each primitive that get expressed in various formats and levels of `if` blocks, but it's really just "update if any of these things changed"