### PR TITLE
example of computed props

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.0.0",
     "d3-timer": "^1.0.0",
-    "lodash": "^4.12.0"
+    "lodash": "^4.12.0",
+    "react-computed-props": "0.1.1"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^3.1.0",

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -70,26 +70,9 @@ export default {
     });
   },
 
-  /**
-   * Takes an array of arrays. Returns whether each subarray has equivalent items.
-   * Each subarray should have two items. Used for componentShouldUpdate functions.
-   *
-   * Example:
-   * const propComparisons = [
-   *   [x, nextProps.x],
-   *   [y, nextProps.y],
-   *   [style, this.style]
-   * ];
-   *
-   * allSetsEqual(propComparisons);
-   * => true
-   *
-   * @param {Array}    itemSets     An array of item sets
-   * @returns {Boolean}             Whether all item comparisons are equal
-   */
-  allSetsEqual(itemSets) {
-    return itemSets.every((comparisonSet) => {
-      return isEqual(comparisonSet[0], comparisonSet[1]);
+  isEqualBy(object, comparisonObject, fields) {
+    return fields.every((field) => {
+      return isEqual(object[field], comparisonObject[field]);
     });
   }
 };

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -152,26 +152,30 @@ describe("collections", () => {
     });
   });
 
-  describe("allSetsEqual", () => {
+  describe("isEqualBy", () => {
+    let firstObject;
+    let secondObject;
 
-    it("returns true when all sets are equal", () => {
-      const comparisons = [
-        [1, 1],
-        ["wow", "wow"],
-        [{ stuff: 43 }, { stuff: 43 }]
-      ];
+    beforeEach(() => {
+      firstObject = {
+        x: 2,
+        y: "wow",
+        z: { things: true }
+      };
 
-      expect(Collection.allSetsEqual(comparisons)).to.eql(true);
+      secondObject = {
+        x: 2,
+        y: "wow",
+        z: { things: false }
+      };
     });
 
-    it("returns false when not all sets are equal", () => {
-      const comparisons = [
-        [1, 1],
-        ["wow", "wow"],
-        [{ stuff: 1 }, { stuff: 43 }]
-      ];
+    it("returns true when objects are equal by all fields", () => {
+      expect(Collection.isEqualBy(firstObject, secondObject, ["x", "y"])).to.eql(true);
+    });
 
-      expect(Collection.allSetsEqual(comparisons)).to.eql(false);
+    it("returns false when not all listed fields are equal", () => {
+      expect(Collection.isEqualBy(firstObject, secondObject, ["x", "y", "z"])).to.eql(false);
     });
   });
 });


### PR DESCRIPTION
@boygirl Here's an example of how we could approach these computed props. The new props all get merged into our normal props using a wrapper, and then we can ditch `componentWillMount`, object state (`this.x`, etc), and reduce our sCU logic down to just a list of props that need to stay unchanged. We also get validation on the computed props since they become no different from "normal" ones as far as this component is concerned. 