### PR TITLE
Add optional title and desc elements to victory-label

### DIFF
--- a/demo/victory-label-demo.js
+++ b/demo/victory-label-demo.js
@@ -18,6 +18,15 @@ export default class App extends React.Component {
           />
 
 
+          <circle cx="200" cy="50" r="2" fill="red"/>
+          <VictoryLabel
+            x={200} y={50}
+            title={"Victory is awesome. This is a title."}
+            desc={"Victory is awesome. This is a description."}
+            text={"Victory is awesome.\nThis has a title and description."}
+          />
+
+
           <circle cx="0" cy="75" r="2" fill="red"/>
           <VictoryLabel
             x={0} y={75}

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -28,6 +28,7 @@ export default class VictoryLabel extends React.Component {
     className: PropTypes.string,
     data: PropTypes.array,
     datum: PropTypes.any,
+    desc: PropTypes.string,
     dx: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
@@ -64,6 +65,7 @@ export default class VictoryLabel extends React.Component {
       ]),
       PropTypes.func
     ]),
+    title: PropTypes.string,
     transform: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
@@ -222,6 +224,8 @@ export default class VictoryLabel extends React.Component {
       <text {...textProps}
         {...props.events}
       >
+        {this.props.title && <title>{this.props.title}</title>}
+        {this.props.desc && <desc>{this.props.desc}</desc>}
         {this.content.map((line, i) => {
           const style = this.style[i] || this.style[0];
           const lastStyle = this.style[i - 1] || this.style[0];

--- a/test/client/spec/victory-label/victory-label.spec.js
+++ b/test/client/spec/victory-label/victory-label.spec.js
@@ -56,6 +56,28 @@ describe("components/victory-label", () => {
     expect(output.length).to.equal(3);
   });
 
+  it("renders title and desc if provided ", () => {
+    const wrapper = shallow(
+      <VictoryLabel text="title and desc" title="title" desc="desc" />
+    );
+
+    const wrapper2 = shallow(
+      <VictoryLabel text="title and desc"/>
+    );
+
+    const title = wrapper.find("title");
+    expect(title.length).to.equal(1);
+
+    const desc = wrapper.find("desc");
+    expect(desc.length).to.equal(1);
+
+    const noTitle = wrapper2.find("title");
+    expect(noTitle.length).to.equal(0);
+
+    const noDesc = wrapper2.find("desc");
+    expect(noDesc.length).to.equal(0);
+  });
+
   it("renders styles tspand independently when `style` is an array", () => {
     const fill = ["red", "green", "blue"];
     const wrapper = shallow(


### PR DESCRIPTION
For accessibility reason it would be nice to add `<title>` and `<desc>` tags to `victory-label`. This is helpful, for example, if the normal label text is truncated (for space reasons) and one wants to provide the full title in a browser tooltip.

This PR adds `title` and `desc` props to `victory-label`. They are optional and render their respective SVG tags only when provided. There is also an example added in the `demo/` folder.