### PR TITLE
Multi line legend

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -16,7 +16,6 @@ class Home extends React.Component {
 }
 
 class App extends React.Component {
-
   constructor() {
     super();
     this.state = {
@@ -52,7 +51,7 @@ class App extends React.Component {
         <ul>
           <li><a href="#/animation">Victory Animation Demo</a></li>
           <li><a href="#/label">Victory Label Demo</a></li>
-          <li><a href="#/legend">Victory Legend</a></li>
+          <li><a href="#/legend">Victory Legend Demo</a></li>
           <li><a href="#/tooltip">Victory Tooltip Demo</a></li>
         </ul>
         <Child/>

--- a/demo/victory-legend-demo.js
+++ b/demo/victory-legend-demo.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { VictoryLegend } from "../src/index";
 
-const svgStyle = { border: "1px solid darkgray" };
+const legendStyle = { parent: { display: "block", marginBottom: 20 }};
 const data = [{
   name: "Series 1",
   symbol: {
@@ -34,21 +34,39 @@ const data = [{
   labels: {
     fill: "purple"
   }
+}, {
+  name: "Series 6",
+  symbol: {
+    type: "circle",
+    fill: "orange"
+  },
+  labels: {
+    fill: "blue"
+  }
 }];
 
 const LegendDemo = () => (
   <div className="demo">
-    <VictoryLegend data={data} />
+    <VictoryLegend
+      data={data}
+      style={legendStyle}
+    />
+    <VictoryLegend
+      data={data}
+      itemsPerRow={4}
+      orientation="horizontal"
+      style={legendStyle}
+    />
     <svg
-      height={56}
-      width={525}
-      style={svgStyle}
+      height={100}
+      width={244}
+      style={{ border: "1px solid #ccc" }}
     >
       <VictoryLegend
         data={data}
-        padding={20}
+        padding={15}
+        itemsPerRow={3}
         standalone={false}
-        orientation="horizontal"
         style={{ labels: { fill: "darkgray" } }}
       />
     </svg>

--- a/demo/victory-legend-demo.js
+++ b/demo/victory-legend-demo.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { VictoryLegend } from "../src/index";
 
-const legendStyle = { parent: { display: "block", marginBottom: 20 }};
+const legendStyle = { parent: { display: "block", marginBottom: 20 } };
 const data = [{
   name: "Series 1",
   symbol: {

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -95,6 +95,7 @@ export default class VictoryLegend extends React.Component {
     return padding.top + contentHeight + padding.bottom;
   }
 
+  // eslint-disable-next-line max-params
   calculateLegendWidth(itemCount, padding, isHorizontal, maxTextWidth) {
     const { gutter, itemsPerRow, symbolSpacer } = this.props;
     const rowCount = itemsPerRow ? Math.ceil(itemCount / itemsPerRow) : 1;
@@ -105,7 +106,7 @@ export default class VictoryLegend extends React.Component {
       const gutterWidth = gutter * rowItemCount;
       const symbolWidth = symbolSpacer * 3 * rowItemCount;
       const textWidth = maxTextWidth * rowItemCount;
-      contentWidth =  symbolWidth + textWidth + gutterWidth;
+      contentWidth = symbolWidth + textWidth + gutterWidth;
     } else {
       contentWidth = (maxTextWidth + symbolSpacer * 2 + gutter) * rowCount;
     }
@@ -123,7 +124,7 @@ export default class VictoryLegend extends React.Component {
 
   getCalculatedProps() { // eslint-disable-line max-statements
     const { role } = this.constructor;
-    const { data, orientation, theme, itemsPerRow } = this.props;
+    const { data, orientation, theme } = this.props;
     const legendTheme = theme && theme[role] ? theme[role] : {};
     const parentStyles = this.getStyles({}, legendTheme, "parent");
     const colorScale = this.getColorScale(legendTheme);
@@ -150,7 +151,7 @@ export default class VictoryLegend extends React.Component {
       height = this.calculateLegendHeight(textSizes, padding, isHorizontal);
     }
     if (!width) {
-      width = this.calculateLegendWidth(textSizes.length, padding, isHorizontal, maxTextWidth); // eslint-disable-line max-params
+      width = this.calculateLegendWidth(textSizes.length, padding, isHorizontal, maxTextWidth);
     }
 
     return Object.assign({}, this.props, {
@@ -161,7 +162,6 @@ export default class VictoryLegend extends React.Component {
       padding,
       parentStyles,
       symbolStyles,
-      textSizes,
       width
     });
   }
@@ -188,30 +188,29 @@ export default class VictoryLegend extends React.Component {
       maxTextWidth,
       padding,
       symbolSpacer,
-      symbolStyles,
-      textSizes
+      symbolStyles
     } = props;
 
     const { fontSize } = labelStyles[i];
     const symbolShift = fontSize / 2;
     const style = symbolStyles[i];
     const rowHeight = fontSize + gutter;
-    let itemRowIndex = i;
+    let itemIndex = i;
     let rowSpacer = 0;
     let rowIndex = 0;
 
     if (itemsPerRow) {
       rowIndex = Math.floor(i / itemsPerRow);
       rowSpacer = rowHeight * rowIndex;
-      itemRowIndex = i % itemsPerRow;
+      itemIndex = i % itemsPerRow;
     }
 
     const symbolCoords = isHorizontal ? {
-      x: padding.left + symbolShift + (fontSize + symbolSpacer + maxTextWidth + gutter) * itemRowIndex,
+      x: padding.left + symbolShift + (fontSize + symbolSpacer + maxTextWidth + gutter) * itemIndex,
       y: padding.top + symbolShift + rowSpacer
     } : {
       x: padding.left + symbolShift + (rowHeight + maxTextWidth) * rowIndex,
-      y: padding.top + symbolShift + rowHeight * itemRowIndex
+      y: padding.top + symbolShift + rowHeight * itemIndex
     };
 
     return defaults({}, dataComponent.props, {
@@ -232,30 +231,30 @@ export default class VictoryLegend extends React.Component {
       labelStyles,
       maxTextWidth,
       padding,
-      symbolSpacer,
-      textSizes
+      symbolSpacer
     } = props;
 
     const style = labelStyles[i];
     const { fontSize } = style;
     const symbolShift = fontSize / 2;
     const rowHeight = fontSize + gutter;
-    let itemRowIndex = i;
+    const symbolWidth = fontSize + symbolSpacer;
+    let itemIndex = i;
     let rowSpacer = 0;
     let rowIndex = 0;
 
     if (itemsPerRow) {
       rowIndex = Math.floor(i / itemsPerRow);
       rowSpacer = rowHeight * rowIndex;
-      itemRowIndex = i % itemsPerRow;
+      itemIndex = i % itemsPerRow;
     }
 
     const labelCoords = isHorizontal ? {
-      x: padding.left + (fontSize + symbolSpacer) * (itemRowIndex + 1) + (maxTextWidth + gutter) * itemRowIndex,
+      x: padding.left + symbolWidth * (itemIndex + 1) + (maxTextWidth + gutter) * itemIndex,
       y: padding.top + symbolShift + rowSpacer
     } : {
-      x: padding.left + fontSize + symbolSpacer + (rowHeight + maxTextWidth) * rowIndex,
-      y: padding.top + symbolShift + rowHeight * itemRowIndex
+      x: padding.left + symbolWidth + (rowHeight + maxTextWidth) * rowIndex,
+      y: padding.top + symbolShift + rowHeight * itemIndex
     };
 
     return defaults({}, labelComponent.props, {

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -40,6 +40,7 @@ export default class VictoryLegend extends React.Component {
       CustomPropTypes.nonNegative,
       PropTypes.func
     ]),
+    itemsPerRow: PropTypes.number,
     labelComponent: PropTypes.element,
     orientation: PropTypes.oneOf(["horizontal", "vertical"]),
     padding: PropTypes.oneOfType([
@@ -84,19 +85,32 @@ export default class VictoryLegend extends React.Component {
   };
 
   calculateLegendHeight(textSizes, padding, isHorizontal) {
-    const { data, gutter } = this.props;
+    const { gutter, itemsPerRow } = this.props;
+    const itemCount = textSizes.length;
+    const rowCount = itemsPerRow ? Math.ceil(itemCount / itemsPerRow) : 1;
     const contentHeight = isHorizontal
-      ? maxBy(textSizes, "height").height
-      : sumBy(textSizes, "height") + gutter * (data.length - 1);
+      ? maxBy(textSizes, "height").height * rowCount + gutter * (rowCount - 1)
+      : (sumBy(textSizes, "height") + gutter * (itemCount - 1)) / rowCount;
 
     return padding.top + contentHeight + padding.bottom;
   }
 
   calculateLegendWidth(textSizes, padding, isHorizontal) {
-    const { data, gutter, symbolSpacer } = this.props;
-    const contentWidth = isHorizontal
-      ? sumBy(textSizes, "width") + (gutter + symbolSpacer * 3) * (data.length - 1)
-      : maxBy(textSizes, "width").width + symbolSpacer * 2;
+    const { gutter, itemsPerRow, symbolSpacer } = this.props;
+    const maxTextWidth = maxBy(textSizes, "width").width;
+    const itemCount = textSizes.length;
+    const rowCount = itemsPerRow ? Math.ceil(itemCount / itemsPerRow) : 1;
+    const rowItemCount = itemsPerRow || itemCount;
+    let contentWidth;
+
+    if (isHorizontal) {
+      const gutterWidth = gutter * rowItemCount;
+      const symbolWidth = symbolSpacer * 3 * rowItemCount;
+      const textWidth = maxTextWidth * rowItemCount;
+      contentWidth =  symbolWidth + textWidth + gutterWidth;
+    } else {
+      contentWidth = (maxTextWidth + symbolSpacer * 2 + gutter) * rowCount;
+    }
 
     return padding.left + contentWidth + padding.right;
   }
@@ -114,7 +128,7 @@ export default class VictoryLegend extends React.Component {
 
   getCalculatedProps() { // eslint-disable-line max-statements
     const { role } = this.constructor;
-    const { data, orientation, theme } = this.props;
+    const { data, orientation, theme, itemsPerRow } = this.props;
     let { height, padding, width } = this.props;
 
     const legendTheme = theme && theme[role] ? theme[role] : {};
@@ -123,7 +137,6 @@ export default class VictoryLegend extends React.Component {
     const isHorizontal = orientation === "horizontal";
     const symbolStyles = [];
     const labelStyles = [];
-    let leftOffset = 0;
 
     padding = Helpers.getPadding({ padding: padding || theme.padding });
     height = Helpers.evaluateProp(height || theme.height, data);
@@ -131,13 +144,9 @@ export default class VictoryLegend extends React.Component {
 
     const textSizes = data.map((datum, i) => {
       const labelStyle = this.getStyles(datum, legendTheme, "labels");
+      const textSize = TextSize.approximateTextSize(datum.name, labelStyle);
       symbolStyles[i] = this.getStyles(datum, legendTheme, "symbol", colorScale[i]);
       labelStyles[i] = labelStyle;
-
-      const textSize = TextSize.approximateTextSize(datum.name, labelStyle);
-      textSize.leftOffset = leftOffset;
-      leftOffset += textSize.width;
-
       return textSize;
     });
 
@@ -148,10 +157,16 @@ export default class VictoryLegend extends React.Component {
       width = this.calculateLegendWidth(textSizes, padding, isHorizontal);
     }
 
-    return Object.assign({},
-      this.props,
-      { isHorizontal, height, labelStyles, padding, parentStyles, symbolStyles, textSizes, width }
-    );
+    return Object.assign({}, this.props, {
+      isHorizontal,
+      height,
+      labelStyles,
+      padding,
+      parentStyles,
+      symbolStyles,
+      textSizes,
+      width
+    });
   }
 
   getStyles(datum, theme, key, color) { // eslint-disable-line max-params
@@ -168,48 +183,82 @@ export default class VictoryLegend extends React.Component {
 
   getSymbolProps(datum, props, i) {
     const {
-      dataComponent, gutter, labelStyles, isHorizontal,
-      padding, symbolSpacer, symbolStyles, textSizes
+      dataComponent,
+      gutter,
+      isHorizontal,
+      itemsPerRow,
+      labelStyles,
+      padding,
+      symbolSpacer,
+      symbolStyles,
+      textSizes
     } = props;
-    const { leftOffset } = textSizes[i];
+
     const { fontSize } = labelStyles[i];
     const symbolShift = fontSize / 2;
     const style = symbolStyles[i];
+    const rowHeight = fontSize + gutter;
+    const maxTextWidth = maxBy(textSizes, "width").width;
+    let itemRowIndex = i;
+    let rowSpacer = 0;
+    let rowIndex = 0;
+
+    if (itemsPerRow) {
+      rowIndex = Math.floor(i / itemsPerRow);
+      rowSpacer = rowHeight * rowIndex;
+      itemRowIndex = i % itemsPerRow;
+    }
 
     const symbolCoords = isHorizontal ? {
-      x: padding.left + leftOffset + symbolShift + (fontSize + symbolSpacer + gutter) * i,
-      y: padding.top + symbolShift
+      x: padding.left + symbolShift + (fontSize + symbolSpacer + maxTextWidth + gutter) * itemRowIndex,
+      y: padding.top + symbolShift + rowSpacer
     } : {
-      x: padding.left + symbolShift,
-      y: padding.top + symbolShift + (fontSize + gutter) * i
+      x: padding.left + symbolShift + (rowHeight + maxTextWidth) * rowIndex,
+      y: padding.top + symbolShift + rowHeight * itemRowIndex
     };
 
-    return defaults({},
-      dataComponent.props,
-      {
-        key: `symbol-${i}`,
-        style,
-        size: this.getSymbolSize(datum, fontSize),
-        symbol: style.type,
-        ...symbolCoords
-      }
-    );
+    return defaults({}, dataComponent.props, {
+      key: `symbol-${i}`,
+      style,
+      size: this.getSymbolSize(datum, fontSize),
+      symbol: style.type,
+      ...symbolCoords
+    });
   }
 
   getLabelProps(datum, props, i) {
     const {
-      gutter, isHorizontal, symbolSpacer, labelComponent, labelStyles, textSizes, padding
+      gutter,
+      isHorizontal,
+      itemsPerRow,
+      labelComponent,
+      labelStyles,
+      padding,
+      symbolSpacer,
+      textSizes
     } = props;
+
     const style = labelStyles[i];
     const { fontSize } = style;
     const symbolShift = fontSize / 2;
+    const rowHeight = fontSize + gutter;
+    const maxTextWidth = maxBy(textSizes, "width").width;
+    let itemRowIndex = i;
+    let rowSpacer = 0;
+    let rowIndex = 0;
+
+    if (itemsPerRow) {
+      rowIndex = Math.floor(i / itemsPerRow);
+      rowSpacer = rowHeight * rowIndex;
+      itemRowIndex = i % itemsPerRow;
+    }
 
     const labelCoords = isHorizontal ? {
-      x: padding.left + textSizes[i].leftOffset + (fontSize + symbolSpacer) * (i + 1) + gutter * i,
-      y: padding.top + symbolShift
+      x: padding.left + (fontSize + symbolSpacer) * (itemRowIndex + 1) + (maxTextWidth + gutter) * itemRowIndex,
+      y: padding.top + symbolShift + rowSpacer
     } : {
-      x: padding.left + fontSize + symbolSpacer,
-      y: padding.top + symbolShift + (fontSize + gutter) * i
+      x: padding.left + fontSize + symbolSpacer + (rowHeight + maxTextWidth) * rowIndex,
+      y: padding.top + symbolShift + rowHeight * itemRowIndex
     };
 
     return defaults({},
@@ -249,6 +298,7 @@ export default class VictoryLegend extends React.Component {
     const style = props.style || {};
     let groupProps = { role: "presentation" };
     const transform = `translate(${x}, ${y})`;
+
     if (!standalone) {
       groupProps = Object.assign(groupProps, { height, width, transform, style: style.parent });
     }

--- a/test/client/spec/victory-legend/victory-legend.spec.js
+++ b/test/client/spec/victory-legend/victory-legend.spec.js
@@ -144,4 +144,64 @@ describe("components/victory-legend", () => {
       expect(outputLabels.get(1).props.style.fill).to.equal("#252525");
     });
   });
+
+  describe("itemsPerRow", () => {
+    const legendData = [{
+      name: "Thing 1"
+    }, {
+      name: "Thing 2"
+    }, {
+      name: "Thing 3"
+    }, {
+      name: "Thing 4"
+    }, {
+      name: "Thing 5"
+    }, {
+      name: "Thing 6"
+    }];
+
+    it("displays items in columns", () => {
+      wrapper = shallow(<VictoryLegend data={legendData} itemsPerRow={3} />);
+      const outputLabels = wrapper.find("VictoryLabel");
+      const outputPoints = wrapper.find("Point");
+
+      // items line up between columns
+      expect(outputPoints.get(0).props.y).to.equal(outputPoints.get(3).props.y);
+      expect(outputLabels.get(0).props.y).to.equal(outputLabels.get(3).props.y);
+      expect(outputPoints.get(1).props.y).to.equal(outputPoints.get(4).props.y);
+      expect(outputLabels.get(1).props.y).to.equal(outputLabels.get(4).props.y);
+      expect(outputPoints.get(2).props.y).to.equal(outputPoints.get(5).props.y);
+      expect(outputLabels.get(2).props.y).to.equal(outputLabels.get(2).props.y);
+
+      // columns are the same distance apart
+      expect(outputPoints.get(0).props.x - outputPoints.get(3).props.x)
+        .to.equal(outputPoints.get(1).props.x - outputPoints.get(4).props.x).and
+        .to.equal(outputPoints.get(2).props.x - outputPoints.get(5).props.x);
+    });
+
+    it("displays items in rows", () => {
+      wrapper = shallow(
+        <VictoryLegend
+          data={legendData}
+          itemsPerRow={3}
+          orientation="horizontal"
+        />
+      );
+      const outputLabels = wrapper.find("VictoryLabel");
+      const outputPoints = wrapper.find("Point");
+
+      // items line up between rows
+      expect(outputPoints.get(0).props.x).to.equal(outputPoints.get(3).props.x);
+      expect(outputLabels.get(0).props.x).to.equal(outputLabels.get(3).props.x);
+      expect(outputPoints.get(1).props.x).to.equal(outputPoints.get(4).props.x);
+      expect(outputLabels.get(1).props.x).to.equal(outputLabels.get(4).props.x);
+      expect(outputPoints.get(2).props.x).to.equal(outputPoints.get(5).props.x);
+      expect(outputLabels.get(2).props.x).to.equal(outputLabels.get(2).props.x);
+
+      // rows are the same distance apart
+      expect(outputPoints.get(0).props.y - outputPoints.get(3).props.y)
+        .to.equal(outputPoints.get(1).props.y - outputPoints.get(4).props.y).and
+        .to.equal(outputPoints.get(2).props.y - outputPoints.get(5).props.y);
+    });
+  });
 });


### PR DESCRIPTION
- fixes https://github.com/FormidableLabs/victory/issues/476
- adds an optional `itemsPerRow` prop for displaying legend items in multiple rows/columns (when `orientation` is `horizontal`/`vertical`, respectively)
- updates `horizontal` legend to use `maxItemWidth` for column width (as displayed in the demo screenshot below)

<img width="650" alt="screen shot 2017-05-15 at 8 20 36 pm" src="https://cloud.githubusercontent.com/assets/2624467/26088423/058bbd7e-39ac-11e7-962f-60c5c6ddad9e.png">
