### PR TITLE
Fix victory-util/style.js typo

### DIFF
--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -54,6 +54,6 @@ export default {
       blue: ["#002C61", "#004B8F", "#006BC9", "#3795E5", "#65B4F4"],
       green: ["#354722", "#466631", "#649146", "#8AB25C", "#A9C97E"]
     };
-    return name ? scales[name] : scales.greyscale;
+    return name ? scales[name] : scales.grayscale;
   }
 };


### PR DESCRIPTION
Spelling of property 'grayscale' incrorrectly referenced as 'greyscale' in return statement of getColorScale function