### PR TITLE
bugfixes for Area render function

### DIFF
--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -118,7 +118,7 @@ export default class Area extends React.Component {
   // Overridden in victory-core-native
   renderLine(path, style, events) {
     if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
-      return [];
+      return null;
     }
     const { role, shapeRendering, className, polar, origin } = this.props;
     const transform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
@@ -141,7 +141,13 @@ export default class Area extends React.Component {
     const { events, groupComponent } = this.props;
     const area = this.renderArea(this.areaPath, this.style, events);
     const line = this.renderLine(this.linePath, this.style, events);
-    const children = [line, area];
-    return children.length === 1 ? children[0] : React.cloneElement(groupComponent, {}, children);
+
+    if (!line) {
+      return area;
+    }
+    const children = [line, area].map((el, i) =>
+      React.cloneElement(el, { key: i })
+    );
+    return React.cloneElement(groupComponent, {}, children);
   }
 }


### PR DESCRIPTION
addresses two things in the `Area` render function...

There was a `children.length === 1` check on an array that was always 2 elements long:
```
const children = [line, area];
return children.length === 1 ? children[0] : React.cloneElement(groupComponent, {}, children);
```
Therefore we were always trying to render `line`, even if it was empty.

Any custom component that extended `Area` would get a unique key warning (`Warning: Each child in an array or iterator should have a unique "key" prop.`) unless they added a unique key to the top-level element returned from `renderArea()`. I thought this was confusing, as there is no indication that `renderArea()` will be wrapped in an array upon final rendering. I found this because the [steam graph](formidable.com/open-source/victory/gallery/stream-graph/) gives this warning, as well steam demo on the the Victory homepage. (On the production site the warnings are silenced, as we are using a prod build of React.)