### PR TITLE
ARIA fix: ensure correct IDs for title and desc

### DIFF
--- a/demo/victory-tooltip-demo.js
+++ b/demo/victory-tooltip-demo.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { VictoryTooltip } from "../src/index";
+import { VictoryTooltip, VictoryContainer } from "../src/index";
 
 export default class App extends React.Component {
 
@@ -27,12 +27,16 @@ export default class App extends React.Component {
     return (
       <div className="demo" style={containerStyle}>
         <svg {...svgProps}>
-          <VictoryTooltip {...baseTooltipProps} text={"what up?\nnot much, you?"}/>
+          <VictoryContainer width={100} height={100} desc="first description" title="first title">
+            <VictoryTooltip {...baseTooltipProps} text={"what up?\nnot much, you?"}/>
+          </VictoryContainer>
           <circle cx="75" cy="75" r="2" fill="red"/>
         </svg>
 
         <svg {...svgProps}>
-          <VictoryTooltip {...baseTooltipProps} text={"o shit\nwaddup"}/>
+          <VictoryContainer width={100} height={100} desc="second description" title="second title">
+            <VictoryTooltip {...baseTooltipProps} text={"o shit\nwaddup"}/>
+          </VictoryContainer>
           <circle cx="75" cy="75" r="2" fill="red"/>
         </svg>
 

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { assign, omit, defaults } from "lodash";
+import { assign, omit, defaults, uniqueId } from "lodash";
 import Portal from "../victory-portal/portal";
 import Timer from "../victory-util/timer";
 
@@ -45,6 +45,7 @@ export default class VictoryContainer extends React.Component {
   constructor(props) {
     super(props);
     this.getTimer = this.getTimer.bind(this);
+    this.containerId = uniqueId("victory-container-");
   }
 
   getChildContext() {
@@ -82,6 +83,10 @@ export default class VictoryContainer extends React.Component {
     return this.timer;
   }
 
+  getIdForElement(elementName) {
+    return `${this.containerId}-${elementName}`;
+  }
+
   // overridden in custom containers
   getChildren(props) {
     return props.children;
@@ -97,8 +102,8 @@ export default class VictoryContainer extends React.Component {
         <svg {...parentProps}>
           {children}
         </svg>
-          {title ? <title id="title">{title}</title> : null}
-          {desc ? <desc id="desc">{desc}</desc> : null}
+          {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
+          {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
         {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
       </svg>
     );
@@ -109,7 +114,8 @@ export default class VictoryContainer extends React.Component {
     const style = responsive ? this.props.style : omit(this.props.style, ["height", "width"]);
     const svgProps = assign(
       {
-        width, height, "aria-labelledby": "title desc", role: "img",
+        width, height, role: "img",
+        "aria-labelledby": `${this.getIdForElement("title")} ${this.getIdForElement("desc")}`,
         viewBox: responsive ? `0 0 ${width} ${height}` : undefined
       },
       events


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/victory/issues/515.

Previously we were rendering every title and desc with the same HTML id. Therefore, screen readers would always read the _first_ occurrence of a title or desc; if there were multiple Victory elements on a page, only one of them would show the correct title and desc.