### PR TITLE
Bug/angular width for stacked bars

### DIFF
--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -95,7 +95,8 @@ export default class Bar extends React.Component {
 
   getAngularWidth(props, datum, width) {
     const { scale } = props;
-    const r = scale.y(datum._y);
+    const range = scale.y.range();
+    const r = Math.max(...range);
     const angularRange = Math.abs(scale.x.range()[1] - scale.x.range()[0]);
     return (width / (2 * Math.PI * r)) * angularRange;
   }
@@ -133,6 +134,7 @@ export default class Bar extends React.Component {
     const { datum, scale, style, index } = props;
     const r1 = scale.y(datum._y0 || 0);
     const r2 = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
+    console.log(datum.y, r1, r2)
     const currentAngle = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
     let start;
     let end;

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -93,7 +93,7 @@ export default class Bar extends React.Component {
     return -1 * angle + (Math.PI / 2);
   }
 
-  getAngularWidth(props, datum, width) {
+  getAngularWidth(props, width) {
     const { scale } = props;
     const range = scale.y.range();
     const r = Math.max(...range);
@@ -134,12 +134,11 @@ export default class Bar extends React.Component {
     const { datum, scale, style, index } = props;
     const r1 = scale.y(datum._y0 || 0);
     const r2 = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
-    console.log(datum.y, r1, r2)
     const currentAngle = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
     let start;
     let end;
     if (style.width) {
-      const width = this.getAngularWidth(props, datum, style.width);
+      const width = this.getAngularWidth(props, style.width);
       start = currentAngle - (width / 2);
       end = currentAngle + (width / 2);
     } else {


### PR DESCRIPTION
In order for angular width to remain constant for stacked bars, we must use the overall radius of the chart rather than the radius of each data point to calculate angular width. This means that bar widths will be the width of each bar at the max radius. Bars of different heights must be different thicknesses.