### PR TITLE
transform slice

### DIFF
--- a/src/victory-primitives/slice.js
+++ b/src/victory-primitives/slice.js
@@ -45,13 +45,15 @@ export default class Slice extends React.Component {
 
   // Overridden in victory-core-native
   renderSlice(path, style, events) {
-    const { role, shapeRendering, className } = this.props;
+    const { role, shapeRendering, className, origin } = this.props;
+    const transform = origin ? `translate(${origin.x}, ${origin.y})` : undefined;
     return (
       <path
         d={path}
         className={className}
         role={role || "presentation"}
         style={style}
+        transform={transform}
         shapeRendering={shapeRendering || "auto"}
         {...events}
       />


### PR DESCRIPTION
translates the slice primitive to a given origin rather than allowing VictoryPie to translate an entire pie including labels. Supports https://github.com/FormidableLabs/victory/issues/639