### PR TITLE
Webpack3 + ES6 Exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "extends": "builder-victory-component/config/babel/.babelrc"
+  "extends": "builder-victory-component/config/babel/.babelrc-react"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ $RECYCLE.BIN/
 
 # App specific
 .tmp
+.vscode
 bower_components
 coverage
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bower_components
 coverage
 dist
 lib
+es
 node_modules
 npm-debug.log*
 yarn.lock

--- a/.npmignore.publishr
+++ b/.npmignore.publishr
@@ -1,6 +1,7 @@
 /*
 !/dist
 dist/*.map
+!/es
 !/lib
 !/src
 !LICENSE.txt

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "builder": "^3.2.1",
-    "builder-victory-component": "^4.0.4",
+    "builder-victory-component": "^5.0.0",
     "d3-ease": "^1.0.0",
     "d3-interpolate": "^1.1.1",
     "d3-scale": "^1.0.0",
@@ -38,7 +38,7 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^4.0.4",
+    "builder-victory-component-dev": "^5.0.0",
     "chai": "^3.5.0",
     "enzyme": "^2.4.1",
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "16.1.1",
   "description": "Victory Core",
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/FormidableLabs/victory-core.git"
@@ -17,7 +19,7 @@
     "npm": ">=2.0.0"
   },
   "scripts": {
-    "postinstall": "cd lib || builder run npm:postinstall",
+    "postinstall": "builder run npm:postinstall",
     "preversion": "builder run npm:preversion",
     "postversion": "builder run npm:postversion",
     "postpublish": "builder run npm:postpublish",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "builder": "^3.2.1",
-    "builder-victory-component": "^5.0.0",
+    "builder-victory-component": "^5.0.1",
     "d3-ease": "^1.0.0",
     "d3-interpolate": "^1.1.1",
     "d3-scale": "^1.0.0",
@@ -38,7 +38,7 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^5.0.0",
+    "builder-victory-component-dev": "^5.0.1",
     "chai": "^3.5.0",
     "enzyme": "^2.4.1",
     "mocha": "^3.0.2",

--- a/test/client/main.js
+++ b/test/client/main.js
@@ -34,7 +34,6 @@ srcReq.keys().map(srcReq);
 
 // Use webpack to infer and `require` tests automatically.
 const testsReq = require.context(".", true, /\.spec.jsx?$/);
-
 testsReq.keys().map(testsReq);
 
 // Only start mocha in browser.


### PR DESCRIPTION
This PR modernizes the Victory build and offerings. Generally:

- Provide an `es/` directory alongside `lib/` that has ES module export / imports (but everything else babel built) per the `redux` model. This model allows webpack2+ to use ESM resolution and enable tree-shaking, while is still backwards compatible with webpack1 which will use `lib/`
- Remove all references to `.jsx` since we don't use those anymore.
- Clean up and hone down a lot of stuff.

/cc @boygirl @chrisbolin

### Cross-reference PRs

First, infrastructure:

* https://github.com/FormidableLabs/builder-victory-component-dev/pull/7
* https://github.com/FormidableLabs/builder-victory-component/pull/92

Second, core:

* https://github.com/FormidableLabs/victory-core/pull/266

Third, dependers:

* https://github.com/FormidableLabs/victory-pie/pull/149
* https://github.com/FormidableLabs/victory-chart/pull/495

Finally, parent:

* https://github.com/FormidableLabs/victory/pull/651

### Tickets

Implemented / fixed:

- Provide es6 build to use with Webpack. Fixes https://github.com/FormidableLabs/victory/issues/256
- Provide efficient webpack helpers for tree-shaking + DCE. Fixes https://github.com/FormidableLabs/victory/issues/548

Opened / still open:

- Webpack tree shaking does not completely remove unused re-exports. https://github.com/FormidableLabs/victory/issues/549

### Bundles

The main goal here is not the victory _bundle_, but enabling webpack2+ users to get more efficient builds going off the `es/` directory. And with the dedupe plugin being removed in webpack2+, our dev bundle is definitely bigger. But, fortunately, the prod minified bundles aren't that different:

*Before / webpack1*

```
$ find ../victory*/dist -type f -exec wc -c {} \;
  993198 ../victory-chart/dist/victory-chart.js
 1323555 ../victory-chart/dist/victory-chart.js.map
  438868 ../victory-chart/dist/victory-chart.min.js
 2634923 ../victory-chart/dist/victory-chart.min.js.map
  659513 ../victory-core/dist/victory-core.js
  915723 ../victory-core/dist/victory-core.js.map
  276427 ../victory-core/dist/victory-core.min.js
 1734458 ../victory-core/dist/victory-core.min.js.map
  674687 ../victory-pie/dist/victory-pie.js
  836742 ../victory-pie/dist/victory-pie.js.map
  284790 ../victory-pie/dist/victory-pie.min.js
 1814890 ../victory-pie/dist/victory-pie.min.js.map
 1013340 ../victory/dist/victory.js
 1235399 ../victory/dist/victory.js.map
  450323 ../victory/dist/victory.min.js
 2747731 ../victory/dist/victory.min.js.map
```

*After / webpack3*

```
$ find ../victory*/dist -type f -exec wc -c {} \;
 1663000 ../victory-chart/dist/victory-chart.js
 1602704 ../victory-chart/dist/victory-chart.js.map
  434851 ../victory-chart/dist/victory-chart.min.js
 3349108 ../victory-chart/dist/victory-chart.min.js.map
  975040 ../victory-core/dist/victory-core.js
  941706 ../victory-core/dist/victory-core.js.map
  265075 ../victory-core/dist/victory-core.min.js
 1930341 ../victory-core/dist/victory-core.min.js.map
 1219152 ../victory-pie/dist/victory-pie.js
 1092945 ../victory-pie/dist/victory-pie.js.map
  304427 ../victory-pie/dist/victory-pie.min.js
 2396990 ../victory-pie/dist/victory-pie.min.js.map
 1869374 ../victory/dist/victory.js
 1680468 ../victory/dist/victory.js.map
  487115 ../victory/dist/victory.min.js
 3846520 ../victory/dist/victory.min.js.map
```