### PR TITLE
#641 - Changes the propTypes for 'x' and 'y' props in VictoryLabel to accept percentage string values

### DIFF
--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -88,8 +88,14 @@ export default class VictoryLabel extends React.Component {
       ]),
       PropTypes.func
     ]),
-    x: PropTypes.number,
-    y: PropTypes.number
+    x: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
+    ]),
+    y: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
+    ])
   };
 
   static defaultProps = {

--- a/test/client/spec/victory-label/victory-label.spec.js
+++ b/test/client/spec/victory-label/victory-label.spec.js
@@ -26,6 +26,15 @@ describe("components/victory-label", () => {
     expect(output.prop("dy")).to.eql(34.97);
   });
 
+  it("sets x and y for text element", () => {
+    const wrapper = shallow(
+      <VictoryLabel x={"100%"} y={30} text={"such text, wow"}/>
+    );
+    const output = wrapper.find("text");
+    expect(output.prop("x")).to.eql("100%");
+    expect(output.prop("y")).to.eql(30);
+  });
+
   it("has a transform property that rotates the text to match the labelAngle prop", () => {
     const wrapper = shallow(
       <VictoryLabel angle={46} text={"such text, wow"}/>


### PR DESCRIPTION
This is an improvement to resolve this issue: https://github.com/FormidableLabs/victory/issues/641. The propTypes around the 'x' and 'y' props in VictoryLabel did not allow percentages, though setting percentages did work. The propTypes have been changed to allow string values as well as numbers.