### PR TITLE
WIP: container rerenders

### DIFF
--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -165,11 +165,12 @@ export default class VictoryTransition extends React.Component {
               ) :
               child.props.groupComponent;
             return React.cloneElement(
-              child, defaults({ animate: null, groupComponent }, newProps, combinedProps)
+              child,
+              defaults({ animate: null, animating: true, groupComponent }, newProps, combinedProps)
             );
           }
           return React.cloneElement(
-            child, defaults({ animate: null }, newProps, combinedProps)
+            child, defaults({ animate: null, animating: true }, newProps, combinedProps)
           );
         }}
       </VictoryAnimation>

--- a/src/victory-util/add-events.js
+++ b/src/victory-util/add-events.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  defaults, assign, isFunction, partialRight, pick, without, isEqual, cloneDeep
+  defaults, assign, isFunction, partialRight, pick, without, isEqual, cloneDeep, get
 } from "lodash";
 import Events from "./events";
 import VictoryTransition from "../victory-transition/victory-transition";
@@ -36,12 +36,12 @@ export default (WrappedComponent) => {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-      if (this.props.animating || this.props.forceUpdate) { return true; }
+      if (this.props.animating || get(nextProps, "sharedEvents.events.length")) {
+        return true;
+      }
 
       const stateChange = !isEqual(this.stateCopy, nextState);
-
       this.stateCopy = cloneDeep(this.state); // save state copy, as events.js must mutate in-place
-
       if (stateChange) {
         return true;
       }

--- a/src/victory-util/add-events.js
+++ b/src/victory-util/add-events.js
@@ -39,8 +39,13 @@ export default (WrappedComponent) => {
     shouldComponentUpdate(nextProps, nextState) {
       if (
         this.props.animating // cannot use props.animate, as this is set to null during animation
-        || get(nextProps, "sharedEvents.events.length") // for parent events
+        || get(nextProps, "sharedEvents.events.length") // [semi-HACK] for parent events
       ) {
+        return true;
+      }
+
+      // [HACK] this is sloppy: if a standalone component with an evented container, force rerender
+      if (this.props.standalone && this.props.containerComponent.type.defaultEvents) {
         return true;
       }
 


### PR DESCRIPTION
**Work in progress**

towards fixing https://github.com/FormidableLabs/victory/issues/658

### Goal

Eliminate the tremendous unnecessary work (not just re-renders, more on that later) done by charts with large data sets (1k to 50k points) that use evented containers (cursor, brush, selection, voronoi, zoom).

### Implementation

Core's `addEvents` HOC adds a `shouldComponentUpdate` that compares props, state, and a few other parameters. It is [heavily commented](https://github.com/FormidableLabs/victory-core/pull/271/files#diff-37a2944489decffecd8d53ec8bc052b7) to shed light on each of the decisions.

### Important Finding

**It is not simply rendering of thousands of SVG nodes that is causing performance degradation.** There are a two pieces of proof for this:

The `shouldComponentUpdate` in `addEvents` is very important, as the `shouldComponentUpdate` call in dataComponents (e.g. `Curve`) _is functional but not helpful_. `Curve`'s sCU works correctly, and prevents rerenders, but performance is still hugely degraded by large datasets. Even forcing `Curve` to never rerender does not change the performance whatsoever; but forcing VictoryLine etc to never rerender has _huge_ benefits. Therefore the extra work must be somewhere in between the two.

Chrome's performance inspect shows most of the work being on in JavaScript, not in rendering (taken from VictoryCursorContainer with 20k data points):

<img width="302" alt="screen shot 2017-07-21 at 9 37 23 am" src="https://user-images.githubusercontent.com/2822048/28472526-e695e682-6e0e-11e7-8032-c5e428588b23.png">

### Results

Some containers improved performance drastically, other maintained performance. There was no degradation in performance, proving that _deep equality on large datasets checks are performant_.

- VictoryBrushContainer and VictorySelectionContainer. 5k points, 12x improvement (4.3 fps to 55 fps). 50k points, 50x improvement (0.4 fps to 20 fps). 
- VictoryCursorContainer. 5k points, 6x improvement (4.3 fps to 27 fps). 50k points, 11x improvement (0.8 fps to 9 fps)
- VictoryZoomContainer. No change in performance (to be expected) in 5k or 50k points.
- VictoryVoronoiContainer. Slight improvement (+70% in fps)

Demo with VictoryCursorContainer and 20,000 data points. (Note that new data would still cause a rerender, so the chart is fully functional).

![jul-21-2017 11-54-10 -- before](https://user-images.githubusercontent.com/2822048/28471782-407e8f30-6e0c-11e7-897a-d4dfbb13d007.gif)

![jul-21-2017 11-55-23 -- after](https://user-images.githubusercontent.com/2822048/28471783-42658cb8-6e0c-11e7-8da7-6ae5ae345759.gif)

### Unfinished Work

There are two remaining problems:
- Victory "Data" components (VictoryLine etc) that have a containerComponent directly on them fail to update very quickly. I believe this is because parent events are not accounted for. There is currently a hack in sCU that checks for `this.props.containerComponent.type.defaultEvents` and `this.props.standalone`.
- The same behavior as described above still exists in Voronoi and Selection containers, even with the hack and even when wrapped in a VictoryChart. This is likely because they modify the `data` prop, but that modification happens after sCU runs, so sCU doesn't see a difference.

### Notes

- No changes needed to `victory-chart`.
- Demo: it's very helpful to have good demos for this. `victory-chart` has a branch with the same name as this https://github.com/FormidableLabs/victory-chart/tree/658-container-rerenders and a demo under http://localhost:3000/#/debug which