### PR TITLE
Always use scale.x for getBarWidth

### DIFF
--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -167,8 +167,8 @@ export default class Bar extends React.Component {
     if (style.width) {
       return style.width;
     }
-    const { scale, data, horizontal } = props;
-    const range = horizontal ? scale.y.range() : scale.x.range();
+    const { scale, data } = props;
+    const range = scale.x.range();
     const extent = Math.abs(range[1] - range[0]);
     const bars = data.length + 2;
     const barRatio = 0.5;


### PR DESCRIPTION
Victory-bar handles switching the x and y scales for horizontal bars in [getCalculatedValues](https://github.com/FormidableLabs/victory-chart/blob/master/src/components/victory-bar/helper-methods.js#L40):

```javascript
const scale = {
  x: horizontal ? yScale : xScale,
  y: horizontal ? xScale : yScale
};
```

Currently, the getBarWidth function switches them again to calculate width: 

```javascript
const range = horizontal ? scale.y.range() : scale.x.range();
```

Because of this, horizontal Bars rendered by VictoryBar actually end up using their VictoryBar's xScale to determine their widths. This results in the following bug:

![image](https://user-images.githubusercontent.com/8824442/28550344-fb5508cc-7094-11e7-9750-fd91fe074507.png) | 
![image](https://user-images.githubusercontent.com/8824442/28550355-062b8e38-7095-11e7-9063-a24d479f89b9.png)
--- | --- 

This patch remediates the problem by always using scale.x in getBarWidth, under the assumption that scale.x will in fact be a parent VictoryBar's yScale if the Bar is horizontal.