### PR TITLE
add Data.downsampleSimple and Data.downsampleZoomFriendly

### DIFF
--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -247,34 +247,15 @@ export default {
   },
 
   /**
-   * Reduces the size of a data array, such that data.length <= maxPoints.
-   * @param {Array} data: an array of data; must be sorted
-   * @param {Number} maxPoints: maximum number of data points to return
-   * @returns {Array} an array of data, a subset of data param
-   */
-  downsampleSimple(data, maxPoints) {
-    // crude (but fast!) downsampling that simply selects every `k`th point
-    if (data.length > maxPoints) {
-      const k = Math.ceil(data.length / maxPoints);
-      return data.filter(
-        (d, i) => ((i % k) === 0)
-      );
-    }
-    return data;
-  },
-
-  /**
-   * Reduces the size of a data array, such that it is <= maxPoints. Specialized for zoommed data.
+   * Reduces the size of a data array, such that it is <= maxPoints.
    * @param {Array} data: an array of data; must be sorted
    * @param {Number} maxPoints: maximum number of data points to return
    * @param {Number} startingIndex: the index of the data[0] *in the entire dataset*; this function
                      assumes `data` param is a subset of larger dataset that has been zoommed
    * @returns {Array} an array of data, a subset of data param
    */
-  downsampleZoomFriendly(data, maxPoints, startingIndex = 0) {
+  downsample(data, maxPoints, startingIndex = 0) {
     // ensures that the downampling of data while zooming looks good.
-    // simply using downsampleSimple would result in a "flicker" of data points while zoomming
-    // downsize: always returns fewer points than downsampleSimple (and requires a bit more math)
     if (data.length > maxPoints) {
       // limit k to powers of 2, e.g. 64, 128, 256
       // so that the same points will be chosen reliably, reducing flicker on zoom

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -244,5 +244,46 @@ export default {
   getCategories(props, axis) {
     return props.categories && !Array.isArray(props.categories) ?
       props.categories[axis] : props.categories;
+  },
+
+  /**
+   * Reduces the size of a data array, such that data.length <= maxPoints.
+   * @param {Array} data: an array of data; must be sorted
+   * @param {Number} maxPoints: maximum number of data points to return
+   * @returns {Array} an array of data, a subset of data param
+   */
+  downsampleSimple(data, maxPoints) {
+    // crude (but fast!) downsampling that simply selects every `k`th point
+    if (data.length > maxPoints) {
+      const k = Math.ceil(data.length / maxPoints);
+      return data.filter(
+        (d, i) => ((i % k) === 0)
+      );
+    }
+    return data;
+  },
+
+  /**
+   * Reduces the size of a data array, such that it is <= maxPoints. Specialized for zoommed data.
+   * @param {Array} data: an array of data; must be sorted
+   * @param {Number} maxPoints: maximum number of data points to return
+   * @param {Number} startingIndex: the index of the data[0] *in the entire dataset*; this function
+                     assumes `data` param is a subset of larger dataset that has been zoommed
+   * @returns {Array} an array of data, a subset of data param
+   */
+  downsampleZoomFriendly(data, maxPoints, startingIndex = 0) {
+    // ensures that the downampling of data while zooming looks good.
+    // simply using downsampleSimple would result in a "flicker" of data points while zoomming
+    // downsize: always returns fewer points than downsampleSimple (and requires a bit more math)
+    if (data.length > maxPoints) {
+      // limit k to powers of 2, e.g. 64, 128, 256
+      // so that the same points will be chosen reliably, reducing flicker on zoom
+      const k = Math.pow(2, Math.ceil(Math.log2(data.length / maxPoints)));
+      return data.filter(
+        // ensure modulo is always calculated from same reference: i + startingIndex
+        (d, i) => (((i + startingIndex) % k) === 0)
+      );
+    }
+    return data;
   }
 };


### PR DESCRIPTION
Summary below. Details in the code.

`Data.downsampleSimple(data, maxPoints)`

Good (and fast) for general use. Shouldn't be used with Zoom though:

![jul-28-2017 12-12-44 - zoom ugly](https://user-images.githubusercontent.com/2822048/28730204-102b1182-739d-11e7-9560-4a29f6c176a6.gif)

`Data.downsampleZoomFriendly(data, maxPoints, startingIndex)`

Starting index is the index relative to the _entire unzoomed dataset_. See `downsampleZoomData` in `VictoryZoomContainer` for more details. Looks good while zoomed :) 

![jul-28-2017 12-12-57 zoom pretty](https://user-images.githubusercontent.com/2822048/28730173-fbb7dd7a-739c-11e7-960e-43a9eb37821e.gif)
