### PR TITLE
Experiment/touch events

### DIFF
--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -112,6 +112,7 @@ export default class VictoryContainer extends React.Component {
   render() {
     const { width, height, responsive, events } = this.props;
     const style = responsive ? this.props.style : omit(this.props.style, ["height", "width"]);
+    const touchStyle = assign({}, style, { touchAction: "none" });
     const svgProps = assign(
       {
         width, height, role: "img",
@@ -120,6 +121,6 @@ export default class VictoryContainer extends React.Component {
       },
       events
     );
-    return this.renderContainer(this.props, svgProps, style);
+    return this.renderContainer(this.props, svgProps, touchStyle);
   }
 }

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -107,7 +107,29 @@ export default class VictoryTooltip extends React.Component {
           }
         ];
       },
+      onTouchStart: (targetProps) => {
+        return [
+          {
+            target: "labels",
+            mutation: () => ({ active: true })
+          }, {
+            target: "data",
+            mutation: () => targetProps.activateData ? ({ active: true }) : ({ active: undefined })
+          }
+        ];
+      },
       onMouseOut: () => {
+        return [
+          {
+            target: "labels",
+            mutation: () => ({ active: undefined })
+          }, {
+            target: "data",
+            mutation: () => ({ active: undefined })
+          }
+        ];
+      },
+      onTouchEnd: () => {
         return [
           {
             target: "labels",

--- a/src/victory-util/selection.js
+++ b/src/victory-util/selection.js
@@ -25,7 +25,7 @@ export default {
         y: evt.nativeEvent.locationY
       };
     }
-    evt = evt.changedTouches ? evt.changedTouches[0] : evt;
+    evt = evt.changedTouches && evt.changedTouches.length ? evt.changedTouches[0] : evt;
     const svg = this.getParentSVG(evt.target);
     const matrix = this.getTransformationMatrix(svg);
     return {

--- a/src/victory-util/selection.js
+++ b/src/victory-util/selection.js
@@ -25,6 +25,7 @@ export default {
         y: evt.nativeEvent.locationY
       };
     }
+    evt = evt.changedTouches ? evt.changedTouches[0] : evt;
     const svg = this.getParentSVG(evt.target);
     const matrix = this.getTransformationMatrix(svg);
     return {


### PR DESCRIPTION
cc/ @chrisbolin 

This PR supports touch events for containers.  The changes are pretty simple. Just swapping out `event` for `event.changedTouches[0]` 

I also needed to add `{ touchAction: "none" }` to container styles to prevent default touch scroll actions, since `preventDefault` doesn't work with passive events: (see this issue: https://github.com/facebook/react/issues/8968)