### PR TITLE
Add test for victory legend groupComponent

### DIFF
--- a/test/client/spec/victory-legend/victory-legend.spec.js
+++ b/test/client/spec/victory-legend/victory-legend.spec.js
@@ -205,3 +205,42 @@ describe("components/victory-legend", () => {
     });
   });
 });
+
+const LegendGroupTest = (props) => {
+  const { width, height } = props; // eslint-disable-line react/prop-types
+  expect(width).to.be.above(0);
+  expect(height).to.be.above(0);
+  return <div />;
+};
+
+describe("groupComponent", () => {
+  const legendData = [{
+    name: "Series 1",
+    labels: {
+      fontSize: 10
+    },
+    symbol: {
+      type: "circle",
+      fill: "red"
+    }
+  }, {
+    name: "Long Series Name",
+    labels: {
+      fontSize: 12
+    },
+    symbol: {
+      type: "triangleUp",
+      fill: "blue"
+    }
+  }];
+
+  it("has width and height values set", () => {
+    render(
+      <VictoryLegend
+        data={legendData}
+        standalone={false}
+        groupComponent={<LegendGroupTest />}
+      />
+    );
+  });
+});


### PR DESCRIPTION
This test fails on v0.21.3; passes on v0.21.2
See [Issue #692 in Victory repo](https://github.com/FormidableLabs/victory/issues/692).

When passing a `groupComponent` to Victory Legend, in 0.21.2 the component would get valid values for `width` and `height`. In 0.21.3 both `width` and `height` are 0.

It looks like this bug was introduced in 7432a72 where previously the victory-legend `render` method would call `getCalculatedProps` where the width & height would then get populated.
Similar code is now in the 'victory-legend/helper-methods.js': `calculateLegendHeight` and `calculateLegendWidth` which are called from the exported `default`. However, that default is imported in 'victory-legend' as `getBaseProps` and then *not called*. (In render, [the props are constructed](https://github.com/FormidableLabs/victory-core/commit/7432a7292febca88e7e18800b462c0d49d26f00d#diff-6da5f8e213cd6fa075b7f42184b3da09R100) - not calling `getBaseProps` and the `renderContainer` isn't actually passed those constructed props.)

I tried to fix this by calling `getBaseProps` but was unable to figure out how that should be done inside the `VictoryLegend` component.