### PR TITLE
BREAKING CHANGE: VictoryTooltip should not have a default theme

### DIFF
--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -86,7 +86,6 @@ export default class VictoryTooltip extends React.Component {
   };
 
   static defaultProps = {
-    theme: VictoryTheme.grayscale,
     active: false,
     renderInPortal: true,
     labelComponent: <VictoryLabel/>,
@@ -209,7 +208,8 @@ export default class VictoryTooltip extends React.Component {
   }
 
   getCalculatedValues(props) {
-    const { style, text, datum, theme, active } = props;
+    const { style, text, datum, active } = props;
+    const theme = props.theme || VictoryTheme.grayscale;
     const defaultLabelStyles = theme && theme.tooltip && theme.tooltip.style ?
       theme.tooltip.style : {};
     const baseLabelStyle = Array.isArray(style) ?


### PR DESCRIPTION
fixes https://github.com/FormidableLabs/victory/issues/719

**this will be a breaking change for people who are using their own themes, but not defining any tooltip theme. To compensate for this change, add the following to your theme object:**

```
tooltip: {
    style: assign({}, centeredLabelStyles, { padding: 5, pointerEvents: "none" }),
    flyoutStyle: {
      stroke: charcoal,
      strokeWidth: 1,
      fill: "#f0f0f0",
      pointerEvents: "none"
    },
    cornerRadius: 5,
    pointerLength: 10
  }
```