### PR TITLE
Render Charts in `div`

### DIFF
--- a/src/victory-clip-container/victory-clip-container.js
+++ b/src/victory-clip-container/victory-clip-container.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import CustomPropTypes from "../victory-util/prop-types";
 import { assign, defaults, isFunction } from "lodash";
 import ClipPath from "../victory-primitives/clip-path";
 
@@ -12,18 +13,18 @@ export default class VictoryClipContainer extends React.Component {
       PropTypes.node
     ]),
     className: PropTypes.string,
-    clipHeight: PropTypes.number,
+    clipHeight: CustomPropTypes.nonNegative,
     clipId: PropTypes.number,
     clipPadding: PropTypes.shape({
       top: PropTypes.number, bottom: PropTypes.number,
       left: PropTypes.number, right: PropTypes.number
     }),
     clipPathComponent: PropTypes.element,
-    clipWidth: PropTypes.number,
+    clipWidth: CustomPropTypes.nonNegative,
     events: PropTypes.object,
-    origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
+    origin: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
     polar: PropTypes.bool,
-    radius: PropTypes.number,
+    radius: CustomPropTypes.nonNegative,
     style: PropTypes.object,
     transform: PropTypes.string,
     translateX: PropTypes.number,

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -95,24 +95,26 @@ export default class VictoryContainer extends React.Component {
   }
 
   renderContainer(props, svgProps, style) {
-    const { title, desc, portalComponent, className } = props;
+    const { title, desc, portalComponent, className, width, height } = props;
     const children = this.getChildren(props);
-    const parentProps = defaults({ style, className }, svgProps);
+    const parentSvgStyle = {
+      width: "100%", height: "100%", maxWidth: "100%", maxHeight: "100%", pointerEvents: "all"
+    };
+    const portalSvgStyle = { width: "100%", height: "100%", overflow: "visible" };
+    const marginTop = `-${100 * height / width}%`; //eslint-disable-line no-magic-numbers
     return (
-        <svg {...parentProps} overflow="visible">
-        <svg>
+      <div style={assign(style, { pointerEvents: "none" })} className={className}>
+        <svg {...svgProps} style={parentSvgStyle}>
           {children}
         </svg>
           {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
-        <foreignObject>
-          <div style={{ zIndex: 1, position: "relative", pointerEvents: "none" }}>
-            <svg overflow="visible">
+          <div style={{ zIndex: 1, position: "relative", pointerEvents: "none", marginTop }}>
+            <svg {...svgProps} style={portalSvgStyle}>
               {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
             </svg>
           </div>
-        </foreignObject>
-        </svg>
+        </div>
     );
   }
 

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -98,6 +98,7 @@ export default class VictoryContainer extends React.Component {
     const { title, desc, portalComponent, className, width, height } = props;
     const children = this.getChildren(props);
     const parentProps = defaults({ style, className }, svgProps);
+    const percent = `${-height / width * 100}%`;
     return (
       <div style={Object.assign(style, { position: "relative" })}>
         <svg viewBox={parentProps.viewBox} style={{ width: "100%", height: "100%" }}>
@@ -106,7 +107,7 @@ export default class VictoryContainer extends React.Component {
           {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
         <foreignObject>
-          <div style={{ zIndex: 1, position: "relative", marginTop: -height, pointerEvents: "none" }}>
+          <div style={{ zIndex: 1, position: "relative", marginTop: percent, pointerEvents: "none" }}>
             <svg viewBox={parentProps.viewBox} style={{ width: "100%", height: "100%" }} overflow="visible">
               {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
             </svg>

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -46,7 +46,7 @@ export default class VictoryContainer extends React.Component {
   constructor(props) {
     super(props);
     this.getTimer = this.getTimer.bind(this);
-    this.containerId = !(isObject(props) && typeof props.containerId === "undefined") ?
+    this.containerId = !isObject(props) || typeof props.containerId === "undefined" ?
       uniqueId("victory-container-") : props.containerId;
   }
 
@@ -97,20 +97,19 @@ export default class VictoryContainer extends React.Component {
   renderContainer(props, svgProps, style) {
     const { title, desc, portalComponent, className, width, height } = props;
     const children = this.getChildren(props);
-    const parentSvgStyle = {
-      width: "100%", height: "100%", maxWidth: "100%", maxHeight: "100%", pointerEvents: "all"
-    };
-    const portalSvgStyle = { width: "100%", height: "100%", overflow: "visible" };
-    const marginTop = `-${100 * height / width}%`; //eslint-disable-line no-magic-numbers
+    const divStyle = { pointerEvents: "none", touchAction: "none" };
+    const svgStyle = { width: "100%", height: "100%" };
+    //eslint-disable-next-line no-magic-numbers
+    const marginTop = `-${Math.round(100 * height / width)}%`;
     return (
-      <div style={assign(style, { pointerEvents: "none" })} className={className}>
-        <svg {...svgProps} style={parentSvgStyle}>
-          {children}
-        </svg>
+      <div style={defaults({}, style, divStyle)} className={className}>
+        <svg {...svgProps} style={{ ...svgStyle, pointerEvents: "all" }}>
           {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
-          <div style={{ zIndex: 1, position: "relative", pointerEvents: "none", marginTop }}>
-            <svg {...svgProps} style={portalSvgStyle}>
+          {children}
+        </svg>
+          <div style={{ ...divStyle, zIndex: 1, position: "relative", marginTop }}>
+            <svg {...svgProps} style={{ ...svgStyle, overflow: "visible" }}>
               {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
             </svg>
           </div>
@@ -121,7 +120,6 @@ export default class VictoryContainer extends React.Component {
   render() {
     const { width, height, responsive, events } = this.props;
     const style = responsive ? this.props.style : omit(this.props.style, ["height", "width"]);
-    const touchStyle = defaults({}, style, { touchAction: "none" });
     const svgProps = assign(
       {
         width, height, role: "img",
@@ -130,6 +128,6 @@ export default class VictoryContainer extends React.Component {
       },
       events
     );
-    return this.renderContainer(this.props, svgProps, touchStyle);
+    return this.renderContainer(this.props, svgProps, style);
   }
 }

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -95,25 +95,24 @@ export default class VictoryContainer extends React.Component {
   }
 
   renderContainer(props, svgProps, style) {
-    const { title, desc, portalComponent, className, width, height } = props;
+    const { title, desc, portalComponent, className } = props;
     const children = this.getChildren(props);
     const parentProps = defaults({ style, className }, svgProps);
-    const percent = `${-height / width * 100}%`;
     return (
-      <div style={Object.assign(style, { position: "relative" })}>
-        <svg viewBox={parentProps.viewBox} style={{ width: "100%", height: "100%" }}>
+        <svg {...parentProps} overflow="visible">
+        <svg>
           {children}
         </svg>
           {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
         <foreignObject>
-          <div style={{ zIndex: 1, position: "relative", marginTop: percent, pointerEvents: "none" }}>
-            <svg viewBox={parentProps.viewBox} style={{ width: "100%", height: "100%" }} overflow="visible">
+          <div style={{ zIndex: 1, position: "relative", pointerEvents: "none" }}>
+            <svg overflow="visible">
               {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
             </svg>
           </div>
         </foreignObject>
-      </div>
+        </svg>
     );
   }
 

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import CustomPropTypes from "../victory-util/prop-types";
 import { assign, omit, defaults, uniqueId, isObject } from "lodash";
 import Portal from "../victory-portal/portal";
 import Timer from "../victory-util/timer";
@@ -16,19 +17,21 @@ export default class VictoryContainer extends React.Component {
     containerId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     desc: PropTypes.string,
     events: PropTypes.object,
-    height: PropTypes.number,
-    origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
+    height: CustomPropTypes.nonNegative,
+    origin: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
     polar: PropTypes.bool,
     portalComponent: PropTypes.element,
+    portalZIndex: CustomPropTypes.integer,
     responsive: PropTypes.bool,
     style: PropTypes.object,
     theme: PropTypes.object,
     title: PropTypes.string,
-    width: PropTypes.number
+    width: CustomPropTypes.nonNegative
   }
 
   static defaultProps = {
     portalComponent: <Portal/>,
+    portalZIndex: 99,
     responsive: true
   }
 
@@ -95,12 +98,15 @@ export default class VictoryContainer extends React.Component {
   }
 
   renderContainer(props, svgProps, style) {
-    const { title, desc, portalComponent, className, width, height } = props;
+    const { title, desc, portalComponent, className, width, height, portalZIndex } = props;
     const children = this.getChildren(props);
     const divStyle = { pointerEvents: "none", touchAction: "none" };
     const svgStyle = { width: "100%", height: "100%" };
     //eslint-disable-next-line no-magic-numbers
     const marginTop = `-${Math.round(100 * height / width)}%`;
+    const portalProps = {
+      width, height, viewBox: svgProps.viewBox, style: assign({}, svgStyle, { overflow: "visible" })
+    };
     return (
       <div style={defaults({}, style, divStyle)} className={className}>
         <svg {...svgProps} style={{ ...svgStyle, pointerEvents: "all" }}>
@@ -108,10 +114,8 @@ export default class VictoryContainer extends React.Component {
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
           {children}
         </svg>
-          <div style={{ ...divStyle, zIndex: 1, position: "relative", marginTop }}>
-            <svg {...svgProps} style={{ ...svgStyle, overflow: "visible" }}>
-              {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
-            </svg>
+          <div style={{ ...divStyle, zIndex: portalZIndex, position: "relative", marginTop }}>
+            {React.cloneElement(portalComponent, { ...portalProps, ref: this.savePortalRef })}
           </div>
         </div>
     );

--- a/src/victory-container/victory-container.js
+++ b/src/victory-container/victory-container.js
@@ -94,20 +94,25 @@ export default class VictoryContainer extends React.Component {
     return props.children;
   }
 
-  // Overridden in victory-core-native
   renderContainer(props, svgProps, style) {
-    const { title, desc, portalComponent, className } = props;
+    const { title, desc, portalComponent, className, width, height } = props;
     const children = this.getChildren(props);
     const parentProps = defaults({ style, className }, svgProps);
     return (
-      <svg {...parentProps} overflow="visible">
-        <svg {...parentProps}>
+      <div style={Object.assign(style, { position: "relative" })}>
+        <svg viewBox={parentProps.viewBox} style={{ width: "100%", height: "100%" }}>
           {children}
         </svg>
           {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
           {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
-        {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
-      </svg>
+        <foreignObject>
+          <div style={{ zIndex: 1, position: "relative", marginTop: -height, pointerEvents: "none" }}>
+            <svg viewBox={parentProps.viewBox} style={{ width: "100%", height: "100%" }} overflow="visible">
+              {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
+            </svg>
+          </div>
+        </foreignObject>
+      </div>
     );
   }
 

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -52,7 +52,7 @@ export default class VictoryLabel extends React.Component {
       CustomPropTypes.nonNegative,
       PropTypes.func
     ]),
-    origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
+    origin: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
     polar: PropTypes.bool,
     renderInPortal: PropTypes.bool,
     style: PropTypes.oneOfType([
@@ -89,11 +89,11 @@ export default class VictoryLabel extends React.Component {
       PropTypes.func
     ]),
     x: PropTypes.oneOfType([
-      PropTypes.number,
+      CustomPropTypes.nonNegative,
       PropTypes.string
     ]),
     y: PropTypes.oneOfType([
-      PropTypes.number,
+      CustomPropTypes.nonNegative,
       PropTypes.string
     ])
   };

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -71,9 +71,9 @@ class VictoryLegend extends React.Component {
       eventHandlers: PropTypes.object
     })),
     groupComponent: PropTypes.element,
-    gutter: PropTypes.number,
+    gutter: CustomPropTypes.nonNegative,
     height: CustomPropTypes.nonNegative,
-    itemsPerRow: PropTypes.number,
+    itemsPerRow: CustomPropTypes.nonNegative,
     labelComponent: PropTypes.element,
     orientation: PropTypes.oneOf(["horizontal", "vertical"]),
     padding: PropTypes.oneOfType([
@@ -103,8 +103,8 @@ class VictoryLegend extends React.Component {
     titleComponent: PropTypes.element,
     titleOrientation: PropTypes.oneOf(["top", "bottom", "left", "right"]),
     width: CustomPropTypes.nonNegative,
-    x: PropTypes.number,
-    y: PropTypes.number
+    x: CustomPropTypes.nonNegative,
+    y: CustomPropTypes.nonNegative
   };
 
   static defaultProps = {

--- a/src/victory-portal/portal.js
+++ b/src/victory-portal/portal.js
@@ -1,16 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
+import CustomPropTypes from "../victory-util/prop-types";
 
 export default class Portal extends React.Component {
   static displayName = "Portal";
 
   static propTypes = {
-    groupComponent: PropTypes.element
+    className: PropTypes.string,
+    height: CustomPropTypes.nonNegative,
+    style: PropTypes.object,
+    viewBox: PropTypes.string,
+    width: CustomPropTypes.nonNegative
   }
-
-  static defaultProps = {
-    groupComponent: <g/>
-  };
 
   constructor(props) {
     super(props);
@@ -34,15 +35,15 @@ export default class Portal extends React.Component {
     delete this.map[key];
   }
 
+  getChildren() {
+    return Object.keys(this.map).map((key) => {
+      const el = this.map[key];
+      return el ? React.cloneElement(el, { key }) : el;
+    });
+  }
+
   // Overridden in victory-core-native
   render() {
-    return React.cloneElement(
-      this.props.groupComponent,
-      {},
-      Object.keys(this.map).map((key) => {
-        const el = this.map[key];
-        return el ? React.cloneElement(el, { key }) : el;
-      })
-    );
+    return <svg {...this.props}>{this.getChildren()}</svg>;
   }
 }

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -354,8 +354,9 @@ export default class VictoryTooltip extends React.Component {
       return renderInPortal ? <VictoryPortal>{null}</VictoryPortal> : null;
     }
     const calculatedValues = this.getCalculatedValues(evaluatedProps);
+    const flyoutProps = this.getFlyoutProps(evaluatedProps, calculatedValues);
     const children = [
-      React.cloneElement(flyoutComponent, this.getFlyoutProps(evaluatedProps, calculatedValues)),
+      React.cloneElement(flyoutComponent, flyoutProps),
       React.cloneElement(labelComponent, this.getLabelProps(evaluatedProps, calculatedValues))
     ];
     const tooltip = React.cloneElement(
@@ -363,7 +364,17 @@ export default class VictoryTooltip extends React.Component {
       { role: "presentation", transform: calculatedValues.transform },
       children
     );
-    return renderInPortal ? <VictoryPortal>{tooltip}</VictoryPortal> : tooltip;
+    const zIndexTooltips = (
+      <foreignObject>
+        <div style={{ position: "relative", zIndex: 100 }}>
+          <svg overflow="visible">
+            {tooltip}
+          </svg>
+        </div>
+      </foreignObject>
+    );
+    // return renderInPortal ? <VictoryPortal>{tooltip}</VictoryPortal> : tooltip;
+    return renderInPortal ? <VictoryPortal>{zIndexTooltips}</VictoryPortal> : zIndexTooltips;
   }
 
   render() {

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -354,9 +354,8 @@ export default class VictoryTooltip extends React.Component {
       return renderInPortal ? <VictoryPortal>{null}</VictoryPortal> : null;
     }
     const calculatedValues = this.getCalculatedValues(evaluatedProps);
-    const flyoutProps = this.getFlyoutProps(evaluatedProps, calculatedValues);
     const children = [
-      React.cloneElement(flyoutComponent, flyoutProps),
+      React.cloneElement(flyoutComponent, this.getFlyoutProps(evaluatedProps, calculatedValues)),
       React.cloneElement(labelComponent, this.getLabelProps(evaluatedProps, calculatedValues))
     ];
     const tooltip = React.cloneElement(

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -81,8 +81,8 @@ export default class VictoryTooltip extends React.Component {
       CustomPropTypes.nonNegative,
       PropTypes.func
     ]),
-    x: PropTypes.number,
-    y: PropTypes.number
+    x: CustomPropTypes.nonNegative,
+    y: CustomPropTypes.nonNegative
   };
 
   static defaultProps = {
@@ -364,17 +364,7 @@ export default class VictoryTooltip extends React.Component {
       { role: "presentation", transform: calculatedValues.transform },
       children
     );
-    const zIndexTooltips = (
-      <foreignObject>
-        <div style={{ position: "relative", zIndex: 100 }}>
-          <svg overflow="visible">
-            {tooltip}
-          </svg>
-        </div>
-      </foreignObject>
-    );
     return renderInPortal ? <VictoryPortal>{tooltip}</VictoryPortal> : tooltip;
-    // return renderInPortal ? <VictoryPortal>{zIndexTooltips}</VictoryPortal> : zIndexTooltips;
   }
 
   render() {

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -373,8 +373,8 @@ export default class VictoryTooltip extends React.Component {
         </div>
       </foreignObject>
     );
-    // return renderInPortal ? <VictoryPortal>{tooltip}</VictoryPortal> : tooltip;
-    return renderInPortal ? <VictoryPortal>{zIndexTooltips}</VictoryPortal> : zIndexTooltips;
+    return renderInPortal ? <VictoryPortal>{tooltip}</VictoryPortal> : tooltip;
+    // return renderInPortal ? <VictoryPortal>{zIndexTooltips}</VictoryPortal> : zIndexTooltips;
   }
 
   render() {


### PR DESCRIPTION
this PR changes how portals are rendered to give z-index control to portal components

fixes https://github.com/FormidableLabs/victory/issues/752

This change should also make it easy to create a custom html portal for rendering html labels and tooltips

**This may be a breaking change for parent styles, as it changes the rendered tree**

before: 
```
<svg {...parentProps} overflow="visible">
  <svg {...parentProps}>
    {children}
  </svg>
    {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
    {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
   // portalComponent renders a <g>
  {React.cloneElement(portalComponent, { ref: this.savePortalRef })}
</svg>
```

after:
```
<div style={defaults({}, style, divStyle)} className={className}>
  <svg {...svgProps} style={{ ...svgStyle, pointerEvents: "all" }}>
    {title ? <title id={this.getIdForElement("title")}>{title}</title> : null}
    {desc ? <desc id={this.getIdForElement("desc")}>{desc}</desc> : null}
    {children}
  </svg>
  <div style={{ ...divStyle, zIndex: portalZIndex, position: "relative", marginTop }}>
    // portalComponent renders an <svg>
    {React.cloneElement(portalComponent, { ...portalProps, ref: this.savePortalRef })}
  </div>
</div>
```