### PR TITLE
Seed random numbers to work correctly with Storyshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.2.0",
     "d3-timer": "^1.0.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "mersenne-twister": "^1.1.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^5.0.1",

--- a/src/victory-clip-container/victory-clip-container.js
+++ b/src/victory-clip-container/victory-clip-container.js
@@ -1,8 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Twister from "mersenne-twister";
 import CustomPropTypes from "../victory-util/prop-types";
 import { assign, defaults, isFunction } from "lodash";
 import ClipPath from "../victory-primitives/clip-path";
+
+const seed = 1234;
+const generator = new Twister(seed);
 
 export default class VictoryClipContainer extends React.Component {
   static displayName = "VictoryClipContainer";
@@ -39,7 +43,7 @@ export default class VictoryClipContainer extends React.Component {
     super(props);
     this.clipId = props.clipId !== undefined ?
       props.clipId :
-      Math.round(Math.random() * 10000); // eslint-disable-line no-magic-numbers
+      Math.round(generator.random() * 10000); // eslint-disable-line no-magic-numbers
   }
 
   // Overridden in victory-core-native

--- a/src/victory-primitives/voronoi.js
+++ b/src/victory-primitives/voronoi.js
@@ -1,9 +1,13 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
+import Twister from "mersenne-twister";
 import Helpers from "../victory-util/helpers";
 import Collection from "../victory-util/collection";
 import CommonProps from "./common-props";
+
+const seed = 2345;
+const generator = new Twister(seed);
 
 export default class Voronoi extends React.Component {
   static propTypes = {
@@ -70,7 +74,7 @@ export default class Voronoi extends React.Component {
 
   // Overridden in victory-core-native
   renderPoint(paths, style, events) {
-    const clipId = paths.circle && `clipPath-${Math.random()}`;
+    const clipId = paths.circle && `clipPath-${generator.random()}`;
     const clipPath = paths.circle ? `url(#${clipId})` : undefined;
     const { role, shapeRendering, className } = this.props;
     const voronoiPath = (


### PR DESCRIPTION
Fixes FormidableLabs/victory#762

This shouldn't change the implementation at all, I just seeded the random numbers so that the sequence remains consistent and it can work with [storyshots](https://github.com/storybooks/storybook/tree/master/addons/storyshots)