### PR TITLE
use datum when label does not receive coords

### DIFF
--- a/src/victory-primitives/path-helpers.js
+++ b/src/victory-primitives/path-helpers.js
@@ -3,84 +3,95 @@ import { range } from "lodash";
 
 export default {
   circle(x, y, size) {
-    const s = Math.floor(size);
-    return `
-        M ${Math.floor(x)}, ${Math.floor(y)}
-        m ${-s}, 0
-        a ${s}, ${s} 0 1,0 ${s * 2},0
-        a ${s}, ${s} 0 1,0 ${-s * 2},0
-    `;
+    x = Math.round(x);
+    y = Math.round(y);
+    return `M ${x}, ${y}
+      m ${-size}, 0
+      a ${size}, ${size} 0 1,0 ${size * 2},0
+      a ${size}, ${size} 0 1,0 ${-size * 2},0`;
   },
 
+
   square(x, y, size) {
+    x = Math.round(x);
+    y = Math.round(y);
     const baseSize = 0.87 * size; // eslint-disable-line no-magic-numbers
-    const x0 = Math.floor(x - baseSize);
-    const y1 = Math.floor(y + baseSize);
-    const distance = Math.abs(x0 - y1);
+    const x0 = x - baseSize;
+    const y1 = y + baseSize;
+    const distance = Math.floor(x + baseSize - x0);
     return `M ${x0}, ${y1}
-            h${distance}
-            v-${distance}
-            h-${distance}
-            z`;
+      h${distance}
+      v-${distance}
+      h-${distance}
+      z`;
   },
 
   diamond(x, y, size) {
+    x = Math.round(x);
+    y = Math.round(y);
     const baseSize = 0.87 * size; // eslint-disable-line no-magic-numbers
     const length = Math.sqrt(2 * (baseSize * baseSize));
-    const distance = Math.floor(length);
-    return `M ${Math.floor(x)}, ${Math.floor(y + length)}
-      l ${distance}, -${distance}
-      l -${distance}, -${distance}
-      l -${distance}, ${distance}
-      l ${distance}, ${distance}
+    return `M ${x}, ${y + length}
+      l ${length}, -${length}
+      l -${length}, -${length}
+      l -${length}, ${length}
+      l ${length}, ${length}
       z`;
   },
 
   triangleDown(x, y, size) {
+    x = Math.round(x);
+    y = Math.round(y);
     const height = size / 2 * Math.sqrt(3);
-    const x0 = Math.floor(x - size);
-    const x1 = Math.floor(x + size);
-    const y0 = Math.floor(y - size);
-    const y1 = Math.floor(y + height);
+    const x0 = x - size;
+    const x1 = x + size;
+    const y0 = y - size;
+    const y1 = y + height;
     return `M ${x0}, ${y0}
-            L ${x1}, ${y0}
-            L ${Math.floor(x)}, ${y1}
-            z`;
+      L ${x1}, ${y0}
+      L ${x}, ${y1}
+      z`;
   },
 
   triangleUp(x, y, size) {
+    x = Math.round(x);
+    y = Math.round(y);
     const height = size / 2 * Math.sqrt(3);
-    const x0 = Math.floor(x - size);
-    const x1 = Math.floor(x + size);
-    const y0 = Math.floor(y - height);
-    const y1 = Math.floor(y + size);
+    const x0 = x - size;
+    const x1 = x + size;
+    const y0 = y - height;
+    const y1 = y + size;
     return `M ${x0}, ${y1}
-          L ${x1}, ${y1}
-          L ${Math.floor(x)}, ${y0}
-          z`;
+      L ${x1}, ${y1}
+      L ${x}, ${y0}
+      z`;
   },
 
   plus(x, y, size) {
+    x = Math.round(x);
+    y = Math.round(y);
     const baseSize = 1.1 * size; // eslint-disable-line no-magic-numbers
-    const distance = Math.floor(baseSize / 2.5) * 2 || 1;
+    const distance = baseSize / 1.5; // eslint-disable-line no-magic-numbers
     return `
-        M ${Math.floor(x - baseSize / 2.5)}, ${Math.floor(y + baseSize)}
-        v-${distance}
-        h-${distance}
-        v-${distance}
-        h${distance}
-        v-${distance}
-        h${distance}
-        v${distance}
-        h${distance}
-        v${distance}
-        h-${distance}
-        v${distance}
-        z`;
+      M ${x - (distance / 2)}, ${y + baseSize}
+      v-${distance}
+      h-${distance}
+      v-${distance}
+      h${distance}
+      v-${distance}
+      h${distance}
+      v${distance}
+      h${distance}
+      v${distance}
+      h-${distance}
+      v${distance}
+      z`;
   },
 
   star(x, y, size) {
-    const baseSize = 1.35 * size; // eslint-disable-line no-magic-numbers
+    x = Math.round(x);
+    y = Math.round(y);
+    const baseSize = Math.round(1.35 * size); // eslint-disable-line no-magic-numbers
     const angle = Math.PI / 5; // eslint-disable-line no-magic-numbers
     const starCoords = range(10).map((index) => { // eslint-disable-line no-magic-numbers
       const length = index % 2 === 0 ? baseSize : baseSize / 2;

--- a/src/victory-primitives/point.js
+++ b/src/victory-primitives/point.js
@@ -70,7 +70,9 @@ export default class Point extends React.Component {
     };
     const symbol = Helpers.evaluateProp(props.symbol, datum, active);
     const size = Helpers.evaluateProp(props.size, datum, active);
-    return pathFunctions[symbol].call(null, x, y, size);
+    const symbolFunction = typeof pathFunctions[symbol] === "function" ?
+      pathFunctions[symbol] : pathFunctions.circle;
+    return symbolFunction(x, y, size);
   }
 
   // Overridden in victory-core-native

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -5,14 +5,14 @@ import React from "react";
 export default {
   getPoint(datum) {
     const exists = (val) => val !== undefined;
-    const { _x, _x1, _x0, _voronoiX, _y, _y1, _y0, _voronoiY } = datum;
-    const defaultX = exists(_x1) ? _x1 : _x;
-    const defaultY = exists(_y1) ? _y1 : _y;
+    const { x, _x, _x1, _x0, _voronoiX, y, _y, _y1, _y0, _voronoiY } = datum;
+    const defaultX = exists(_x1) ? _x1 : _x || x;
+    const defaultY = exists(_y1) ? _y1 : _y || y;
     return {
       x: exists(_voronoiX) ? _voronoiX : defaultX,
-      x0: exists(_x0) ? _x0 : _x,
+      x0: exists(_x0) ? _x0 : _x || x,
       y: exists(_voronoiY) ? _voronoiY : defaultY,
-      y0: exists(_y0) ? _y0 : _y
+      y0: exists(_y0) ? _y0 : _y || y
     };
   },
 

--- a/test/client/spec/victory-primitives/path-helper.spec.js
+++ b/test/client/spec/victory-primitives/path-helper.spec.js
@@ -16,7 +16,7 @@ describe("path-helpers", () => {
     it("draws a path for a square at the correct location", () => {
       const pathResult = PathHelpers.square(x, y, size);
       const baseSize = 0.87 * size;
-      expect(pathResult).to.contain(`M ${Math.floor(x - baseSize)}, ${Math.floor(y + baseSize)}`);
+      expect(pathResult).to.contain(`M ${x - baseSize}, ${y + baseSize}`);
     });
   });
 
@@ -47,8 +47,9 @@ describe("path-helpers", () => {
     it("draws a path for a plus at the correct location", () => {
       const pathResult = PathHelpers.plus(0, 0, 1);
       const baseSize = 1.1 * size;
+      const distance = baseSize / 1.5;
       expect(pathResult).to.contain(
-        `M ${Math.floor(x - baseSize / 2.5)}, ${Math.floor(y + baseSize)}`
+        `M ${(x - (distance / 2))}, ${(y + baseSize)}`
       );
     });
   });
@@ -57,8 +58,9 @@ describe("path-helpers", () => {
     it("draws a path for a star at the correct location", () => {
       const pathResult = PathHelpers.star(0, 0, 1);
       const angle = Math.PI / 5;
-      expect(pathResult).to.contain(`M ${(1.35 * size) * Math.sin(angle) + x },
-        ${(1.35 * size) * Math.cos(angle) + y}`);
+      const baseSize = Math.round(1.35 * size);
+      expect(pathResult).to.contain(`M ${(baseSize) * Math.sin(angle) + x },
+        ${(baseSize) * Math.cos(angle) + y}`);
     });
   });
 });


### PR DESCRIPTION
Uses datum to determine label position when x and y are not provided. This will make it easier to add label annotations to VictoryChart

Minor corrections for path functions