### PR TITLE
Bug/victory zoom container with portal

### DIFF
--- a/src/victory-clip-container/victory-clip-container.js
+++ b/src/victory-clip-container/victory-clip-container.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "../victory-util/prop-types";
-import { assign, defaults, isFunction } from "lodash";
+import { assign, defaults, isFunction, isObject, uniqueId } from "lodash";
 import ClipPath from "../victory-primitives/clip-path";
 
 export default class VictoryClipContainer extends React.Component {
@@ -37,9 +37,8 @@ export default class VictoryClipContainer extends React.Component {
 
   constructor(props) {
     super(props);
-    this.clipId = props.clipId !== undefined ?
-      props.clipId :
-      Math.round(Math.random() * 10000); // eslint-disable-line no-magic-numbers
+    this.clipId = !isObject(props) || typeof props.clipId === "undefined" ?
+      uniqueId("victory-clip-") : props.clipId;
   }
 
   // Overridden in victory-core-native

--- a/src/victory-portal/victory-portal.js
+++ b/src/victory-portal/victory-portal.js
@@ -9,7 +9,12 @@ export default class VictoryPortal extends React.Component {
   static role = "portal";
 
   static propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    groupComponent: PropTypes.element
+  };
+
+  static defaultProps = {
+    groupComponent: <g/>
   };
 
   static contextTypes = {
@@ -56,10 +61,13 @@ export default class VictoryPortal extends React.Component {
   render() {
     const children = Array.isArray(this.props.children) ?
       this.props.children[0] : this.props.children;
+    const { groupComponent } = this.props;
     const childProps = children && children.props || {};
-    const child = children && React.cloneElement(
-      children, defaults({}, childProps, omit(this.props, "children"))
+    const standardProps = childProps.groupComponent ? { groupComponent, standalone: false } : {};
+    const newProps = defaults(
+      standardProps, childProps, omit(this.props, ["children", "groupComponent"])
     );
+    const child = children && React.cloneElement(children, newProps);
     return this.renderPortal(child);
   }
 }

--- a/src/victory-primitives/clip-path.js
+++ b/src/victory-primitives/clip-path.js
@@ -8,7 +8,7 @@ export default class ClipPath extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     clipHeight: CustomPropTypes.nonNegative,
-    clipId: PropTypes.number,
+    clipId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     clipPadding: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.shape({


### PR DESCRIPTION
Adds a groupComponent for `VictoryPortal` so that it may clip children. Supports zooming for `VictoryZoomContainer`