### PR TITLE
Issue #794 - Fix error when approximateTextHeight calls `match` from a number primitive

### DIFF
--- a/src/victory-util/textsize.js
+++ b/src/victory-util/textsize.js
@@ -1,6 +1,6 @@
 // http://www.pearsonified.com/2012/01/characters-per-line.php
 /*eslint-disable no-magic-numbers */
-import { merge, defaults } from "lodash";
+import { merge, defaults, toString } from "lodash";
 
 const fontDictionary = {
   "American Typewriter": 2.09,
@@ -116,7 +116,7 @@ const _approximateTextWidthInternal = (text, style) => {
 const _approximateTextHeightInternal = (text, style) => {
   return _splitToLines(text).reduce((total, line, index) => {
     const lineStyle = _prepareParams(style, index);
-    const containsCaps = line.match(/[(A-Z)(0-9)]/);
+    const containsCaps = toString(line).match(/[(A-Z)(0-9)]/);
     const height = containsCaps ?
       lineStyle.fontSize * coefficients.lineCapitalCoef : lineStyle.fontSize;
     const emptySpace = index === 0 ? 0 : lineStyle.fontSize * coefficients.lineSpaceHeightCoef;


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/FormidableLabs/victory/issues/794
