### PR TITLE
feat(add-events.js): no render label components when it is null

### DIFF
--- a/src/victory-util/add-events.js
+++ b/src/victory-util/add-events.js
@@ -186,6 +186,9 @@ export default (WrappedComponent, options) => {
       });
 
       const labelComponents = this.dataKeys.map((_dataKey, index) => {
+				if(labelComponents === null)
+					return undefined;
+
         const labelProps = this.getComponentProps(labelComponent, "labels", index);
         if (typeof labelProps.text !== "undefined" && labelProps.text !== null) {
           return React.cloneElement(labelComponent, labelProps);


### PR DESCRIPTION
i have modified to not render labelComponents when it is null.