### PR TITLE
Add support for row gutters

### DIFF
--- a/demo/victory-legend-demo.js
+++ b/demo/victory-legend-demo.js
@@ -69,7 +69,7 @@ const data = [{
 const LegendDemo = () => (
   <div className="demo" style={containerStyle}>
     <svg
-      height={500}
+      height={800}
       width={1000}
       style={{ border: "1px solid #ccc", margin: "2%" }}
     >
@@ -136,6 +136,13 @@ const LegendDemo = () => (
         gutter={30}
         data={data}
         style={legendStyle}
+      />
+      <VictoryLegend x={25} y={480}
+        standalone={false}
+        orientation="vertical"
+        gutter={{ column: 20, row: 50 }}
+        style={{ border: { stroke: "black" } }}
+        data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
       />
     </svg>
     <VictoryLegend

--- a/demo/victory-legend-demo.js
+++ b/demo/victory-legend-demo.js
@@ -140,7 +140,8 @@ const LegendDemo = () => (
       <VictoryLegend x={25} y={480}
         standalone={false}
         orientation="vertical"
-        gutter={{ column: 20, row: 50 }}
+        gutter={20}
+        rowGutter={50}
         style={{ border: { stroke: "black" } }}
         data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "victory-core",
-  "version": "20.0.0",
+  "version": "20.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/victory-legend/helper-methods.js
+++ b/src/victory-legend/helper-methods.js
@@ -75,13 +75,11 @@ const groupData = (props) => {
 };
 
 const getColumnWidths = (props, data) => {
-  const gutter = props.gutter || {};
-  const columnGutter = (typeof gutter === "object" ? gutter.column : gutter) || 0;
   const dataByColumn = groupBy(data, "column");
   const columns = keys(dataByColumn);
   return columns.reduce((memo, curr, index) => {
     const lengths = dataByColumn[curr].map((d) => {
-      return d.textSize.width + d.size + d.symbolSpacer + columnGutter;
+      return d.textSize.width + d.size + d.symbolSpacer + (props.gutter || 0);
     });
     memo[index] = Math.max(...lengths);
     return memo;
@@ -89,14 +87,11 @@ const getColumnWidths = (props, data) => {
 };
 
 const getRowHeights = (props, data) => {
-  const gutter = props.gutter || {};
-  // If `gutter` is a number, it only refers to column gutter.
-  const rowGutter = (typeof gutter === "object" ? gutter.row : 0) || 0;
   const dataByRow = groupBy(data, "row");
   return keys(dataByRow).reduce((memo, curr, index) => {
     const rows = dataByRow[curr];
     const lengths = rows.map((d) => {
-      return d.textSize.height + d.symbolSpacer + rowGutter;
+      return d.textSize.height + d.symbolSpacer + (props.rowGutter || 0);
     });
     memo[index] = Math.max(...lengths);
     return memo;

--- a/src/victory-legend/helper-methods.js
+++ b/src/victory-legend/helper-methods.js
@@ -75,11 +75,13 @@ const groupData = (props) => {
 };
 
 const getColumnWidths = (props, data) => {
+  const gutter = props.gutter || {};
+  const columnGutter = (typeof gutter === "object" ? gutter.column : gutter) || 0;
   const dataByColumn = groupBy(data, "column");
   const columns = keys(dataByColumn);
   return columns.reduce((memo, curr, index) => {
     const lengths = dataByColumn[curr].map((d) => {
-      return d.textSize.width + props.gutter + d.size + d.symbolSpacer;
+      return d.textSize.width + d.size + d.symbolSpacer + columnGutter;
     });
     memo[index] = Math.max(...lengths);
     return memo;
@@ -87,10 +89,15 @@ const getColumnWidths = (props, data) => {
 };
 
 const getRowHeights = (props, data) => {
+  const gutter = props.gutter || {};
+  // If `gutter` is a number, it only refers to column gutter.
+  const rowGutter = (typeof gutter === "object" ? gutter.row : 0) || 0;
   const dataByRow = groupBy(data, "row");
   return keys(dataByRow).reduce((memo, curr, index) => {
     const rows = dataByRow[curr];
-    const lengths = rows.map((d) => d.textSize.height + d.symbolSpacer);
+    const lengths = rows.map((d) => {
+      return d.textSize.height + d.symbolSpacer + rowGutter;
+    });
     memo[index] = Math.max(...lengths);
     return memo;
   }, []);
@@ -242,4 +249,3 @@ export default (props, fallbackProps) => {
     return childProps;
   }, initialProps);
 };
-

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -71,7 +71,13 @@ class VictoryLegend extends React.Component {
       eventHandlers: PropTypes.object
     })),
     groupComponent: PropTypes.element,
-    gutter: CustomPropTypes.nonNegative,
+    gutter: PropTypes.oneOfType([
+      CustomPropTypes.nonNegative,
+      PropTypes.shape({
+        column: CustomPropTypes.nonNegative,
+        row: CustomPropTypes.nonNegative
+      })
+    ]),
     height: CustomPropTypes.nonNegative,
     itemsPerRow: CustomPropTypes.nonNegative,
     labelComponent: PropTypes.element,

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -71,13 +71,7 @@ class VictoryLegend extends React.Component {
       eventHandlers: PropTypes.object
     })),
     groupComponent: PropTypes.element,
-    gutter: PropTypes.oneOfType([
-      CustomPropTypes.nonNegative,
-      PropTypes.shape({
-        column: CustomPropTypes.nonNegative,
-        row: CustomPropTypes.nonNegative
-      })
-    ]),
+    gutter: PropTypes.nonNegative,
     height: CustomPropTypes.nonNegative,
     itemsPerRow: CustomPropTypes.nonNegative,
     labelComponent: PropTypes.element,
@@ -91,6 +85,7 @@ class VictoryLegend extends React.Component {
         right: PropTypes.number
       })
     ]),
+    rowGutter: PropTypes.nonNegative,
     sharedEvents: PropTypes.shape({
       events: PropTypes.array,
       getEventState: PropTypes.func


### PR DESCRIPTION
Per FormidableLabs/victory#862, the [docs](https://formidable.com/open-source/victory/docs/victory-legend/#gutter) currently state that:

> When `orientation` is horizontal, gutters are between columns. When `orientation` is vertical, gutters are the space between rows.

This is a simple change to make, but when I did so, the result was not great:

<img width="163" alt="screen shot 2017-12-01 at 1 38 05 pm" src="https://user-images.githubusercontent.com/53522/33506809-36085768-d6a6-11e7-9634-adc45e51dffb.png">

And given that we support multiple `itemsPerRow`, even if the docs were correct there'd still be a desire to specify column and row gutters independently.

In fact all of the vertical `<VictoryLegend>` demos are relying on the fact that `gutter` only applies horizontally – they are not assuming that the docs are correct. If we made this change to match the docs, it would be a real pain for everyone using Victory to upgrade, because their chart layouts would likely be broken.

So this PR takes a different approach: when `gutter` is a number, it still only refers to the column gutter, no matter the orientation. But it adds support for `gutter` being an object like `{ column: 50, row: 25 }`. We can update the docs to reflect this.

Details regarding the object shape can be fleshed out here (should it be `{ horizontal, vertical }`? `{ top, bottom, left, right }`?), but I think this general approach is the way to go.

/cc @boygirl @ebrillhart @tacomanator