### PR TITLE
Add support for top/bottom/left/right gutter.

### DIFF
--- a/demo/victory-legend-demo.js
+++ b/demo/victory-legend-demo.js
@@ -140,8 +140,8 @@ const LegendDemo = () => (
       <VictoryLegend x={25} y={480}
         standalone={false}
         orientation="vertical"
-        gutter={20}
-        rowGutter={50}
+        gutter={{ left: 20, right: 50 }}
+        rowGutter={{ top: 5, bottom: 8 }}
         style={{ border: { stroke: "black" } }}
         data={[{ name: "One" }, { name: "Two" }, { name: "Three" }]}
       />

--- a/src/victory-legend/helper-methods.js
+++ b/src/victory-legend/helper-methods.js
@@ -75,11 +75,15 @@ const groupData = (props) => {
 };
 
 const getColumnWidths = (props, data) => {
+  const gutter = props.gutter || {};
+  const gutterWidth = typeof gutter === "object" ?
+    (gutter.left || 0) + (gutter.right || 0) :
+    (gutter || 0);
   const dataByColumn = groupBy(data, "column");
   const columns = keys(dataByColumn);
   return columns.reduce((memo, curr, index) => {
     const lengths = dataByColumn[curr].map((d) => {
-      return d.textSize.width + d.size + d.symbolSpacer + (props.gutter || 0);
+      return d.textSize.width + d.size + d.symbolSpacer + gutterWidth;
     });
     memo[index] = Math.max(...lengths);
     return memo;
@@ -87,11 +91,15 @@ const getColumnWidths = (props, data) => {
 };
 
 const getRowHeights = (props, data) => {
+  const gutter = props.rowGutter || {};
+  const gutterHeight = typeof gutter === "object" ?
+    (gutter.top || 0) + (gutter.bottom || 0) :
+    0;
   const dataByRow = groupBy(data, "row");
   return keys(dataByRow).reduce((memo, curr, index) => {
     const rows = dataByRow[curr];
     const lengths = rows.map((d) => {
-      return d.textSize.height + d.symbolSpacer + (props.rowGutter || 0);
+      return d.textSize.height + d.symbolSpacer + gutterHeight;
     });
     memo[index] = Math.max(...lengths);
     return memo;
@@ -179,11 +187,12 @@ const getBorderProps = (props, contentHeight, contentWidth) => {
   return { x, y, height, width, style: style.border };
 };
 
+// eslint-disable-next-line max-statements, complexity
 export default (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "legend");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
-    data, standalone, theme, padding, style, colorScale,
+    data, standalone, theme, padding, style, colorScale, gutter, rowGutter,
     borderPadding, title, titleOrientation, x = 0, y = 0
   } = props;
   const groupedData = groupData(props);
@@ -194,6 +203,10 @@ export default (props, fallbackProps) => {
   const titleOffset = {
     x: titleOrientation === "left" ? titleDimensions.width : 0,
     y: titleOrientation === "top" ? titleDimensions.height : 0
+  };
+  const gutterOffset = {
+    x: gutter && typeof gutter === "object" ? gutter.left || 0 : 0,
+    y: rowGutter && typeof rowGutter === "object" ? rowGutter.top || 0 : 0
   };
 
   const contentHeight = titleOrientation === "left" || titleOrientation === "right" ?
@@ -225,8 +238,8 @@ export default (props, fallbackProps) => {
       symbol: dataStyle.type || dataStyle.symbol || "circle",
       size: datum.size,
       style: dataStyle,
-      y: originY + offset.y + titleOffset.y,
-      x: originX + offset.x + titleOffset.x
+      y: originY + offset.y + titleOffset.y + gutterOffset.y,
+      x: originX + offset.x + titleOffset.x + gutterOffset.x
     };
 
     const labelProps = {
@@ -234,8 +247,8 @@ export default (props, fallbackProps) => {
       key: `legend-label-${i}`,
       text: datum.name,
       style: labelStyles[i],
-      y: originY + offset.y + titleOffset.y,
-      x: originX + offset.x + titleOffset.x + datum.symbolSpacer + (datum.size / 2)
+      y: dataProps.y,
+      x: dataProps.x + datum.symbolSpacer + (datum.size / 2)
     };
     childProps[eventKey] = eventKey === 0 ?
       { data: dataProps, labels: labelProps, border: borderProps, title: titleProps } :

--- a/src/victory-legend/helper-methods.js
+++ b/src/victory-legend/helper-methods.js
@@ -94,7 +94,7 @@ const getRowHeights = (props, data) => {
   const gutter = props.rowGutter || {};
   const gutterHeight = typeof gutter === "object" ?
     (gutter.top || 0) + (gutter.bottom || 0) :
-    0;
+    (gutter || 0);
   const dataByRow = groupBy(data, "row");
   return keys(dataByRow).reduce((memo, curr, index) => {
     const rows = dataByRow[curr];

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -71,7 +71,13 @@ class VictoryLegend extends React.Component {
       eventHandlers: PropTypes.object
     })),
     groupComponent: PropTypes.element,
-    gutter: PropTypes.nonNegative,
+    gutter: PropTypes.oneOfType([
+      CustomPropTypes.nonNegative,
+      PropTypes.shape({
+        left: CustomPropTypes.nonNegative,
+        right: CustomPropTypes.nonNegative
+      })
+    ]),
     height: CustomPropTypes.nonNegative,
     itemsPerRow: CustomPropTypes.nonNegative,
     labelComponent: PropTypes.element,
@@ -85,7 +91,13 @@ class VictoryLegend extends React.Component {
         right: PropTypes.number
       })
     ]),
-    rowGutter: PropTypes.nonNegative,
+    rowGutter: PropTypes.oneOfType([
+      CustomPropTypes.nonNegative,
+      PropTypes.shape({
+        top: CustomPropTypes.nonNegative,
+        bottom: CustomPropTypes.nonNegative
+      })
+    ]),
     sharedEvents: PropTypes.shape({
       events: PropTypes.array,
       getEventState: PropTypes.func


### PR DESCRIPTION
@boygirl I think this does the trick!

This is an alternative to #319 that replaces `rowGutter` with `gutter` accepting `top`, `bottom`, `left`, and `right` properties.

Alternatively, we could keep `rowGutter` and have `gutter={ left, right }` + `rowGutter={ top, bottom }` – thoughts?

Appears to work like a charm, here's `gutter={{ left: 20, right: 50, top: 5, bottom: 8 }}`:

<img width="162" alt="screen shot 2017-12-01 at 4 45 41 pm" src="https://user-images.githubusercontent.com/53522/33509542-6bcaf67e-d6b7-11e7-9d1d-c2f06f04a95d.png">




Fixes FormidableLabs/victory#862.
