### PR TITLE
Immutable support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chai": "^3.5.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.3",
+    "immutable": "^3.8.2",
     "mocha": "^3.0.2",
     "prop-types": "^15.5.8",
     "react": "^16.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ export { default as DefaultTransitions } from "./victory-util/default-transition
 export { default as Domain } from "./victory-util/domain";
 export { default as Events } from "./victory-util/events";
 export { default as Helpers } from "./victory-util/helpers";
+export { default as Immutable } from "./victory-util/immutable";
 export { default as LabelHelpers } from "./victory-util/label-helpers";
 export { default as Log } from "./victory-util/log";
 export { default as PropTypes } from "./victory-util/prop-types";

--- a/src/victory-primitives/common-props.js
+++ b/src/victory-primitives/common-props.js
@@ -4,7 +4,7 @@ import CustomPropTypes from "../victory-util/prop-types";
 export default {
   active: PropTypes.bool,
   className: PropTypes.string,
-  data: PropTypes.array,
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   events: PropTypes.object,
   index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -218,11 +218,16 @@ export default {
     if (!isArrayOrIterable) {
       return [];
     }
+
     const key = typeof props[axis] === "undefined" ? axis : props[axis];
     const accessor = Helpers.createAccessor(key);
-    const dataStrings = (props.data)
-        .map((datum) => accessor(datum))
-        .filter((datum) => typeof datum === "string");
+
+    const dataStrings = props.data.reduce((dataArr, datum) => {
+      datum = this.parseDatum(datum);
+      dataArr.push(accessor(datum));
+      return dataArr;
+    }, []).filter((datum) => typeof datum === "string");
+
     // return a unique set of strings
     return dataStrings.reduce((prev, curr) => {
       if (typeof curr !== "undefined" && curr !== null && prev.indexOf(curr) === -1) {

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -87,9 +87,7 @@ export default {
     };
 
     const data = dataset.reduce((dataArr, datum, index) => { // eslint-disable-line complexity
-      datum = Immutable.isImmutable(datum)
-        ? Immutable.shallowToJS(datum, this.immutableDatumWhitelist)
-        : datum;
+      datum = this.parseDatum(datum);
 
       const evaluatedX = datum._x !== undefined ? datum._x : accessor.x(datum);
       const evaluatedY = datum._y !== undefined ? datum._y : accessor.y(datum);
@@ -302,5 +300,11 @@ export default {
 
   getLength(data) {
     return Immutable.isIterable(data) ? data.size : data.length;
+  },
+
+  parseDatum(datum) {
+    return Immutable.isImmutable(datum)
+      ? Immutable.shallowToJS(datum, this.immutableDatumWhitelist)
+      : datum;
   }
 };

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -115,13 +115,12 @@ export default {
       const evaluatedX = trimmedDatum._x !== undefined ? trimmedDatum._x : accessor.x(datum);
       const evaluatedY = trimmedDatum._y !== undefined ? trimmedDatum._y : accessor.y(datum);
       const y0 = trimmedDatum._y0 !== undefined ? trimmedDatum._y0 : accessor.y0(datum);
-
       const x = evaluatedX !== undefined ? evaluatedX : index;
       const y = evaluatedY !== undefined ? evaluatedY : trimmedDatum;
       const originalValues = y0 === undefined ? { x, y } : { x, y, y0 };
       const privateValues = y0 === undefined ? { _x: x, _y: y } : { _x: x, _y: y, _y0: y0 };
 
-      return dataArr.concat([
+      dataArr.push(
         assign(
           originalValues, trimmedDatum, privateValues,
           // map string data to numeric values, and add names
@@ -129,7 +128,9 @@ export default {
           typeof y === "string" ? { _y: stringMap.y[y], yName: y } : {},
           typeof y0 === "string" ? { _y0: stringMap.y[y0], yName: y0 } : {}
         )
-      ]);
+      );
+
+      return dataArr;
     }, []);
 
     const sortedData = this.sortData(data, props.sortKey);

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -76,8 +76,9 @@ export default {
   },
 
   trimDatum(datum) {
+    const datumIsImmutable = Immutable.isImmutable(datum);
     return this.datumProps.reduce((finalProps, prop) => {
-      const propValue = Immutable.isImmutable(datum) ? datum.get(prop) : datum[prop];
+      const propValue = datumIsImmutable ? datum.get(prop) : datum[prop];
       if (propValue !== undefined) {
         finalProps[prop] = propValue;
       }
@@ -110,7 +111,9 @@ export default {
     };
 
     const data = dataset.reduce((dataArr, datum, index) => {
-      const trimmedDatum = this.trimDatum(datum);
+      const trimmedDatum = Array.isArray(datum) || Immutable.isList(datum)
+        ? datum
+        : this.trimDatum(datum);
 
       const evaluatedX = trimmedDatum._x !== undefined ? trimmedDatum._x : accessor.x(datum);
       const evaluatedY = trimmedDatum._y !== undefined ? trimmedDatum._y : accessor.y(datum);

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -233,7 +233,8 @@ export default {
    * @returns {Array} an array of strings
    */
   getStringsFromData(props, axis) {
-    if (!Array.isArray(props.data)) {
+    const isArrayOrIterable = Array.isArray(props.data) || Immutable.isIterable(props.data);
+    if (!isArrayOrIterable) {
       return [];
     }
     const key = typeof props[axis] === "undefined" ? axis : props[axis];

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,6 +1,7 @@
+import React from "react";
 import { defaults, isFunction, property, omit, reduce } from "lodash";
 import Collection from "./collection";
-import React from "react";
+import Immutable from "./immutable";
 
 export default {
   getPoint(datum) {
@@ -144,7 +145,18 @@ export default {
       return (x) => x;
     }
     // otherwise, assume it is an array index, property key or path (_.property handles all three)
-    return property(key);
+    return (x) => {
+      if (Immutable.isImmutable(x)) {
+        if (Array.isArray(key)) {
+          return x.getIn(key);
+        } else if (typeof key === "string") {
+          return x.getIn(key.split("."));
+        } else {
+          return x.get(key);
+        }
+      }
+      return property(key)(x);
+    };
   },
 
   modifyProps(props, fallbackProps, role) {

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -150,7 +150,7 @@ export default {
         if (Array.isArray(key)) {
           return x.getIn(key);
         } else if (typeof key === "string") {
-          return x.getIn(key.split("."));
+          return x.getIn(key.replace("[", ".").replace("]", "").split("."));
         } else {
           return x.get(key);
         }

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { defaults, isFunction, property, omit, reduce } from "lodash";
 import Collection from "./collection";
-import Immutable from "./immutable";
 
 export default {
   getPoint(datum) {
@@ -145,18 +144,7 @@ export default {
       return (x) => x;
     }
     // otherwise, assume it is an array index, property key or path (_.property handles all three)
-    return (x) => {
-      if (Immutable.isImmutable(x)) {
-        if (Array.isArray(key)) {
-          return x.getIn(key);
-        } else if (typeof key === "string") {
-          return x.getIn(key.replace("[", ".").replace("]", "").split("."));
-        } else {
-          return x.get(key);
-        }
-      }
-      return property(key)(x);
-    };
+    return property(key);
   },
 
   modifyProps(props, fallbackProps, role) {

--- a/src/victory-util/immutable.js
+++ b/src/victory-util/immutable.js
@@ -2,6 +2,7 @@ export default {
   IMMUTABLE_ITERABLE: "@@__IMMUTABLE_ITERABLE__@@",
   IMMUTABLE_RECORD: "@@__IMMUTABLE_RECORD__@@",
   IMMUTABLE_LIST: "@@__IMMUTABLE_LIST__@@",
+  IMMUTABLE_MAP: "@@__IMMUTABLE_MAP__@@",
 
   isImmutable(x) {
     return this.isIterable(x) || this.isRecord(x);
@@ -17,5 +18,16 @@ export default {
 
   isList(x) {
     return !!(x && x[this.IMMUTABLE_LIST]);
+  },
+
+  isMap(x) {
+    return !!(x && x[this.IMMUTABLE_MAP]);
+  },
+
+  shallowToJS(x) {
+    return this.isIterable(x) ? x.reduce((prev, curr, key) => {
+      prev[key] = curr;
+      return prev;
+    }, this.isList(x) ? [] : {}) : x;
   }
 };

--- a/src/victory-util/immutable.js
+++ b/src/victory-util/immutable.js
@@ -24,8 +24,11 @@ export default {
     return !!(x && x[this.IMMUTABLE_MAP]);
   },
 
-  shallowToJS(x) {
+  shallowToJS(x, whitelist) {
     return this.isIterable(x) ? x.reduce((prev, curr, key) => {
+      if (whitelist && whitelist[key]) {
+        curr = this.shallowToJS(curr);
+      }
       prev[key] = curr;
       return prev;
     }, this.isList(x) ? [] : {}) : x;

--- a/src/victory-util/immutable.js
+++ b/src/victory-util/immutable.js
@@ -1,0 +1,16 @@
+export default {
+  IMMUTABLE_ITERABLE: "@@__IMMUTABLE_ITERABLE__@@",
+  IMMUTABLE_RECORD: "@@__IMMUTABLE_RECORD__@@",
+
+  isImmutable(x) {
+    return this.isIterable(x) || this.isRecord(x);
+  },
+
+  isIterable(x) {
+    return !!(x && x[this.IMMUTABLE_ITERABLE]);
+  },
+
+  isRecord(x) {
+    return !!(x && x[this.IMMUTABLE_RECORD]);
+  }
+};

--- a/src/victory-util/immutable.js
+++ b/src/victory-util/immutable.js
@@ -1,6 +1,7 @@
 export default {
   IMMUTABLE_ITERABLE: "@@__IMMUTABLE_ITERABLE__@@",
   IMMUTABLE_RECORD: "@@__IMMUTABLE_RECORD__@@",
+  IMMUTABLE_LIST: "@@__IMMUTABLE_LIST__@@",
 
   isImmutable(x) {
     return this.isIterable(x) || this.isRecord(x);
@@ -12,5 +13,9 @@ export default {
 
   isRecord(x) {
     return !!(x && x[this.IMMUTABLE_RECORD]);
+  },
+
+  isList(x) {
+    return !!(x && x[this.IMMUTABLE_LIST]);
   }
 };

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -2,287 +2,303 @@
 /* global sinon */
 
 import { Data } from "src/index";
+import { fromJS } from "immutable";
 
-describe("helpers/data", () => {
-  describe("createStringMap", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Data, "getStringsFromAxes");
-      sandbox.spy(Data, "getStringsFromCategories");
-      sandbox.spy(Data, "getStringsFromData");
-    });
-    afterEach(() => {
-      sandbox.restore();
-    });
+const immutableDataTest = {
+  createDataObj: (data) => fromJS(data),
+  readDataObj: (data) => data.toJS(),
+  testLabel: "helpers/data for immutable"
+};
 
-    const tickValues = ["one", "two", "three"];
-    const categories = ["red", "green", "blue"];
-    const data = [{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }];
-    it("returns a string map from strings in tickValues", () => {
-      const props = { tickValues };
-      const stringMap = Data.createStringMap(props, "x");
-      expect(Data.getStringsFromAxes).calledWith(props, "x");
-      expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
-      expect(stringMap).to.eql({ one: 1, two: 2, three: 3 });
-    });
+const dataTest = {
+  createDataObj: (data) => data,
+  readDataObj: (data) => data,
+  testLabel: "helpers/data"
+};
 
-    it("returns a string map from strings in categories", () => {
-      const props = { categories };
-      const stringMap = Data.createStringMap(props, "x");
-      expect(Data.getStringsFromCategories).calledWith(props, "x");
-      expect(Data.getStringsFromCategories).to.have.returned(["red", "green", "blue"]);
-      expect(stringMap).to.eql({ red: 1, green: 2, blue: 3 });
-    });
+[dataTest, immutableDataTest].forEach(({ createDataObj, readDataObj, testLabel }) => {
+  describe(`${testLabel}`, () => {
+    describe("createStringMap", () => {
+      let sandbox;
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        sandbox.spy(Data, "getStringsFromAxes");
+        sandbox.spy(Data, "getStringsFromCategories");
+        sandbox.spy(Data, "getStringsFromData");
+      });
+      afterEach(() => {
+        sandbox.restore();
+      });
 
-    it("returns a string map from strings in data", () => {
-      const props = { data };
-      const stringMap = Data.createStringMap(props, "x");
-      expect(Data.getStringsFromData).calledWith(props, "x");
-      expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
-      expect(stringMap).to.eql({ one: 1, red: 2, cat: 3 });
-    });
+      const tickValues = ["one", "two", "three"];
+      const categories = ["red", "green", "blue"];
+      const data = createDataObj([{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }]);
 
-    it("a unique set of values is returned from multiple sources", () => {
-      const props = { tickValues, data };
-      const stringMap = Data.createStringMap(props, "x");
-      expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
-      expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
-      expect(stringMap).to.eql({ one: 1, two: 2, three: 3, red: 4, cat: 5 });
-    });
-  });
+      it("returns a string map from strings in tickValues", () => {
+        const props = { tickValues };
+        const stringMap = Data.createStringMap(props, "x");
+        expect(Data.getStringsFromAxes).calledWith(props, "x");
+        expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
+        expect(stringMap).to.eql({ one: 1, two: 2, three: 3 });
+      });
 
-  describe("getStringsFromData", () => {
-    it("returns an array of strings from a data prop", () => {
-      const props = { data: [{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }] };
-      const dataStrings = Data.getStringsFromData(props, "x");
-      expect(dataStrings).to.eql(["one", "red", "cat"]);
-    });
+      it("returns a string map from strings in categories", () => {
+        const props = { categories };
+        const stringMap = Data.createStringMap(props, "x");
+        expect(Data.getStringsFromCategories).calledWith(props, "x");
+        expect(Data.getStringsFromCategories).to.have.returned(["red", "green", "blue"]);
+        expect(stringMap).to.eql({ red: 1, green: 2, blue: 3 });
+      });
 
-    it("returns an array of strings from array-type data", () => {
-      const props = { data: [["one", 1], ["red", 2], ["cat", 3]], x: 0, y: 1 };
-      const dataStrings = Data.getStringsFromData(props, "x");
-      expect(dataStrings).to.eql(["one", "red", "cat"]);
-    });
+      it("returns a string map from strings in data", () => {
+        const props = { data };
+        const stringMap = Data.createStringMap(props, "x");
+        expect(Data.getStringsFromData).calledWith(props, "x");
+        expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+        expect(stringMap).to.eql({ one: 1, red: 2, cat: 3 });
+      });
 
-    it("only returns strings, if data is mixed", () => {
-      const props = { data: [{ x: 1, y: 1 }, { x: "three", y: 3 }] };
-      expect(Data.getStringsFromData(props, "x")).to.eql(["three"]);
+      it("a unique set of values is returned from multiple sources", () => {
+        const props = { tickValues, data };
+        const stringMap = Data.createStringMap(props, "x");
+        expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
+        expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+        expect(stringMap).to.eql({ one: 1, two: 2, three: 3, red: 4, cat: 5 });
+      });
     });
 
-    it("returns an empty array when no strings are present", () => {
-      const props = { data: [{ x: 1, y: 1 }, { x: 3, y: 3 }] };
-      expect(Data.getStringsFromData(props, "x")).to.eql([]);
+    describe("getStringsFromData", () => {
+      it("returns an array of strings from a data prop", () => {
+        const props = { data: createDataObj([{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }]) };
+        const dataStrings = Data.getStringsFromData(props, "x");
+        expect(dataStrings).to.eql(["one", "red", "cat"]);
+      });
+
+      it("returns an array of strings from array-type data", () => {
+        const props = { data: createDataObj([["one", 1], ["red", 2], ["cat", 3]]), x: 0, y: 1 };
+        const dataStrings = Data.getStringsFromData(props, "x");
+        expect(dataStrings).to.eql(["one", "red", "cat"]);
+      });
+
+      it("only returns strings, if data is mixed", () => {
+        const props = { data: createDataObj([{ x: 1, y: 1 }, { x: "three", y: 3 }]) };
+        expect(Data.getStringsFromData(props, "x")).to.eql(["three"]);
+      });
+
+      it("returns an empty array when no strings are present", () => {
+        const props = { data: createDataObj([{ x: 1, y: 1 }, { x: 3, y: 3 }]) };
+        expect(Data.getStringsFromData(props, "x")).to.eql([]);
+      });
+
+      it("returns an empty array when the data prop is undefined", () => {
+        expect(Data.getStringsFromData({}, "x")).to.eql([]);
+      });
     });
 
-    it("returns an empty array when the data prop is undefined", () => {
-      expect(Data.getStringsFromData({}, "x")).to.eql([]);
-    });
-  });
+    describe("getStringsFromAxes", () => {
+      it("returns an array of strings when tickValues is an array", () => {
+        const props = { tickValues: [1, "three", 5] };
+        expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
+      });
 
-  describe("getStringsFromAxes", () => {
-    it("returns an array of strings when tickValues is an array", () => {
-      const props = { tickValues: [1, "three", 5] };
-      expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
-    });
+      it("returns an array of strings when tickValues is an object", () => {
+        const props = { tickValues: { x: [1, "three", 5] } };
+        expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
+      });
 
-    it("returns an array of strings when tickValues is an object", () => {
-      const props = { tickValues: { x: [1, "three", 5] } };
-      expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
-    });
+      it("returns an empty array when a given axis is not defined", () => {
+        const props = { tickValues: { y: [1, "three", 5] } };
+        expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
+      });
 
-    it("returns an empty array when a given axis is not defined", () => {
-      const props = { tickValues: { y: [1, "three", 5] } };
-      expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
-    });
+      it("returns an empty array when no strings are present", () => {
+        const props = { tickValues: [1, 3, 5] };
+        expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
+      });
 
-    it("returns an empty array when no strings are present", () => {
-      const props = { tickValues: [1, 3, 5] };
-      expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
-    });
-
-    it("returns an empty array when the tickValues prop is undefined", () => {
-      expect(Data.getStringsFromAxes({}, "x")).to.eql([]);
-    });
-  });
-
-  describe("getStringsFromCategories", () => {
-    it("returns an empty array when no strings are present", () => {
-      const props = { categories: [1, 3, 5] };
-      expect(Data.getStringsFromCategories(props, "x")).to.eql([]);
+      it("returns an empty array when the tickValues prop is undefined", () => {
+        expect(Data.getStringsFromAxes({}, "x")).to.eql([]);
+      });
     });
 
-    it("returns an empty array when the category prop is undefined", () => {
-      expect(Data.getStringsFromCategories({}, "x")).to.eql([]);
-    });
-  });
+    describe("getStringsFromCategories", () => {
+      it("returns an empty array when no strings are present", () => {
+        const props = { categories: [1, 3, 5] };
+        expect(Data.getStringsFromCategories(props, "x")).to.eql([]);
+      });
 
-  describe("formatData", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Data, "cleanData");
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      it("returns an empty array when the category prop is undefined", () => {
+        expect(Data.getStringsFromCategories({}, "x")).to.eql([]);
+      });
     });
 
-    it("formats a single dataset", () => {
-      const dataset = [{ _x: 1, _y: 3, x: 1, y: 3 }, { _x: 2, _y: 5, x: 2, y: 5 }];
-      const props = { data: dataset };
-      const formatted = Data.formatData(dataset, props);
-      expect(Data.cleanData).called.and.returned(dataset);
-      expect(formatted).to.be.an.array;
-      expect(formatted[0]).to.have.keys(["_x", "_y", "x", "y"]);
-    });
-  });
+    describe("formatData", () => {
+      let sandbox;
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        sandbox.spy(Data, "cleanData");
+      });
 
-  describe("getData", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Data, "formatData");
-      sandbox.spy(Data, "generateData");
-      sandbox.spy(Data, "addEventKeys");
-    });
+      afterEach(() => {
+        sandbox.restore();
+      });
 
-    afterEach(() => {
-      sandbox.restore();
+      it("formats a single dataset", () => {
+        const dataset = createDataObj([{ _x: 1, _y: 3, x: 1, y: 3 }, { _x: 2, _y: 5, x: 2, y: 5 }]);
+        const props = { data: dataset };
+        const formatted = Data.formatData(dataset, props);
+        expect(Data.cleanData).called.and.returned(readDataObj(dataset));
+        expect(formatted).to.be.an.array;
+        expect(formatted[0]).to.have.keys(["_x", "_y", "x", "y"]);
+      });
     });
 
-    it("formats and returns the data prop", () => {
-      const data = [{ x: "kittens", y: 3 }, { x: "cats", y: 5 }];
-      const props = { data, x: "x", y: "y" };
-      const expectedReturn = [
-        { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3 },
-        { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5 }
-      ];
-      const expectedReturnWithEventKeys = [
-         { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3, eventKey: 0 },
-         { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5, eventKey: 1 }
-      ];
-      const returnData = Data.getData(props);
-      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
-      expect(returnData).to.eql(expectedReturnWithEventKeys);
-    });
+    describe("getData", () => {
+      let sandbox;
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        sandbox.spy(Data, "formatData");
+        sandbox.spy(Data, "generateData");
+        sandbox.spy(Data, "addEventKeys");
+      });
 
-    it("uses the event key when it is passed in", () => {
-      const data = [
-        { x: 2, y: 2, eventKey: 13 },
-        { x: 1, y: 3, eventKey: 21 },
-        { x: 3, y: 1, eventKey: 11 }
-      ];
+      afterEach(() => {
+        sandbox.restore();
+      });
 
-      const returnData = Data.getData({ data });
+      it("formats and returns the data prop", () => {
+        const data = createDataObj([{ x: "kittens", y: 3 }, { x: "cats", y: 5 }]);
+        const props = { data, x: "x", y: "y" };
+        const expectedReturn = [
+          { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3 },
+          { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5 }
+        ];
+        const expectedReturnWithEventKeys = [
+           { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3, eventKey: 0 },
+           { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5, eventKey: 1 }
+        ];
+        const returnData = Data.getData(props);
+        expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+        expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+        expect(returnData).to.eql(expectedReturnWithEventKeys);
+      });
 
-      expect(returnData).to.eql([
-        { _x: 2, x: 2, _y: 2, y: 2, eventKey: 13 },
-        { _x: 1, x: 1, _y: 3, y: 3, eventKey: 21 },
-        { _x: 3, x: 3, _y: 1, y: 1, eventKey: 11 }
-      ]);
-    });
+      it("uses the event key when it is passed in", () => {
+        const data = createDataObj([
+          { x: 2, y: 2, eventKey: 13 },
+          { x: 1, y: 3, eventKey: 21 },
+          { x: 3, y: 1, eventKey: 11 }
+        ]);
 
-    it("uses a custom event key when it is passed in", () => {
-      const data = [
-        { x: 2, y: 2, myEventKey: 3 },
-        { x: 1, y: 3, myEventKey: 2 },
-        { x: 3, y: 1, myEventKey: 1 }
-      ];
+        const returnData = Data.getData({ data });
 
-      const returnData = Data.getData({ data, eventKey: "myEventKey" });
+        expect(returnData).to.eql([
+          { _x: 2, x: 2, _y: 2, y: 2, eventKey: 13 },
+          { _x: 1, x: 1, _y: 3, y: 3, eventKey: 21 },
+          { _x: 3, x: 3, _y: 1, y: 1, eventKey: 11 }
+        ]);
+      });
 
-      expect(returnData).to.eql([
-        { _x: 2, x: 2, _y: 2, y: 2, eventKey: 3, myEventKey: 3 },
-        { _x: 1, x: 1, _y: 3, y: 3, eventKey: 2, myEventKey: 2 },
-        { _x: 3, x: 3, _y: 1, y: 1, eventKey: 1, myEventKey: 1 }
-      ]);
-    });
+      it("uses a custom event key when it is passed in", () => {
+        const data = createDataObj([
+          { x: 2, y: 2, myEventKey: 3 },
+          { x: 1, y: 3, myEventKey: 2 },
+          { x: 3, y: 1, myEventKey: 1 }
+        ]);
 
-    it("does not sort data when sort key not passed", () => {
-      const data = [{ x: 2, y: 2 }, { x: 1, y: 3 }, { x: 3, y: 1 }];
+        const returnData = Data.getData({ data, eventKey: "myEventKey" });
 
-      const returnData = Data.getData({ data });
+        expect(returnData).to.eql([
+          { _x: 2, x: 2, _y: 2, y: 2, eventKey: 3, myEventKey: 3 },
+          { _x: 1, x: 1, _y: 3, y: 3, eventKey: 2, myEventKey: 2 },
+          { _x: 3, x: 3, _y: 1, y: 1, eventKey: 1, myEventKey: 1 }
+        ]);
+      });
 
-      expect(returnData).to.eql([
-        { _x: 2, x: 2, _y: 2, y: 2, eventKey: 0 },
-        { _x: 1, x: 1, _y: 3, y: 3, eventKey: 1 },
-        { _x: 3, x: 3, _y: 1, y: 1, eventKey: 2 }
-      ]);
-    });
+      it("does not sort data when sort key not passed", () => {
+        const data = createDataObj([{ x: 2, y: 2 }, { x: 1, y: 3 }, { x: 3, y: 1 }]);
 
-    it("sorts data according to sort key", () => {
-      const data = [
-        { x: 1, y: 1, order: 2 },
-        { x: 3, y: 3, order: 1 },
-        { x: 2, y: 2, order: 3 }
-      ];
+        const returnData = Data.getData({ data });
 
-      const returnData = Data.getData({ data, sortKey: "order" });
+        expect(returnData).to.eql([
+          { _x: 2, x: 2, _y: 2, y: 2, eventKey: 0 },
+          { _x: 1, x: 1, _y: 3, y: 3, eventKey: 1 },
+          { _x: 3, x: 3, _y: 1, y: 1, eventKey: 2 }
+        ]);
+      });
 
-      expect(returnData).to.eql([
-        { _x: 3, x: 3, _y: 3, y: 3, order: 1, eventKey: 0 },
-        { _x: 1, x: 1, _y: 1, y: 1, order: 2, eventKey: 1 },
-        { _x: 2, x: 2, _y: 2, y: 2, order: 3, eventKey: 2 }
-      ]);
-    });
+      it("sorts data according to sort key", () => {
+        const data = createDataObj([
+          { x: 1, y: 1, order: 2 },
+          { x: 3, y: 3, order: 1 },
+          { x: 2, y: 2, order: 3 }
+        ]);
 
-    // Ensures previous VictoryLine api for sortKey prop stays consistent
-    it("sorts data according to evaluated sort key when sort key is x or y", () => {
-      const data = [
-        { _x: 2, x: 10, _y: 2, y: 10 },
-        { _x: 1, x: 20, _y: 3, y: 20 },
-        { _x: 3, x: 30, _y: 1, y: 30 }
-      ];
+        const returnData = Data.getData({ data, sortKey: "order" });
 
-      const returnDataX = Data.getData({ data, sortKey: "x" });
+        expect(returnData).to.eql([
+          { _x: 3, x: 3, _y: 3, y: 3, order: 1, eventKey: 0 },
+          { _x: 1, x: 1, _y: 1, y: 1, order: 2, eventKey: 1 },
+          { _x: 2, x: 2, _y: 2, y: 2, order: 3, eventKey: 2 }
+        ]);
+      });
 
-      expect(returnDataX).to.eql([
-        { _x: 1, x: 20, _y: 3, y: 20, eventKey: 0 },
-        { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
-        { _x: 3, x: 30, _y: 1, y: 30, eventKey: 2 }
-      ]);
+      // Ensures previous VictoryLine api for sortKey prop stays consistent
+      it("sorts data according to evaluated sort key when sort key is x or y", () => {
+        const data = createDataObj([
+          { _x: 2, x: 10, _y: 2, y: 10 },
+          { _x: 1, x: 20, _y: 3, y: 20 },
+          { _x: 3, x: 30, _y: 1, y: 30 }
+        ]);
 
-      const returnDataY = Data.getData({ data, sortKey: "y" });
+        const returnDataX = Data.getData({ data, sortKey: "x" });
 
-      expect(returnDataY).to.eql([
-        { _x: 3, x: 30, _y: 1, y: 30, eventKey: 0 },
-        { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
-        { _x: 1, x: 20, _y: 3, y: 20, eventKey: 2 }
-      ]);
-    });
+        expect(returnDataX).to.eql([
+          { _x: 1, x: 20, _y: 3, y: 20, eventKey: 0 },
+          { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
+          { _x: 3, x: 30, _y: 1, y: 30, eventKey: 2 }
+        ]);
 
-    it("generates a dataset from domain", () => {
-      const generatedReturn = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
-      const expectedReturn = [{ _x: 0, x: 0, _y: 0, y: 0 }, { _x: 10, x: 10, _y: 10, y: 10 }];
-      const expectedReturnWithEventKeys = [
-        { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 }, { _x: 10, x: 10, _y: 10, y: 10, eventKey: 1 }
-      ];
-      const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] } };
-      const returnData = Data.getData(props);
-      expect(Data.generateData).calledOnce.and.returned(generatedReturn);
-      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
-      expect(returnData).to.eql(expectedReturnWithEventKeys);
-    });
+        const returnDataY = Data.getData({ data, sortKey: "y" });
 
-    it("generates a dataset from domain and samples", () => {
-      const generatedReturn = [{ x: 0, y: 0 }, { x: 5, y: 5 }, { x: 10, y: 10 }];
-      const expectedReturn = [
-        { _x: 0, x: 0, _y: 0, y: 0 }, { _x: 5, x: 5, _y: 5, y: 5 }, { _x: 10, x: 10, _y: 10, y: 10 }
-      ];
-      const expectedReturnWithEventKeys = [
-        { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 },
-        { _x: 5, x: 5, _y: 5, y: 5, eventKey: 1 },
-        { _x: 10, x: 10, _y: 10, y: 10, eventKey: 2 }
-      ];
-      const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] }, samples: 2 };
-      const returnData = Data.getData(props);
-      expect(Data.generateData).calledOnce.and.returned(generatedReturn);
-      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
-      expect(returnData).to.eql(expectedReturnWithEventKeys);
+        expect(returnDataY).to.eql([
+          { _x: 3, x: 30, _y: 1, y: 30, eventKey: 0 },
+          { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
+          { _x: 1, x: 20, _y: 3, y: 20, eventKey: 2 }
+        ]);
+      });
+
+      it("generates a dataset from domain", () => {
+        const generatedReturn = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
+        const expectedReturn = [{ _x: 0, x: 0, _y: 0, y: 0 }, { _x: 10, x: 10, _y: 10, y: 10 }];
+        const expectedReturnWithEventKeys = [
+          { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 }, { _x: 10, x: 10, _y: 10, y: 10, eventKey: 1 }
+        ];
+        const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] } };
+        const returnData = Data.getData(props);
+        expect(Data.generateData).calledOnce.and.returned(generatedReturn);
+        expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+        expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+        expect(returnData).to.eql(expectedReturnWithEventKeys);
+      });
+
+      it("generates a dataset from domain and samples", () => {
+        const generatedReturn = [{ x: 0, y: 0 }, { x: 5, y: 5 }, { x: 10, y: 10 }];
+        const expectedReturn = [
+          { _x: 0, x: 0, _y: 0, y: 0 }, { _x: 5, x: 5, _y: 5, y: 5 }, { _x: 10, x: 10, _y: 10, y: 10 }
+        ];
+        const expectedReturnWithEventKeys = [
+          { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 },
+          { _x: 5, x: 5, _y: 5, y: 5, eventKey: 1 },
+          { _x: 10, x: 10, _y: 10, y: 10, eventKey: 2 }
+        ];
+        const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] }, samples: 2 };
+        const returnData = Data.getData(props);
+        expect(Data.generateData).calledOnce.and.returned(generatedReturn);
+        expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+        expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+        expect(returnData).to.eql(expectedReturnWithEventKeys);
+      });
     });
   });
 });

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -168,6 +168,38 @@ describe("helpers/data", () => {
       expect(returnData).to.eql(expectedReturnWithEventKeys);
     });
 
+    it("uses the event key when it is passed in", () => {
+      const data = [
+        { x: 2, y: 2, eventKey: 13 },
+        { x: 1, y: 3, eventKey: 21 },
+        { x: 3, y: 1, eventKey: 11 }
+      ];
+
+      const returnData = Data.getData({ data });
+
+      expect(returnData).to.eql([
+        { _x: 2, x: 2, _y: 2, y: 2, eventKey: 13 },
+        { _x: 1, x: 1, _y: 3, y: 3, eventKey: 21 },
+        { _x: 3, x: 3, _y: 1, y: 1, eventKey: 11 }
+      ]);
+    });
+
+    it("uses a custom event key when it is passed in", () => {
+      const data = [
+        { x: 2, y: 2, myEventKey: 3 },
+        { x: 1, y: 3, myEventKey: 2 },
+        { x: 3, y: 1, myEventKey: 1 }
+      ];
+
+      const returnData = Data.getData({ data, eventKey: "myEventKey" });
+
+      expect(returnData).to.eql([
+        { _x: 2, x: 2, _y: 2, y: 2, eventKey: 3, myEventKey: 3 },
+        { _x: 1, x: 1, _y: 3, y: 3, eventKey: 2, myEventKey: 2 },
+        { _x: 3, x: 3, _y: 1, y: 1, eventKey: 1, myEventKey: 1 }
+      ]);
+    });
+
     it("does not sort data when sort key not passed", () => {
       const data = [{ x: 2, y: 2 }, { x: 1, y: 3 }, { x: 3, y: 1 }];
 

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -1,4 +1,4 @@
-/* eslint no-unused-expressions: 0 */
+/* eslint no-unused-expressions: 0, max-nested-callbacks: 0 */
 /* global sinon */
 
 import { Data } from "src/index";
@@ -69,7 +69,13 @@ const dataTest = {
 
     describe("getStringsFromData", () => {
       it("returns an array of strings from a data prop", () => {
-        const props = { data: createDataObj([{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }]) };
+        const props = {
+          data: createDataObj([
+            { x: "one", y: 1 },
+            { x: "red", y: 2 },
+            { x: "cat", y: 3 }
+          ])
+        };
         const dataStrings = Data.getStringsFromData(props, "x");
         expect(dataStrings).to.eql(["one", "red", "cat"]);
       });
@@ -285,7 +291,9 @@ const dataTest = {
       it("generates a dataset from domain and samples", () => {
         const generatedReturn = [{ x: 0, y: 0 }, { x: 5, y: 5 }, { x: 10, y: 10 }];
         const expectedReturn = [
-          { _x: 0, x: 0, _y: 0, y: 0 }, { _x: 5, x: 5, _y: 5, y: 5 }, { _x: 10, x: 10, _y: 10, y: 10 }
+          { _x: 0, x: 0, _y: 0, y: 0 },
+          { _x: 5, x: 5, _y: 5, y: 5 },
+          { _x: 10, x: 10, _y: 10, y: 10 }
         ];
         const expectedReturnWithEventKeys = [
           { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 },

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -250,11 +250,11 @@ const dataTest = {
       });
 
       it("sorts data according to sort key and sort order", () => {
-        const data = [
+        const data = createDataObj([
           { x: 1, y: 1, order: 2 },
           { x: 3, y: 3, order: 1 },
           { x: 2, y: 2, order: 3 }
-        ];
+        ]);
 
         const returnData = Data.getData({ data, sortKey: "order", sortOrder: "descending" });
 

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -7,67 +7,72 @@ import { fromJS } from "immutable";
 const immutableDataTest = {
   createDataObj: (data) => fromJS(data),
   readDataObj: (data) => data.toJS(),
-  testLabel: "helpers/data for immutable"
+  testLabel: "data in immutable"
 };
 
 const dataTest = {
   createDataObj: (data) => data,
   readDataObj: (data) => data,
-  testLabel: "helpers/data"
+  testLabel: "data in js"
 };
 
-[dataTest, immutableDataTest].forEach(({ createDataObj, readDataObj, testLabel }) => {
-  describe(`${testLabel}`, () => {
-    describe("createStringMap", () => {
-      let sandbox;
-      beforeEach(() => {
-        sandbox = sinon.sandbox.create();
-        sandbox.spy(Data, "getStringsFromAxes");
-        sandbox.spy(Data, "getStringsFromCategories");
-        sandbox.spy(Data, "getStringsFromData");
-      });
-      afterEach(() => {
-        sandbox.restore();
-      });
-
-      const tickValues = ["one", "two", "three"];
-      const categories = ["red", "green", "blue"];
-      const data = createDataObj([{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }]);
-
-      it("returns a string map from strings in tickValues", () => {
-        const props = { tickValues };
-        const stringMap = Data.createStringMap(props, "x");
-        expect(Data.getStringsFromAxes).calledWith(props, "x");
-        expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
-        expect(stringMap).to.eql({ one: 1, two: 2, three: 3 });
-      });
-
-      it("returns a string map from strings in categories", () => {
-        const props = { categories };
-        const stringMap = Data.createStringMap(props, "x");
-        expect(Data.getStringsFromCategories).calledWith(props, "x");
-        expect(Data.getStringsFromCategories).to.have.returned(["red", "green", "blue"]);
-        expect(stringMap).to.eql({ red: 1, green: 2, blue: 3 });
-      });
-
-      it("returns a string map from strings in data", () => {
-        const props = { data };
-        const stringMap = Data.createStringMap(props, "x");
-        expect(Data.getStringsFromData).calledWith(props, "x");
-        expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
-        expect(stringMap).to.eql({ one: 1, red: 2, cat: 3 });
-      });
-
-      it("a unique set of values is returned from multiple sources", () => {
-        const props = { tickValues, data };
-        const stringMap = Data.createStringMap(props, "x");
-        expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
-        expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
-        expect(stringMap).to.eql({ one: 1, two: 2, three: 3, red: 4, cat: 5 });
-      });
+describe("helpers/data", () => {
+  describe("createStringMap", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Data, "getStringsFromAxes");
+      sandbox.spy(Data, "getStringsFromCategories");
+      sandbox.spy(Data, "getStringsFromData");
+    });
+    afterEach(() => {
+      sandbox.restore();
     });
 
-    describe("getStringsFromData", () => {
+    const tickValues = ["one", "two", "three"];
+    const categories = ["red", "green", "blue"];
+
+    it("returns a string map from strings in tickValues", () => {
+      const props = { tickValues };
+      const stringMap = Data.createStringMap(props, "x");
+      expect(Data.getStringsFromAxes).calledWith(props, "x");
+      expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
+      expect(stringMap).to.eql({ one: 1, two: 2, three: 3 });
+    });
+
+    it("returns a string map from strings in categories", () => {
+      const props = { categories };
+      const stringMap = Data.createStringMap(props, "x");
+      expect(Data.getStringsFromCategories).calledWith(props, "x");
+      expect(Data.getStringsFromCategories).to.have.returned(["red", "green", "blue"]);
+      expect(stringMap).to.eql({ red: 1, green: 2, blue: 3 });
+    });
+
+    [dataTest, immutableDataTest].forEach(({ createDataObj, testLabel }) => {
+      describe(`returning string maps with ${testLabel}`, () => {
+        const data = createDataObj([{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }]);
+
+        it("returns a string map from strings in data", () => {
+          const props = { data };
+          const stringMap = Data.createStringMap(props, "x");
+          expect(Data.getStringsFromData).calledWith(props, "x");
+          expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+          expect(stringMap).to.eql({ one: 1, red: 2, cat: 3 });
+        });
+
+        it("a unique set of values is returned from multiple sources", () => {
+          const props = { tickValues, data };
+          const stringMap = Data.createStringMap(props, "x");
+          expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
+          expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+          expect(stringMap).to.eql({ one: 1, two: 2, three: 3, red: 4, cat: 5 });
+        });
+      });
+    });
+  });
+
+  [dataTest, immutableDataTest].forEach(({ createDataObj, testLabel }) => {
+    describe(`getStringsFromData with ${testLabel}`, () => {
       it("returns an array of strings from a data prop", () => {
         const props = {
           data: createDataObj([
@@ -100,45 +105,47 @@ const dataTest = {
         expect(Data.getStringsFromData({}, "x")).to.eql([]);
       });
     });
+  });
 
-    describe("getStringsFromAxes", () => {
-      it("returns an array of strings when tickValues is an array", () => {
-        const props = { tickValues: [1, "three", 5] };
-        expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
-      });
-
-      it("returns an array of strings when tickValues is an object", () => {
-        const props = { tickValues: { x: [1, "three", 5] } };
-        expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
-      });
-
-      it("returns an empty array when a given axis is not defined", () => {
-        const props = { tickValues: { y: [1, "three", 5] } };
-        expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
-      });
-
-      it("returns an empty array when no strings are present", () => {
-        const props = { tickValues: [1, 3, 5] };
-        expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
-      });
-
-      it("returns an empty array when the tickValues prop is undefined", () => {
-        expect(Data.getStringsFromAxes({}, "x")).to.eql([]);
-      });
+  describe("getStringsFromAxes", () => {
+    it("returns an array of strings when tickValues is an array", () => {
+      const props = { tickValues: [1, "three", 5] };
+      expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
     });
 
-    describe("getStringsFromCategories", () => {
-      it("returns an empty array when no strings are present", () => {
-        const props = { categories: [1, 3, 5] };
-        expect(Data.getStringsFromCategories(props, "x")).to.eql([]);
-      });
-
-      it("returns an empty array when the category prop is undefined", () => {
-        expect(Data.getStringsFromCategories({}, "x")).to.eql([]);
-      });
+    it("returns an array of strings when tickValues is an object", () => {
+      const props = { tickValues: { x: [1, "three", 5] } };
+      expect(Data.getStringsFromAxes(props, "x")).to.eql(["three"]);
     });
 
-    describe("formatData", () => {
+    it("returns an empty array when a given axis is not defined", () => {
+      const props = { tickValues: { y: [1, "three", 5] } };
+      expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when no strings are present", () => {
+      const props = { tickValues: [1, 3, 5] };
+      expect(Data.getStringsFromAxes(props, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when the tickValues prop is undefined", () => {
+      expect(Data.getStringsFromAxes({}, "x")).to.eql([]);
+    });
+  });
+
+  describe("getStringsFromCategories", () => {
+    it("returns an empty array when no strings are present", () => {
+      const props = { categories: [1, 3, 5] };
+      expect(Data.getStringsFromCategories(props, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when the category prop is undefined", () => {
+      expect(Data.getStringsFromCategories({}, "x")).to.eql([]);
+    });
+  });
+
+  [dataTest, immutableDataTest].forEach(({ createDataObj, readDataObj, testLabel }) => {
+    describe(`formatData with ${testLabel}`, () => {
       let sandbox;
       beforeEach(() => {
         sandbox = sinon.sandbox.create();
@@ -158,172 +165,176 @@ const dataTest = {
         expect(formatted[0]).to.have.keys(["_x", "_y", "x", "y"]);
       });
     });
+  });
 
-    describe("getData", () => {
-      let sandbox;
-      beforeEach(() => {
-        sandbox = sinon.sandbox.create();
-        sandbox.spy(Data, "formatData");
-        sandbox.spy(Data, "generateData");
-        sandbox.spy(Data, "addEventKeys");
+  describe("getData", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Data, "formatData");
+      sandbox.spy(Data, "generateData");
+      sandbox.spy(Data, "addEventKeys");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    [dataTest, immutableDataTest].forEach(({ createDataObj, testLabel }) => {
+      describe(`with ${testLabel}`, () => {
+        it("formats and returns the data prop", () => {
+          const data = createDataObj([{ x: "kittens", y: 3 }, { x: "cats", y: 5 }]);
+          const props = { data, x: "x", y: "y" };
+          const expectedReturn = [
+            { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3 },
+            { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5 }
+          ];
+          const expectedReturnWithEventKeys = [
+             { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3, eventKey: 0 },
+             { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5, eventKey: 1 }
+          ];
+          const returnData = Data.getData(props);
+          expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+          expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+          expect(returnData).to.eql(expectedReturnWithEventKeys);
+        });
+
+        it("uses the event key when it is passed in", () => {
+          const data = createDataObj([
+            { x: 2, y: 2, eventKey: 13 },
+            { x: 1, y: 3, eventKey: 21 },
+            { x: 3, y: 1, eventKey: 11 }
+          ]);
+
+          const returnData = Data.getData({ data });
+
+          expect(returnData).to.eql([
+            { _x: 2, x: 2, _y: 2, y: 2, eventKey: 13 },
+            { _x: 1, x: 1, _y: 3, y: 3, eventKey: 21 },
+            { _x: 3, x: 3, _y: 1, y: 1, eventKey: 11 }
+          ]);
+        });
+
+        it("uses a custom event key when it is passed in", () => {
+          const data = createDataObj([
+            { x: 2, y: 2, myEventKey: 3 },
+            { x: 1, y: 3, myEventKey: 2 },
+            { x: 3, y: 1, myEventKey: 1 }
+          ]);
+
+          const returnData = Data.getData({ data, eventKey: "myEventKey" });
+
+          expect(returnData).to.eql([
+            { _x: 2, x: 2, _y: 2, y: 2, eventKey: 3, myEventKey: 3 },
+            { _x: 1, x: 1, _y: 3, y: 3, eventKey: 2, myEventKey: 2 },
+            { _x: 3, x: 3, _y: 1, y: 1, eventKey: 1, myEventKey: 1 }
+          ]);
+        });
+
+        it("does not sort data when sort key not passed", () => {
+          const data = createDataObj([{ x: 2, y: 2 }, { x: 1, y: 3 }, { x: 3, y: 1 }]);
+
+          const returnData = Data.getData({ data });
+
+          expect(returnData).to.eql([
+            { _x: 2, x: 2, _y: 2, y: 2, eventKey: 0 },
+            { _x: 1, x: 1, _y: 3, y: 3, eventKey: 1 },
+            { _x: 3, x: 3, _y: 1, y: 1, eventKey: 2 }
+          ]);
+        });
+
+        it("sorts data according to sort key", () => {
+          const data = createDataObj([
+            { x: 1, y: 1, order: 2 },
+            { x: 3, y: 3, order: 1 },
+            { x: 2, y: 2, order: 3 }
+          ]);
+
+          const returnData = Data.getData({ data, sortKey: "order" });
+
+          expect(returnData).to.eql([
+            { _x: 3, x: 3, _y: 3, y: 3, order: 1, eventKey: 0 },
+            { _x: 1, x: 1, _y: 1, y: 1, order: 2, eventKey: 1 },
+            { _x: 2, x: 2, _y: 2, y: 2, order: 3, eventKey: 2 }
+          ]);
+        });
+
+        it("sorts data according to sort key and sort order", () => {
+          const data = createDataObj([
+            { x: 1, y: 1, order: 2 },
+            { x: 3, y: 3, order: 1 },
+            { x: 2, y: 2, order: 3 }
+          ]);
+
+          const returnData = Data.getData({ data, sortKey: "order", sortOrder: "descending" });
+
+          expect(returnData).to.eql([
+            { _x: 2, x: 2, _y: 2, y: 2, order: 3, eventKey: 0 },
+            { _x: 1, x: 1, _y: 1, y: 1, order: 2, eventKey: 1 },
+            { _x: 3, x: 3, _y: 3, y: 3, order: 1, eventKey: 2 }
+
+          ]);
+        });
+
+        // Ensures previous VictoryLine api for sortKey prop stays consistent
+        it("sorts data according to evaluated sort key when sort key is x or y", () => {
+          const data = createDataObj([
+            { _x: 2, x: 10, _y: 2, y: 10 },
+            { _x: 1, x: 20, _y: 3, y: 20 },
+            { _x: 3, x: 30, _y: 1, y: 30 }
+          ]);
+
+          const returnDataX = Data.getData({ data, sortKey: "x" });
+
+          expect(returnDataX).to.eql([
+            { _x: 1, x: 20, _y: 3, y: 20, eventKey: 0 },
+            { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
+            { _x: 3, x: 30, _y: 1, y: 30, eventKey: 2 }
+          ]);
+
+          const returnDataY = Data.getData({ data, sortKey: "y" });
+
+          expect(returnDataY).to.eql([
+            { _x: 3, x: 30, _y: 1, y: 30, eventKey: 0 },
+            { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
+            { _x: 1, x: 20, _y: 3, y: 20, eventKey: 2 }
+          ]);
+        });
       });
+    });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
+    it("generates a dataset from domain", () => {
+      const generatedReturn = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
+      const expectedReturn = [{ _x: 0, x: 0, _y: 0, y: 0 }, { _x: 10, x: 10, _y: 10, y: 10 }];
+      const expectedReturnWithEventKeys = [
+        { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 }, { _x: 10, x: 10, _y: 10, y: 10, eventKey: 1 }
+      ];
+      const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] } };
+      const returnData = Data.getData(props);
+      expect(Data.generateData).calledOnce.and.returned(generatedReturn);
+      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+      expect(returnData).to.eql(expectedReturnWithEventKeys);
+    });
 
-      it("formats and returns the data prop", () => {
-        const data = createDataObj([{ x: "kittens", y: 3 }, { x: "cats", y: 5 }]);
-        const props = { data, x: "x", y: "y" };
-        const expectedReturn = [
-          { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3 },
-          { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5 }
-        ];
-        const expectedReturnWithEventKeys = [
-           { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3, eventKey: 0 },
-           { _x: 2, x: "cats", xName: "cats", _y: 5, y: 5, eventKey: 1 }
-        ];
-        const returnData = Data.getData(props);
-        expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-        expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
-        expect(returnData).to.eql(expectedReturnWithEventKeys);
-      });
-
-      it("uses the event key when it is passed in", () => {
-        const data = createDataObj([
-          { x: 2, y: 2, eventKey: 13 },
-          { x: 1, y: 3, eventKey: 21 },
-          { x: 3, y: 1, eventKey: 11 }
-        ]);
-
-        const returnData = Data.getData({ data });
-
-        expect(returnData).to.eql([
-          { _x: 2, x: 2, _y: 2, y: 2, eventKey: 13 },
-          { _x: 1, x: 1, _y: 3, y: 3, eventKey: 21 },
-          { _x: 3, x: 3, _y: 1, y: 1, eventKey: 11 }
-        ]);
-      });
-
-      it("uses a custom event key when it is passed in", () => {
-        const data = createDataObj([
-          { x: 2, y: 2, myEventKey: 3 },
-          { x: 1, y: 3, myEventKey: 2 },
-          { x: 3, y: 1, myEventKey: 1 }
-        ]);
-
-        const returnData = Data.getData({ data, eventKey: "myEventKey" });
-
-        expect(returnData).to.eql([
-          { _x: 2, x: 2, _y: 2, y: 2, eventKey: 3, myEventKey: 3 },
-          { _x: 1, x: 1, _y: 3, y: 3, eventKey: 2, myEventKey: 2 },
-          { _x: 3, x: 3, _y: 1, y: 1, eventKey: 1, myEventKey: 1 }
-        ]);
-      });
-
-      it("does not sort data when sort key not passed", () => {
-        const data = createDataObj([{ x: 2, y: 2 }, { x: 1, y: 3 }, { x: 3, y: 1 }]);
-
-        const returnData = Data.getData({ data });
-
-        expect(returnData).to.eql([
-          { _x: 2, x: 2, _y: 2, y: 2, eventKey: 0 },
-          { _x: 1, x: 1, _y: 3, y: 3, eventKey: 1 },
-          { _x: 3, x: 3, _y: 1, y: 1, eventKey: 2 }
-        ]);
-      });
-
-      it("sorts data according to sort key", () => {
-        const data = createDataObj([
-          { x: 1, y: 1, order: 2 },
-          { x: 3, y: 3, order: 1 },
-          { x: 2, y: 2, order: 3 }
-        ]);
-
-        const returnData = Data.getData({ data, sortKey: "order" });
-
-        expect(returnData).to.eql([
-          { _x: 3, x: 3, _y: 3, y: 3, order: 1, eventKey: 0 },
-          { _x: 1, x: 1, _y: 1, y: 1, order: 2, eventKey: 1 },
-          { _x: 2, x: 2, _y: 2, y: 2, order: 3, eventKey: 2 }
-        ]);
-      });
-
-      it("sorts data according to sort key and sort order", () => {
-        const data = createDataObj([
-          { x: 1, y: 1, order: 2 },
-          { x: 3, y: 3, order: 1 },
-          { x: 2, y: 2, order: 3 }
-        ]);
-
-        const returnData = Data.getData({ data, sortKey: "order", sortOrder: "descending" });
-
-        expect(returnData).to.eql([
-          { _x: 2, x: 2, _y: 2, y: 2, order: 3, eventKey: 0 },
-          { _x: 1, x: 1, _y: 1, y: 1, order: 2, eventKey: 1 },
-          { _x: 3, x: 3, _y: 3, y: 3, order: 1, eventKey: 2 }
-
-        ]);
-      });
-
-      // Ensures previous VictoryLine api for sortKey prop stays consistent
-      it("sorts data according to evaluated sort key when sort key is x or y", () => {
-        const data = createDataObj([
-          { _x: 2, x: 10, _y: 2, y: 10 },
-          { _x: 1, x: 20, _y: 3, y: 20 },
-          { _x: 3, x: 30, _y: 1, y: 30 }
-        ]);
-
-        const returnDataX = Data.getData({ data, sortKey: "x" });
-
-        expect(returnDataX).to.eql([
-          { _x: 1, x: 20, _y: 3, y: 20, eventKey: 0 },
-          { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
-          { _x: 3, x: 30, _y: 1, y: 30, eventKey: 2 }
-        ]);
-
-        const returnDataY = Data.getData({ data, sortKey: "y" });
-
-        expect(returnDataY).to.eql([
-          { _x: 3, x: 30, _y: 1, y: 30, eventKey: 0 },
-          { _x: 2, x: 10, _y: 2, y: 10, eventKey: 1 },
-          { _x: 1, x: 20, _y: 3, y: 20, eventKey: 2 }
-        ]);
-      });
-
-      it("generates a dataset from domain", () => {
-        const generatedReturn = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
-        const expectedReturn = [{ _x: 0, x: 0, _y: 0, y: 0 }, { _x: 10, x: 10, _y: 10, y: 10 }];
-        const expectedReturnWithEventKeys = [
-          { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 }, { _x: 10, x: 10, _y: 10, y: 10, eventKey: 1 }
-        ];
-        const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] } };
-        const returnData = Data.getData(props);
-        expect(Data.generateData).calledOnce.and.returned(generatedReturn);
-        expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-        expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
-        expect(returnData).to.eql(expectedReturnWithEventKeys);
-      });
-
-      it("generates a dataset from domain and samples", () => {
-        const generatedReturn = [{ x: 0, y: 0 }, { x: 5, y: 5 }, { x: 10, y: 10 }];
-        const expectedReturn = [
-          { _x: 0, x: 0, _y: 0, y: 0 },
-          { _x: 5, x: 5, _y: 5, y: 5 },
-          { _x: 10, x: 10, _y: 10, y: 10 }
-        ];
-        const expectedReturnWithEventKeys = [
-          { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 },
-          { _x: 5, x: 5, _y: 5, y: 5, eventKey: 1 },
-          { _x: 10, x: 10, _y: 10, y: 10, eventKey: 2 }
-        ];
-        const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] }, samples: 2 };
-        const returnData = Data.getData(props);
-        expect(Data.generateData).calledOnce.and.returned(generatedReturn);
-        expect(Data.formatData).calledOnce.and.returned(expectedReturn);
-        expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
-        expect(returnData).to.eql(expectedReturnWithEventKeys);
-      });
+    it("generates a dataset from domain and samples", () => {
+      const generatedReturn = [{ x: 0, y: 0 }, { x: 5, y: 5 }, { x: 10, y: 10 }];
+      const expectedReturn = [
+        { _x: 0, x: 0, _y: 0, y: 0 },
+        { _x: 5, x: 5, _y: 5, y: 5 },
+        { _x: 10, x: 10, _y: 10, y: 10 }
+      ];
+      const expectedReturnWithEventKeys = [
+        { _x: 0, x: 0, _y: 0, y: 0, eventKey: 0 },
+        { _x: 5, x: 5, _y: 5, y: 5, eventKey: 1 },
+        { _x: 10, x: 10, _y: 10, y: 10, eventKey: 2 }
+      ];
+      const props = { x: "x", y: "y", domain: { x: [0, 10], y: [0, 10] }, samples: 2 };
+      const returnData = Data.getData(props);
+      expect(Data.generateData).calledOnce.and.returned(generatedReturn);
+      expect(Data.formatData).calledOnce.and.returned(expectedReturn);
+      expect(Data.addEventKeys).calledOnce.and.returned(expectedReturnWithEventKeys);
+      expect(returnData).to.eql(expectedReturnWithEventKeys);
     });
   });
 });

--- a/test/client/spec/victory-util/data.spec.js
+++ b/test/client/spec/victory-util/data.spec.js
@@ -5,14 +5,12 @@ import { Data } from "src/index";
 import { fromJS } from "immutable";
 
 const immutableDataTest = {
-  createDataObj: (data) => fromJS(data),
-  readDataObj: (data) => data.toJS(),
+  createData: (data) => fromJS(data),
   testLabel: "data in immutable"
 };
 
 const dataTest = {
-  createDataObj: (data) => data,
-  readDataObj: (data) => data,
+  createData: (data) => data,
   testLabel: "data in js"
 };
 
@@ -48,9 +46,9 @@ describe("helpers/data", () => {
       expect(stringMap).to.eql({ red: 1, green: 2, blue: 3 });
     });
 
-    [dataTest, immutableDataTest].forEach(({ createDataObj, testLabel }) => {
+    [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
       describe(`returning string maps with ${testLabel}`, () => {
-        const data = createDataObj([{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }]);
+        const data = createData([{ x: "one", y: 1 }, { x: "red", y: 2 }, { x: "cat", y: 3 }]);
 
         it("returns a string map from strings in data", () => {
           const props = { data };
@@ -71,11 +69,11 @@ describe("helpers/data", () => {
     });
   });
 
-  [dataTest, immutableDataTest].forEach(({ createDataObj, testLabel }) => {
+  [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
     describe(`getStringsFromData with ${testLabel}`, () => {
       it("returns an array of strings from a data prop", () => {
         const props = {
-          data: createDataObj([
+          data: createData([
             { x: "one", y: 1 },
             { x: "red", y: 2 },
             { x: "cat", y: 3 }
@@ -86,18 +84,18 @@ describe("helpers/data", () => {
       });
 
       it("returns an array of strings from array-type data", () => {
-        const props = { data: createDataObj([["one", 1], ["red", 2], ["cat", 3]]), x: 0, y: 1 };
+        const props = { data: createData([["one", 1], ["red", 2], ["cat", 3]]), x: 0, y: 1 };
         const dataStrings = Data.getStringsFromData(props, "x");
         expect(dataStrings).to.eql(["one", "red", "cat"]);
       });
 
       it("only returns strings, if data is mixed", () => {
-        const props = { data: createDataObj([{ x: 1, y: 1 }, { x: "three", y: 3 }]) };
+        const props = { data: createData([{ x: 1, y: 1 }, { x: "three", y: 3 }]) };
         expect(Data.getStringsFromData(props, "x")).to.eql(["three"]);
       });
 
       it("returns an empty array when no strings are present", () => {
-        const props = { data: createDataObj([{ x: 1, y: 1 }, { x: 3, y: 3 }]) };
+        const props = { data: createData([{ x: 1, y: 1 }, { x: 3, y: 3 }]) };
         expect(Data.getStringsFromData(props, "x")).to.eql([]);
       });
 
@@ -144,7 +142,7 @@ describe("helpers/data", () => {
     });
   });
 
-  [dataTest, immutableDataTest].forEach(({ createDataObj, readDataObj, testLabel }) => {
+  [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
     describe(`formatData with ${testLabel}`, () => {
       let sandbox;
       beforeEach(() => {
@@ -157,10 +155,10 @@ describe("helpers/data", () => {
       });
 
       it("formats a single dataset", () => {
-        const dataset = createDataObj([{ _x: 1, _y: 3, x: 1, y: 3 }, { _x: 2, _y: 5, x: 2, y: 5 }]);
-        const props = { data: dataset };
+        const dataset = [{ _x: 1, _y: 3, x: 1, y: 3 }, { _x: 2, _y: 5, x: 2, y: 5 }];
+        const props = { data: createData(dataset) };
         const formatted = Data.formatData(dataset, props);
-        expect(Data.cleanData).called.and.returned(readDataObj(dataset));
+        expect(Data.cleanData).called.and.returned(dataset);
         expect(formatted).to.be.an.array;
         expect(formatted[0]).to.have.keys(["_x", "_y", "x", "y"]);
       });
@@ -180,10 +178,10 @@ describe("helpers/data", () => {
       sandbox.restore();
     });
 
-    [dataTest, immutableDataTest].forEach(({ createDataObj, testLabel }) => {
+    [dataTest, immutableDataTest].forEach(({ createData, testLabel }) => {
       describe(`with ${testLabel}`, () => {
         it("formats and returns the data prop", () => {
-          const data = createDataObj([{ x: "kittens", y: 3 }, { x: "cats", y: 5 }]);
+          const data = createData([{ x: "kittens", y: 3 }, { x: "cats", y: 5 }]);
           const props = { data, x: "x", y: "y" };
           const expectedReturn = [
             { _x: 1, x: "kittens", xName: "kittens", _y: 3, y: 3 },
@@ -200,7 +198,7 @@ describe("helpers/data", () => {
         });
 
         it("uses the event key when it is passed in", () => {
-          const data = createDataObj([
+          const data = createData([
             { x: 2, y: 2, eventKey: 13 },
             { x: 1, y: 3, eventKey: 21 },
             { x: 3, y: 1, eventKey: 11 }
@@ -216,7 +214,7 @@ describe("helpers/data", () => {
         });
 
         it("uses a custom event key when it is passed in", () => {
-          const data = createDataObj([
+          const data = createData([
             { x: 2, y: 2, myEventKey: 3 },
             { x: 1, y: 3, myEventKey: 2 },
             { x: 3, y: 1, myEventKey: 1 }
@@ -232,7 +230,7 @@ describe("helpers/data", () => {
         });
 
         it("does not sort data when sort key not passed", () => {
-          const data = createDataObj([{ x: 2, y: 2 }, { x: 1, y: 3 }, { x: 3, y: 1 }]);
+          const data = createData([{ x: 2, y: 2 }, { x: 1, y: 3 }, { x: 3, y: 1 }]);
 
           const returnData = Data.getData({ data });
 
@@ -244,7 +242,7 @@ describe("helpers/data", () => {
         });
 
         it("sorts data according to sort key", () => {
-          const data = createDataObj([
+          const data = createData([
             { x: 1, y: 1, order: 2 },
             { x: 3, y: 3, order: 1 },
             { x: 2, y: 2, order: 3 }
@@ -260,7 +258,7 @@ describe("helpers/data", () => {
         });
 
         it("sorts data according to sort key and sort order", () => {
-          const data = createDataObj([
+          const data = createData([
             { x: 1, y: 1, order: 2 },
             { x: 3, y: 3, order: 1 },
             { x: 2, y: 2, order: 3 }
@@ -278,7 +276,7 @@ describe("helpers/data", () => {
 
         // Ensures previous VictoryLine api for sortKey prop stays consistent
         it("sorts data according to evaluated sort key when sort key is x or y", () => {
-          const data = createDataObj([
+          const data = createData([
             { _x: 2, x: 10, _y: 2, y: 10 },
             { _x: 1, x: 20, _y: 3, y: 20 },
             { _x: 3, x: 30, _y: 1, y: 30 }

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -76,39 +76,27 @@ describe("helpers", () => {
     });
   });
 
-  const immutableAccessorTest = {
-    createDataObj: (x) => fromJS(x),
-    testLabel: "createAccessor for immutable"
-  };
+  describe("createAccessor", () => {
+    it("creates a valid object accessor from a property key", () => {
+      const accessor = Helpers.createAccessor("k");
+      expect(accessor({ k: 42 })).to.eql(42);
+    });
 
-  const accessorTest = {
-    createDataObj: (x) => x,
-    testLabel: "createAccessor"
-  };
+    it("creates a valid array accessor from an index", () => {
+      const accessor = Helpers.createAccessor(2);
+      expect(accessor([3, 4, 5])).to.eql(5);
+    });
 
-  [accessorTest, immutableAccessorTest].forEach(({ createDataObj, testLabel }) => {
-    describe(`${testLabel}`, () => {
-      it("creates a valid object accessor from a property key", () => {
-        const accessor = Helpers.createAccessor("k");
-        expect(accessor(createDataObj({ k: 42 }))).to.eql(42);
-      });
+    it("creates a valid array accessor from a deeply nested path", () => {
+      const accessor = Helpers.createAccessor("x.y[0].0.z");
+      expect(accessor({ x: { y: [[{ z: 1987 }]] } })).to.eql(1987);
+    });
 
-      it("creates a valid array accessor from an index", () => {
-        const accessor = Helpers.createAccessor(2);
-        expect(accessor(createDataObj([3, 4, 5]))).to.eql(5);
-      });
-
-      it("creates a valid array accessor from a deeply nested path", () => {
-        const accessor = Helpers.createAccessor("x.y[0].0.z");
-        expect(accessor(createDataObj({ x: { y: [[{ z: 1987 }]] } }))).to.eql(1987);
-      });
-
-      it("creates a value (passthrough) accessor from null/undefined", () => {
-        const nullAccessor = Helpers.createAccessor(null);
-        const undefinedAccessor = Helpers.createAccessor(undefined);
-        expect(nullAccessor("ok")).to.eql("ok");
-        expect(undefinedAccessor(14)).to.eql(14);
-      });
+    it("creates a value (passthrough) accessor from null/undefined", () => {
+      const nullAccessor = Helpers.createAccessor(null);
+      const undefinedAccessor = Helpers.createAccessor(undefined);
+      expect(nullAccessor("ok")).to.eql("ok");
+      expect(undefinedAccessor(14)).to.eql(14);
     });
   });
 

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -1,6 +1,7 @@
 /* eslint no-unused-expressions: 0 */
-
+import { fromJS } from "immutable";
 import Helpers from "src/victory-util/helpers";
+
 describe("helpers", () => {
   describe("evaluateProp", () => {
     const data = { x: 3, y: 2 };
@@ -75,27 +76,39 @@ describe("helpers", () => {
     });
   });
 
-  describe("createAccessor", () => {
-    it("creates a valid object accessor from a property key", () => {
-      const accessor = Helpers.createAccessor("k");
-      expect(accessor({ k: 42 })).to.eql(42);
-    });
+  const immutableAccessorTest = {
+    createDataObj: (x) => fromJS(x),
+    testLabel: "createAccessor for immutable"
+  };
 
-    it("creates a valid array accessor from an index", () => {
-      const accessor = Helpers.createAccessor(2);
-      expect(accessor([3, 4, 5])).to.eql(5);
-    });
+  const accessorTest = {
+    createDataObj: (x) => x,
+    testLabel: "createAccessor"
+  };
 
-    it("creates a valid array accessor from a deeply nested path", () => {
-      const accessor = Helpers.createAccessor("x.y[0].0.z");
-      expect(accessor({ x: { y: [[{ z: 1987 }]] } })).to.eql(1987);
-    });
+  [accessorTest, immutableAccessorTest].forEach(({ createDataObj, testLabel }) => {
+    describe(`${testLabel}`, () => {
+      it("creates a valid object accessor from a property key", () => {
+        const accessor = Helpers.createAccessor("k");
+        expect(accessor(createDataObj({ k: 42 }))).to.eql(42);
+      });
 
-    it("creates a value (passthrough) accessor from null/undefined", () => {
-      const nullAccessor = Helpers.createAccessor(null);
-      const undefinedAccessor = Helpers.createAccessor(undefined);
-      expect(nullAccessor("ok")).to.eql("ok");
-      expect(undefinedAccessor(14)).to.eql(14);
+      it("creates a valid array accessor from an index", () => {
+        const accessor = Helpers.createAccessor(2);
+        expect(accessor(createDataObj([3, 4, 5]))).to.eql(5);
+      });
+
+      it("creates a valid array accessor from a deeply nested path", () => {
+        const accessor = Helpers.createAccessor("x.y[0].0.z");
+        expect(accessor(createDataObj({ x: { y: [[{ z: 1987 }]] } }))).to.eql(1987);
+      });
+
+      it("creates a value (passthrough) accessor from null/undefined", () => {
+        const nullAccessor = Helpers.createAccessor(null);
+        const undefinedAccessor = Helpers.createAccessor(undefined);
+        expect(nullAccessor("ok")).to.eql("ok");
+        expect(undefinedAccessor(14)).to.eql(14);
+      });
     });
   });
 

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -1,5 +1,4 @@
 /* eslint no-unused-expressions: 0 */
-import { fromJS } from "immutable";
 import Helpers from "src/victory-util/helpers";
 
 describe("helpers", () => {


### PR DESCRIPTION
shallowly converts `data` prop from `immutable` object to js, preserving all props in each data point within `data`. 

corresponding PR in victory chart: https://github.com/FormidableLabs/victory-chart/pull/542

`x` and `y` accessors and other props like `animate` that can take a function with a `datum` argument will receive a shallowly converted `datum` (`datum` will be a js plain object, but the keys will be in their original forms with a few exceptions).

i.e.
```
x={(datum) => {
  // datum is regular js but the keys are the original immutable objects
  return datum["myNestedStructure"].get("myNestedValue") + 10;
}}
animate={
  onEnter: {
    before: (datum) => {
      // datum is regular js
      // datum.someProp will be an immutable object if it was passed in as such
    }
  }
}
```