### PR TITLE
Add support for inlining multiple text and passing an array via the lineHeight prop. Features for #893, #902, and #904.

### DIFF
--- a/demo/victory-label-demo.js
+++ b/demo/victory-label-demo.js
@@ -17,7 +17,6 @@ export default class App extends React.Component {
             text={"Victory is awesome.\nThis is default anchoring.\nCapisce?"}
           />
 
-
           <circle cx="200" cy="50" r="2" fill="red"/>
           <VictoryLabel
             x={200} y={50}
@@ -25,7 +24,6 @@ export default class App extends React.Component {
             desc={"Victory is awesome. This is a description."}
             text={"Victory is awesome.\nThis has a title and description."}
           />
-
 
           <circle cx="0" cy="75" r="2" fill="red"/>
           <VictoryLabel
@@ -90,26 +88,45 @@ export default class App extends React.Component {
           {/* examples for inlining VictoryLabel with mutlitple labels */}
           <circle cx="300" cy="1500" r="2" fill="red"/>
           <VictoryLabel x={300} y={1500} textAnchor="end" verticalAnchor="middle"
-            text={"This is inline styling for <tspan>. Woohoo!"} inline
+            text={["Victory is awesome.", "This is inline styling for labels."]}
+            inline
           />
 
           <circle cx="300" cy="1650" r="2" fill="red"/>
           <VictoryLabel x={300} y={1650} textAnchor="start" verticalAnchor="middle"
-            text={[ 'We still get', 'varying label styles!' ]}
-            style={[{ fill: '#000' }, { fill: '#6128ff', fontSize: 20 }]} inline dx={25}
+            text={["This is varying styles", "inline."]}
+            style={[{ fill: "#000" }, { fill: "#6128ff", fontSize: 20 }]}
+            inline
+            dx={25}
           />
 
           <circle cx="0" cy="1800" r="2" fill="red"/>
           <VictoryLabel x={0} y={1800} textAnchor="start" verticalAnchor="start"
-            text={["Use", "dx", "attribute", "to", "shift", "labels", "relative to one another."]} inline dx={"10"}
+            text={["Use", "dx", "attribute", "to", "shift", "labels", "relative to one another."]}
+            inline
+            dx={"10"}
           />
 
-          {/* example for passing an array of lineHeights - can accept a number[] or string[] */}
+          {/**
+            * example for passing an array of lineHeights.
+            * lineHeight prop can accept a number[] or string[].
+          */}
           <circle cx="0" cy="2000" r="2" fill="red"/>
           <VictoryLabel
             x={0} y={2000}
-            text={["Victory is awesome.", "We can even specify", "a lineHeight array!", "Just like this!"]}
-            style={[{ fontSize: 50, fill: "green" }, { fontSize: 60 }, { fontSize: 30 }, { fontSize: 30 }]}
+            text={[
+              "Victory is awesome.",
+              "This is variable",
+              "lineHeight",
+              "as an array."
+            ]}
+            style={[
+              { fontSize: 50, fill: "green" },
+              { fontSize: 60 },
+              { fontSize: 30 },
+              { fontSize: 30 }
+            ]}
+            // eslint-disable-next-line no-magic-numbers
             lineHeight={[1.22, 2, 3, 1]}
             verticalAnchor="start"
           />
@@ -118,7 +135,12 @@ export default class App extends React.Component {
           <circle cx="300" cy="2300" r="2" fill="red"/>
           <VictoryLabel
             x={300} y={2300}
-            text={["Victory is awesome.", "Even if we leave blank arrays.", "Victory will save us with defaults."]}
+            text={[
+              "Victory is awesome.",
+              "Even if we leave blank arrays",
+              "for style or lineHeight,",
+              "Victory will save us with defaults."
+            ]}
             style={[]}
             lineHeight={[]}
             verticalAnchor="start"

--- a/demo/victory-label-demo.js
+++ b/demo/victory-label-demo.js
@@ -9,7 +9,7 @@ export default class App extends React.Component {
           VictoryLabel demo! The little circles show the anchor points for
           each label.
         </p>
-        <svg width="600" height="1800" style={{ border: "1px solid #ccc", padding: 40 }}>
+        <svg width="600" height="2000" style={{ border: "1px solid #ccc", padding: 40 }}>
 
           <circle cx="0" cy="0" r="2" fill="red"/>
           <VictoryLabel
@@ -85,6 +85,23 @@ export default class App extends React.Component {
           <circle cx="300" cy="1350" r="2" fill="red"/>
           <VictoryLabel x={300} y={1350} textAnchor="start" verticalAnchor="middle"
             text={"Victory is awesome.\nThis is (start, middle) anchoring.\nCapisce?"}
+          />
+
+          {/* examples for inlining VictoryLabel with mutlitple labels */}
+          <circle cx="300" cy="1500" r="2" fill="red"/>
+          <VictoryLabel x={300} y={1500} textAnchor="end" verticalAnchor="middle"
+            text={"Victory is awesome.\nThis is inline styling for <tspan>. Woohoo!"} inline
+          />
+
+          <circle cx="300" cy="1650" r="2" fill="red"/>
+          <VictoryLabel x={300} y={1650} textAnchor="start" verticalAnchor="middle"
+            text={[ '% of target', '44% for 2017' ]}
+            style={[{ fill: '#000' }, { fill: '#6128ff', fontSize: 20 }]} inline dx={25}
+          />
+
+          <circle cx="300" cy="1800" r="2" fill="red"/>
+          <VictoryLabel x={300} y={1800} textAnchor="start" verticalAnchor="start"
+            text={["shift", "subsequent", "labels", "by", "5"]} inline dx={"5"}
           />
         </svg>
       </div>

--- a/demo/victory-label-demo.js
+++ b/demo/victory-label-demo.js
@@ -90,7 +90,7 @@ export default class App extends React.Component {
           {/* examples for inlining VictoryLabel with mutlitple labels */}
           <circle cx="300" cy="1500" r="2" fill="red"/>
           <VictoryLabel x={300} y={1500} textAnchor="end" verticalAnchor="middle"
-            text={"Victory is awesome.\nThis is inline styling for <tspan>. Woohoo!"} inline
+            text={"This is inline styling for <tspan>. Woohoo!"} inline
           />
 
           <circle cx="300" cy="1650" r="2" fill="red"/>
@@ -104,12 +104,23 @@ export default class App extends React.Component {
             text={["Use", "dx", "attribute", "to", "shift", "labels", "relative to one another."]} inline dx={"10"}
           />
 
+          {/* example for passing an array of lineHeights - can accept a number[] or string[] */}
           <circle cx="0" cy="2000" r="2" fill="red"/>
           <VictoryLabel
             x={0} y={2000}
             text={["Victory is awesome.", "We can even specify", "a lineHeight array!", "Just like this!"]}
             style={[{ fontSize: 50, fill: "green" }, { fontSize: 60 }, { fontSize: 30 }, { fontSize: 30 }]}
             lineHeight={[1.22, 2, 3, 1]}
+            verticalAnchor="start"
+          />
+
+          {/* example for guarding against empty style and lineHeight arrays */}
+          <circle cx="300" cy="2300" r="2" fill="red"/>
+          <VictoryLabel
+            x={300} y={2300}
+            text={["Victory is awesome.", "Even if we leave blank arrays.", "Victory will save us with defaults."]}
+            style={[]}
+            lineHeight={[]}
             verticalAnchor="start"
           />
 

--- a/demo/victory-label-demo.js
+++ b/demo/victory-label-demo.js
@@ -9,7 +9,7 @@ export default class App extends React.Component {
           VictoryLabel demo! The little circles show the anchor points for
           each label.
         </p>
-        <svg width="600" height="2000" style={{ border: "1px solid #ccc", padding: 40 }}>
+        <svg width="600" height="2500" style={{ border: "1px solid #ccc", padding: 40 }}>
 
           <circle cx="0" cy="0" r="2" fill="red"/>
           <VictoryLabel
@@ -43,12 +43,12 @@ export default class App extends React.Component {
             ]}
             text={"Victory is awesome.\nThis is (end, start) anchoring.\nOK?"}
           />
+
           <circle cx="300" cy="300" r="2" fill="blue"/>
           <VictoryLabel x={300} y={300} textAnchor="middle" verticalAnchor="start"
             style={{ padding: 15 }}
             text={"Victory is awesome.\nThis is (middle, start) anchoring.\nGot it?"}
           />
-
 
           <circle cx="300" cy="450" r="2" fill="red"/>
           <VictoryLabel x={300} y={450} textAnchor="start" verticalAnchor="start"
@@ -95,14 +95,24 @@ export default class App extends React.Component {
 
           <circle cx="300" cy="1650" r="2" fill="red"/>
           <VictoryLabel x={300} y={1650} textAnchor="start" verticalAnchor="middle"
-            text={[ '% of target', '44% for 2017' ]}
+            text={[ 'We still get', 'varying label styles!' ]}
             style={[{ fill: '#000' }, { fill: '#6128ff', fontSize: 20 }]} inline dx={25}
           />
 
-          <circle cx="300" cy="1800" r="2" fill="red"/>
-          <VictoryLabel x={300} y={1800} textAnchor="start" verticalAnchor="start"
-            text={["shift", "subsequent", "labels", "by", "5"]} inline dx={"5"}
+          <circle cx="0" cy="1800" r="2" fill="red"/>
+          <VictoryLabel x={0} y={1800} textAnchor="start" verticalAnchor="start"
+            text={["Use", "dx", "attribute", "to", "shift", "labels", "relative to one another."]} inline dx={"10"}
           />
+
+          <circle cx="0" cy="2000" r="2" fill="red"/>
+          <VictoryLabel
+            x={0} y={2000}
+            text={["Victory is awesome.", "We can even specify", "a lineHeight array!", "Just like this!"]}
+            style={[{ fontSize: 50, fill: "green" }, { fontSize: 60 }, { fontSize: 30 }, { fontSize: 30 }]}
+            lineHeight={[1.22, 2, 3, 1]}
+            verticalAnchor="start"
+          />
+
         </svg>
       </div>
     );

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -281,7 +281,7 @@ export default class VictoryLabel extends React.Component {
           const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
           const lineHeight = this.checkLineHeight(
             this.lineHeight,
-            (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2),
+            ((this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0])) / 2),
             1
           );
           const textAnchor = style.textAnchor || this.textAnchor;

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -7,7 +7,7 @@ import Helpers from "../victory-util/helpers";
 import LabelHelpers from "../victory-util/label-helpers";
 import Style from "../victory-util/style";
 import Log from "../victory-util/log";
-import { assign, merge } from "lodash";
+import { assign, merge, isEmpty } from "lodash";
 
 const defaultStyles = {
   fill: "#252525",
@@ -180,7 +180,7 @@ export default class VictoryLabel extends React.Component {
   }
 
   getStyles(props) {
-    return Array.isArray(props.style) ?
+    return Array.isArray(props.style) && !isEmpty(props.style) ?
       props.style.map((style) => this.getStyle(props, style)) : [this.getStyle(props, props.style)];
   }
 
@@ -203,7 +203,12 @@ export default class VictoryLabel extends React.Component {
 
   getDy(props, style, content, lineHeight) { //eslint-disable-line max-params
     style = Array.isArray(style) ? style[0] : style;
-    lineHeight = Array.isArray(lineHeight) ? lineHeight[0] : lineHeight;
+    lineHeight = this.checkLineHeight(lineHeight, lineHeight[0], 1);
+    // lineHeight = Array.isArray(lineHeight)
+    //   ? isEmpty(lineHeight)
+    //     ? 1
+    //     : lineHeight[0]
+    //   : lineHeight;
     const fontSize = style.fontSize;
     const datum = props.datum || props.data;
     const dy = props.dy ? Helpers.evaluateProp(props.dy, datum) : 0;
@@ -220,6 +225,18 @@ export default class VictoryLabel extends React.Component {
     default:
       return dy + (capHeight / 2 + lineHeight / 2) * fontSize;
     }
+  }
+
+  checkLineHeight(lineHeight, val, fallbackVal) {
+    if (Array.isArray(lineHeight)) {
+      if (isEmpty(lineHeight)) {
+        return fallbackVal;
+      }
+
+      return val;
+    }
+
+    return lineHeight;
   }
 
   getTransform(props, style) {
@@ -267,9 +284,12 @@ export default class VictoryLabel extends React.Component {
           const style = this.style[i] || this.style[0];
           const lastStyle = this.style[i - 1] || this.style[0];
           const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
-          const lineHeight = Array.isArray(this.lineHeight)
-            ? (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2)
-            : this.lineHeight;
+          // const lineHeight = Array.isArray(this.lineHeight)
+          //   ? isEmpty(this.lineHeight)
+          //     ? 1
+          //     : (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2)
+          // : this.lineHeight;
+          const lineHeight = this.checkLineHeight(this.lineHeight, (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2), 1)
           const textAnchor = style.textAnchor || this.textAnchor;
           const dy = i && !props.inline ? (lineHeight * fontSize) : undefined;
           const x = !props.inline ? props.x : undefined;

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -51,7 +51,8 @@ export default class VictoryLabel extends React.Component {
     lineHeight: PropTypes.oneOfType([
       PropTypes.string,
       CustomPropTypes.nonNegative,
-      PropTypes.func
+      PropTypes.func,
+      PropTypes.array
     ]),
     origin: PropTypes.shape({ x: CustomPropTypes.nonNegative, y: CustomPropTypes.nonNegative }),
     polar: PropTypes.bool,
@@ -202,6 +203,7 @@ export default class VictoryLabel extends React.Component {
 
   getDy(props, style, content, lineHeight) { //eslint-disable-line max-params
     style = Array.isArray(style) ? style[0] : style;
+    lineHeight = Array.isArray(lineHeight) ? lineHeight[0] : lineHeight;
     const fontSize = style.fontSize;
     const datum = props.datum || props.data;
     const dy = props.dy ? Helpers.evaluateProp(props.dy, datum) : 0;
@@ -265,8 +267,11 @@ export default class VictoryLabel extends React.Component {
           const style = this.style[i] || this.style[0];
           const lastStyle = this.style[i - 1] || this.style[0];
           const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
+          const lineHeight = Array.isArray(this.lineHeight)
+            ? (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2)
+            : this.lineHeight;
           const textAnchor = style.textAnchor || this.textAnchor;
-          const dy = i && !props.inline ? (this.lineHeight * fontSize) : undefined;
+          const dy = i && !props.inline ? (lineHeight * fontSize) : undefined;
           const x = !props.inline ? props.x : undefined;
           return (
             <tspan key={i} x={x} dy={dy} dx={this.dx} style={style} textAnchor={textAnchor}>

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -204,11 +204,6 @@ export default class VictoryLabel extends React.Component {
   getDy(props, style, content, lineHeight) { //eslint-disable-line max-params
     style = Array.isArray(style) ? style[0] : style;
     lineHeight = this.checkLineHeight(lineHeight, lineHeight[0], 1);
-    // lineHeight = Array.isArray(lineHeight)
-    //   ? isEmpty(lineHeight)
-    //     ? 1
-    //     : lineHeight[0]
-    //   : lineHeight;
     const fontSize = style.fontSize;
     const datum = props.datum || props.data;
     const dy = props.dy ? Helpers.evaluateProp(props.dy, datum) : 0;
@@ -284,12 +279,11 @@ export default class VictoryLabel extends React.Component {
           const style = this.style[i] || this.style[0];
           const lastStyle = this.style[i - 1] || this.style[0];
           const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
-          // const lineHeight = Array.isArray(this.lineHeight)
-          //   ? isEmpty(this.lineHeight)
-          //     ? 1
-          //     : (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2)
-          // : this.lineHeight;
-          const lineHeight = this.checkLineHeight(this.lineHeight, (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2), 1)
+          const lineHeight = this.checkLineHeight(
+            this.lineHeight,
+            (this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0]) / 2),
+            1
+          );
           const textAnchor = style.textAnchor || this.textAnchor;
           const dy = i && !props.inline ? (lineHeight * fontSize) : undefined;
           const x = !props.inline ? props.x : undefined;

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -46,6 +46,7 @@ export default class VictoryLabel extends React.Component {
     ]),
     events: PropTypes.object,
     index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    inline: PropTypes.bool,
     labelPlacement: PropTypes.oneOf(["parallel", "perpendicular", "vertical"]),
     lineHeight: PropTypes.oneOfType([
       PropTypes.string,
@@ -265,9 +266,10 @@ export default class VictoryLabel extends React.Component {
           const lastStyle = this.style[i - 1] || this.style[0];
           const fontSize = (style.fontSize + lastStyle.fontSize) / 2;
           const textAnchor = style.textAnchor || this.textAnchor;
-          const dy = i ? (this.lineHeight * fontSize) : undefined;
+          const dy = i && !props.inline ? (this.lineHeight * fontSize) : undefined;
+          const x = !props.inline ? props.x : undefined;
           return (
-            <tspan key={i} x={props.x} dy={dy} dx={this.dx} style={style} textAnchor={textAnchor}>
+            <tspan key={i} x={x} dy={dy} dx={this.dx} style={style} textAnchor={textAnchor}>
               {line}
             </tspan>
           );

--- a/test/client/spec/victory-label/victory-label.spec.js
+++ b/test/client/spec/victory-label/victory-label.spec.js
@@ -120,4 +120,79 @@ describe("components/victory-label", () => {
       expect(clickHandler.called).to.equal(true);
     });
   });
+
+  it("renders <tspan /> elements inline when `inline` prop is passed", () => {
+    const wrapper = shallow(
+      <VictoryLabel
+        text={["Inline", "label", "testing"]}
+        inline
+        dx={5}
+      />
+    );
+
+    const output = wrapper.find("tspan");
+    output.forEach((tspan) => {
+      // passing `inline` sets x and dy to undefined
+      expect(tspan.prop("x")).to.be.eql(undefined);
+      expect(tspan.prop("dy")).to.be.eql(undefined);
+      expect(tspan.prop("dx")).to.be.eql(5);
+    });
+  });
+
+  it("passes lineHeight as an array if provided", () => {
+    const lineHeight = [1, 2, 3];
+    const expectedDy = [undefined, 21, 35];
+    const wrapper = shallow(
+      <VictoryLabel
+        text={["lineHeight", "array", "testing"]}
+        // eslint-disable-next-line no-magic-numbers
+        lineHeight={lineHeight}
+      />
+    );
+
+    const output = wrapper.find("tspan");
+    output.forEach((tspan, index) => {
+      /*
+      to calculate dy:
+      ((this.lineHeight[i] + (this.lineHeight[i - 1] || this.lineHeight[0])) / 2)
+      */
+      expect(tspan.prop("dy")).to.be.eql(expectedDy[index]);
+    });
+  });
+
+  it("defaults lineHeight to 1 if an empty array is provided for lineHeight", () => {
+    const expectedDy = [undefined, 14, 14, 14];
+    const wrapper = shallow(
+      <VictoryLabel
+        text={["lineHeight", "empty", "array", "testing"]}
+        lineHeight={[]}
+      />
+    );
+
+    const output = wrapper.find("tspan");
+    output.forEach((tspan, index) => {
+      expect(tspan.prop("dy")).to.be.eql(expectedDy[index]);
+    });
+  });
+
+  it("defaults style to `defaultStyles` if an empty array is provided for `style`", () => {
+    const defaultStyles = {
+      fill: "#252525",
+      fontSize: 14,
+      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+      stroke: "transparent"
+    };
+
+    const wrapper = shallow(
+      <VictoryLabel
+        text={["style", "empty", "array", "testing"]}
+        style={[]}
+      />
+    );
+
+    const output = wrapper.find("tspan");
+    output.forEach((tspan) => {
+      expect(tspan.prop("style")).to.be.eql(defaultStyles);
+    });
+  });
 });


### PR DESCRIPTION
This PR accomplishes three tasks, related to issues #893, #902, and #904.

## Issue #893: Allow VictoryLabel to render multiple text inline

The first portion of this PR adds support for a `boolean inline` prop, which specifies that labels passed as an array in `VictoryLabel`'s `text` `prop` should be rendered inline. To do this, we simply return undefined for the `x` and `dy` attributes if `inline` is `true`. This allows the `dx` `prop` to specify the relative spacing of inlined `<tspan />` elements. For example, this code:


```
import React from "react";
import { VictoryLabel } from "../src/index";
import data from "../src/victory-util/data";

export default class App extends React.Component {
  render() {

    const example = ["hello", "Formidable", "Labs"];

    return (
      <div className="demo">
        <p>
          VictoryLabel demo! The little circles show the anchor points for
          each label.
        </p>
        <svg width="600" height="1800" style={{ border: "1px solid #ccc", padding: 40 }}>

          <circle cx="300" cy="0" r="2" fill="red"/>
          <VictoryLabel x={300} y={0} textAnchor="end" verticalAnchor="middle"
            text={"Victory is awesome.\nThis is inline styling for <tspan>. Woohoo!"} inline
          />

          <circle cx="300" cy="150" r="2" fill="red"/>
          <VictoryLabel x={300} y={150} textAnchor="start" verticalAnchor="middle"
            text={[ '% of target', '44% for 2017' ]}
            style={[{ fill: '#000' }, { fill: '#6128ff' }]} inline dx={25}
          />

          <circle cx="300" cy="300" r="2" fill="red"/>
          <VictoryLabel x={300} y={300} textAnchor="start" verticalAnchor="start"
            text={example} inline dx={"10"}
          />
        </svg>
      </div>
    );
  }
}
``` 

will render: 
![screen shot 2018-01-16 at 10 56 14 am](https://user-images.githubusercontent.com/19421190/35006651-fa78c000-faab-11e7-9a2b-3265268dfd23.png)

We could also consider doing some more explicit styling for inlined labels – this solution just takes advantage of `svg`'s default inline display for `<tspan />`s inside of `<text />`.

## Issue #902: For a multiline VictoryLabel, I would like to have different lineHeights per line.

The second portion of this PR adds support for passing a `number[]` or `string[]` as a valid `lineHeight prop`. To do this, we check if `lineHeight` is passed as an array and, if so, average the `lineHeight` of the current and previous index (similar to how we average `fontSize`) in order to calculate the proper `dy` attribute for each `<tspan />`. For example, the following code:

```
<circle cx="0" cy="2000" r="2" fill="red"/>
<VictoryLabel
         x={0} y={2000}
         text={["Victory is awesome.", "We can even specify", "a lineHeight array!", "Just like this!"]}
         style={[{ fontSize: 50, fill: "green" }, { fontSize: 60 }, { fontSize: 30 }, { fontSize: 30 }]}
         lineHeight={[1.22, 2, 3, 1]}
        verticalAnchor="start"
/>
```

will render:
![screen shot 2018-01-16 at 4 37 35 pm](https://user-images.githubusercontent.com/19421190/35019428-b325e3ba-fadb-11e7-9c9f-2a2cc61a3f90.png)

We may want to revisit how this interacts with `verticalTextAnchor` – we use the first `lineHeight`, similar to how we use the first `fontSize`, to determine the `dy` attribute of the `<text />` container itself.

## Issue #904 Empty arrays for VictoryLabel's style prop cause an error
There are now checks for a user passing empty arrays into both the `style` and `lineHeight` props. If an empty array gets passed into `style`, we default to `defaultStyles`. If an empty array gets passed into `lineHeight`, we default to using 1 as the `lineHeight`.


