### PR TITLE
Update add-events.js

### DIFF
--- a/src/victory-util/add-events.js
+++ b/src/victory-util/add-events.js
@@ -152,7 +152,7 @@ export default (WrappedComponent, options) => {
     getComponentProps(component, type, index) {
       const { role } = WrappedComponent;
       const key = this.dataKeys && this.dataKeys[index] || index;
-      const baseProps = this.baseProps[key][type] || this.baseProps[key];
+      const baseProps = this.baseProps[key] && this.baseProps[key][type] || this.baseProps[key];
       if (!baseProps && !this.hasEvents) {
         return undefined;
       }


### PR DESCRIPTION
Cross X-Axis breaks when scrolling (zooming) out of view (e.g. below min y domain) when using createContainer() to create a combined veronoi/zoom container. Enhanced null checking per proposed change fixes.