### PR TITLE
Support for a wickStrokeWidth style prop

### DIFF
--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -10,18 +10,18 @@ export default class Candle extends React.Component {
   static propTypes = {
     ...CommonProps,
     candleHeight: PropTypes.number,
-    wickStrokeWidth: PropTypes.number,
     datum: PropTypes.object,
     groupComponent: PropTypes.element,
     padding: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.object
     ]),
+    wickStrokeWidth: PropTypes.number,
     width: PropTypes.number,
     x: PropTypes.number,
     y: PropTypes.number,
-    y1: PropTypes.number,
-    y2: PropTypes.number
+    high: PropTypes.number,
+    low: PropTypes.number
   }
 
   static defaultProps = {
@@ -35,7 +35,7 @@ export default class Candle extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const { className, candleHeight, datum, x, y, y1, y2 } = this.props;
+    const { className, candleHeight, datum, x, y, high, low } = this.props;
     const { style, candleWidth } = this.calculateAttributes(nextProps);
 
     if (!Collection.allSetsEqual([
@@ -43,8 +43,8 @@ export default class Candle extends React.Component {
       [candleHeight, nextProps.candleHeight],
       [x, nextProps.x],
       [y, nextProps.y],
-      [y1, nextProps.y1],
-      [y2, nextProps.y2],
+      [high, nextProps.high],
+      [low, nextProps.low],
       [candleWidth, this.candleWidth],
       [style, this.style],
       [datum, nextProps.datum]
@@ -85,13 +85,13 @@ export default class Candle extends React.Component {
   }
 
   getWickProps(props, wickType) {
-    const { x, y1, y2, highWick, lowWick, wickStrokeWidth, events, className } = props;
+    const { x, high, low, highWick, lowWick, wickStrokeWidth, events, className } = props;
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
     const wickStyle = assign(
       {}, this.style, { strokeWidth: wickStrokeWidth || props.style.strokeWidth });
     return assign({
-      x1: x, x2: x, y1: wickType === "low" ? lowWick : y1, y2: wickType === "high" ? highWick : y2,
+      x1: x, x2: x, y1: wickType === "low" ? lowWick : high, y2: wickType === "high" ? highWick : low,
       style: wickStyle, role, shapeRendering, className
     }, events);
   }

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -12,6 +12,8 @@ export default class Candle extends React.Component {
     candleHeight: PropTypes.number,
     datum: PropTypes.object,
     groupComponent: PropTypes.element,
+    high: PropTypes.number,
+    low: PropTypes.number,
     padding: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.object
@@ -19,9 +21,7 @@ export default class Candle extends React.Component {
     wickStrokeWidth: PropTypes.number,
     width: PropTypes.number,
     x: PropTypes.number,
-    y: PropTypes.number,
-    high: PropTypes.number,
-    low: PropTypes.number
+    y: PropTypes.number
   }
 
   static defaultProps = {
@@ -79,8 +79,14 @@ export default class Candle extends React.Component {
     const shapeRendering = props.shapeRendering || "auto";
     const candleX = x - this.candleWidth / 2;
     return assign({
-      x: candleX, y, style: this.style, role, width: this.candleWidth, height: candleHeight,
-      shapeRendering, className
+      x: candleX,
+      y,
+      style: this.style,
+      role,
+      width: this.candleWidth,
+      height: candleHeight,
+      shapeRendering,
+      className
     }, events);
   }
 
@@ -91,8 +97,14 @@ export default class Candle extends React.Component {
     const wickStyle = assign(
       {}, this.style, { strokeWidth: wickStrokeWidth || props.style.strokeWidth });
     return assign({
-      x1: x, x2: x, y1: wickType === "low" ? lowWick : high, y2: wickType === "high" ? highWick : low,
-      style: wickStyle, role, shapeRendering, className
+      x1: x,
+      x2: x,
+      y1: wickType === "low" ? lowWick : high,
+      y2: wickType === "high" ? highWick : low,
+      style: wickStyle,
+      role,
+      shapeRendering,
+      className
     }, events);
   }
 

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -87,8 +87,9 @@ export default class Candle extends React.Component {
     const { x, y1, y2, events, className } = props;
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
+    const wickStyle = assign({}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
     return assign(
-      { x1: x, x2: x, y1, y2, style: this.style, role, shapeRendering, className },
+      { x1: x, x2: x, y1, y2, style: wickStyle, role, shapeRendering, className },
       events
     );
   }

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -89,16 +89,22 @@ export default class Candle extends React.Component {
     const role = props.role || "presentation";
     const wickStyle = assign(
       {}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
-    return assign(
-      { x1: x, x2: x, y1: wickType === "low" ? lowWick : y1, y2: wickType === "high" ? highWick : y2, style: wickStyle, role, shapeRendering, className },
-      events
-    );
+    return assign({ 
+      x1: x, x2: x, y1: wickType === "low" ? lowWick : y1, y2: wickType === "high" ? highWick : y2, 
+      style: wickStyle, role, shapeRendering, className 
+    }, events);
   }
 
   render() {
     const candleProps = this.getCandleProps(this.props);
     const highWickProps = this.getWickProps(this.props, "high");
     const lowWickProps = this.getWickProps(this.props, "low");
-    return React.cloneElement(this.props.groupComponent, {}, this.renderWick(highWickProps), this.renderWick(lowWickProps), this.renderCandle(candleProps));
+    return React.cloneElement(
+      this.props.groupComponent, 
+      {}, 
+      this.renderWick(highWickProps), 
+      this.renderWick(lowWickProps), 
+      this.renderCandle(candleProps)
+  );
   }
 }

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Helpers from "../victory-util/helpers";
 import Collection from "../victory-util/collection";
-import { assign } from "lodash";
+import { assign, defaults } from "lodash";
 import CommonProps from "./common-props";
 
 export default class Candle extends React.Component {
@@ -36,16 +36,17 @@ export default class Candle extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const { className, candleHeight, datum, x, y, high, low } = this.props;
+    const { className, candleHeight, datum, x, high, low, open, close } = this.props;
     const { style, candleWidth } = this.calculateAttributes(nextProps);
 
     if (!Collection.allSetsEqual([
       [className, nextProps.className],
       [candleHeight, nextProps.candleHeight],
       [x, nextProps.x],
-      [y, nextProps.y],
       [high, nextProps.high],
       [low, nextProps.low],
+      [open, nextProps.open],
+      [close, nextProps.close],
       [candleWidth, this.candleWidth],
       [style, this.style],
       [datum, nextProps.datum]
@@ -97,8 +98,7 @@ export default class Candle extends React.Component {
     const role = props.role || "presentation";
     const lowWick = Math.min(close, open);
     const highWick = Math.max(close, open);
-    const wickStyle = assign(
-      {}, this.style, { strokeWidth: wickStrokeWidth || this.style.strokeWidth });
+    const wickStyle = defaults({}, this.style, { strokeWidth: wickStrokeWidth });
     return assign({
       x1: x,
       x2: x,

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -65,7 +65,6 @@ export default class Candle extends React.Component {
 
   // Overridden in victory-core-native
   renderWick(wickProps) {
-    console.log(wickProps);
     return <line {...wickProps}/>;
   }
 
@@ -89,7 +88,6 @@ export default class Candle extends React.Component {
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
     const wickStyle = assign({}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
-  
     return assign(
       { x1: x, x2: x, y1: wickType === 'low' ? lowWick : y1, y2: wickType === 'high' ? highWick : y2, style: wickStyle, role, shapeRendering, className },
       events

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -65,6 +65,7 @@ export default class Candle extends React.Component {
 
   // Overridden in victory-core-native
   renderWick(wickProps) {
+    console.log(wickProps);
     return <line {...wickProps}/>;
   }
 
@@ -83,22 +84,27 @@ export default class Candle extends React.Component {
     }, events);
   }
 
-  getWickProps(props) {
-    const { x, y1, y2, events, className } = props;
+  getWickProps(props, wickType) {
+    const { x, y1, y2, highWick, lowWick, events, className } = props;
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
     const wickStyle = assign({}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
+  
     return assign(
-      { x1: x, x2: x, y1, y2, style: wickStyle, role, shapeRendering, className },
+      { x1: x, x2: x, y1: wickType === 'low' ? lowWick : y1, y2: wickType === 'high' ? highWick : y2, style: wickStyle, role, shapeRendering, className },
       events
     );
   }
 
   render() {
     const candleProps = this.getCandleProps(this.props);
-    const wickProps = this.getWickProps(this.props);
+    const highWickProps = this.getWickProps(this.props, 'high');
+    const lowWickProps = this.getWickProps(this.props, 'low');
     return React.cloneElement(
-      this.props.groupComponent, {}, this.renderWick(wickProps), this.renderCandle(candleProps)
+      this.props.groupComponent, {}, 
+      this.renderWick(highWickProps), 
+      this.renderWick(lowWickProps), 
+      this.renderCandle(candleProps)
     );
   }
 }

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -98,7 +98,7 @@ export default class Candle extends React.Component {
     const role = props.role || "presentation";
     const lowWick = Math.min(close, open);
     const highWick = Math.max(close, open);
-    const wickStyle = defaults({}, this.style, { strokeWidth: wickStrokeWidth });
+    const wickStyle = defaults({ strokeWidth: wickStrokeWidth }, this.style);
     return assign({
       x1: x,
       x2: x,

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -10,6 +10,7 @@ export default class Candle extends React.Component {
   static propTypes = {
     ...CommonProps,
     candleHeight: PropTypes.number,
+    wickStrokeWidth: PropTypes.number,
     datum: PropTypes.object,
     groupComponent: PropTypes.element,
     padding: PropTypes.oneOfType([
@@ -84,11 +85,11 @@ export default class Candle extends React.Component {
   }
 
   getWickProps(props, wickType) {
-    const { x, y1, y2, highWick, lowWick, events, className } = props;
+    const { x, y1, y2, highWick, lowWick, wickStrokeWidth, events, className } = props;
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
     const wickStyle = assign(
-      {}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
+      {}, this.style, { strokeWidth: wickStrokeWidth || props.style.strokeWidth });
     return assign({
       x1: x, x2: x, y1: wickType === "low" ? lowWick : y1, y2: wickType === "high" ? highWick : y2,
       style: wickStyle, role, shapeRendering, className

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -87,22 +87,18 @@ export default class Candle extends React.Component {
     const { x, y1, y2, highWick, lowWick, events, className } = props;
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
-    const wickStyle = assign({}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
+    const wickStyle = assign(
+      {}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
     return assign(
-      { x1: x, x2: x, y1: wickType === 'low' ? lowWick : y1, y2: wickType === 'high' ? highWick : y2, style: wickStyle, role, shapeRendering, className },
+      { x1: x, x2: x, y1: wickType === "low" ? lowWick : y1, y2: wickType === "high" ? highWick : y2, style: wickStyle, role, shapeRendering, className },
       events
     );
   }
 
   render() {
     const candleProps = this.getCandleProps(this.props);
-    const highWickProps = this.getWickProps(this.props, 'high');
-    const lowWickProps = this.getWickProps(this.props, 'low');
-    return React.cloneElement(
-      this.props.groupComponent, {}, 
-      this.renderWick(highWickProps), 
-      this.renderWick(lowWickProps), 
-      this.renderCandle(candleProps)
-    );
+    const highWickProps = this.getWickProps(this.props, "high");
+    const lowWickProps = this.getWickProps(this.props, "low");
+    return React.cloneElement(this.props.groupComponent, {}, this.renderWick(highWickProps), this.renderWick(lowWickProps), this.renderCandle(candleProps));
   }
 }

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -10,18 +10,19 @@ export default class Candle extends React.Component {
   static propTypes = {
     ...CommonProps,
     candleHeight: PropTypes.number,
+    close: PropTypes.number,
     datum: PropTypes.object,
     groupComponent: PropTypes.element,
     high: PropTypes.number,
     low: PropTypes.number,
+    open: PropTypes.number,
     padding: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.object
     ]),
     wickStrokeWidth: PropTypes.number,
     width: PropTypes.number,
-    x: PropTypes.number,
-    y: PropTypes.number
+    x: PropTypes.number
   }
 
   static defaultProps = {
@@ -75,12 +76,12 @@ export default class Candle extends React.Component {
   }
 
   getCandleProps(props) {
-    const { candleHeight, x, y, events, role, className } = props;
+    const { candleHeight, x, open, close, events, role, className } = props;
     const shapeRendering = props.shapeRendering || "auto";
     const candleX = x - this.candleWidth / 2;
     return assign({
       x: candleX,
-      y,
+      y: Math.min(open, close),
       style: this.style,
       role,
       width: this.candleWidth,
@@ -91,16 +92,18 @@ export default class Candle extends React.Component {
   }
 
   getWickProps(props, wickType) {
-    const { x, high, low, highWick, lowWick, wickStrokeWidth, events, className } = props;
+    const { x, high, low, open, close, wickStrokeWidth, events, className } = props;
     const shapeRendering = props.shapeRendering || "auto";
     const role = props.role || "presentation";
+    const lowWick = Math.min(close, open);
+    const highWick = Math.max(close, open);
     const wickStyle = assign(
-      {}, this.style, { strokeWidth: wickStrokeWidth || props.style.strokeWidth });
+      {}, this.style, { strokeWidth: wickStrokeWidth || this.style.strokeWidth });
     return assign({
       x1: x,
       x2: x,
-      y1: wickType === "low" ? lowWick : high,
-      y2: wickType === "high" ? highWick : low,
+      y1: wickType === "low" ? lowWick : highWick,
+      y2: wickType === "high" ? low : high,
       style: wickStyle,
       role,
       shapeRendering,
@@ -118,6 +121,6 @@ export default class Candle extends React.Component {
       this.renderWick(highWickProps),
       this.renderWick(lowWickProps),
       this.renderCandle(candleProps)
-  );
+    );
   }
 }

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -89,9 +89,9 @@ export default class Candle extends React.Component {
     const role = props.role || "presentation";
     const wickStyle = assign(
       {}, this.style, { strokeWidth: props.style.wickStrokeWidth || props.style.strokeWidth });
-    return assign({ 
-      x1: x, x2: x, y1: wickType === "low" ? lowWick : y1, y2: wickType === "high" ? highWick : y2, 
-      style: wickStyle, role, shapeRendering, className 
+    return assign({
+      x1: x, x2: x, y1: wickType === "low" ? lowWick : y1, y2: wickType === "high" ? highWick : y2,
+      style: wickStyle, role, shapeRendering, className
     }, events);
   }
 
@@ -100,10 +100,10 @@ export default class Candle extends React.Component {
     const highWickProps = this.getWickProps(this.props, "high");
     const lowWickProps = this.getWickProps(this.props, "low");
     return React.cloneElement(
-      this.props.groupComponent, 
-      {}, 
-      this.renderWick(highWickProps), 
-      this.renderWick(lowWickProps), 
+      this.props.groupComponent,
+      {},
+      this.renderWick(highWickProps),
+      this.renderWick(lowWickProps),
       this.renderCandle(candleProps)
   );
   }

--- a/test/client/spec/victory-primitives/candle.spec.js
+++ b/test/client/spec/victory-primitives/candle.spec.js
@@ -20,8 +20,14 @@ describe("victory-primitives/candle", () => {
 
   it("should render a wick line", () => {
     const wrapper = shallow(<Candle {...baseProps}/>);
+    const wicks = wrapper.find("line");
 
-    expect(wrapper.find("line")).to.have.length(2);
+    wicks.forEach((wick) => {
+      expect(wick.prop("x1")).to.eql(5);
+      expect(wick.prop("x2")).to.eql(5);
+      // expect(wick.prop("y1")).to.eql(50 || 5);
+      // expect(wick.prop("y2")).to.eql(50 || 5);
+    });
   });
 
   it("should render a candle rectangle", () => {
@@ -34,6 +40,9 @@ describe("victory-primitives/candle", () => {
     expect(rect.prop("height")).to.eql(20);
     // x = x - width / 2
     expect(rect.prop("x")).to.eql(4);
+    expect(rect.prop("close")).to.eql(10);
+    // expect(rect.prop("open")).to.eql(10);
+    // expect(rect.prop("y")).to.eql(10);
   });
 
   it("should allow style to override width", () => {

--- a/test/client/spec/victory-primitives/candle.spec.js
+++ b/test/client/spec/victory-primitives/candle.spec.js
@@ -11,9 +11,8 @@ describe("victory-primitives/candle", () => {
     ],
     datum: { x: 1, open: 10, close: 30, high: 50, low: 5, eventKey: 0 },
     x: 5,
-    y: 30,
-    y1: 50,
-    y2: 5,
+    high: 50,
+    low: 5,
     candleHeight: 20,
     width: 10,
     padding: 1
@@ -21,12 +20,8 @@ describe("victory-primitives/candle", () => {
 
   it("should render a wick line", () => {
     const wrapper = shallow(<Candle {...baseProps}/>);
-    const wick = wrapper.find("line");
 
-    expect(wick.prop("x1")).to.eql(5);
-    expect(wick.prop("x2")).to.eql(5);
-    expect(wick.prop("y1")).to.eql(50);
-    expect(wick.prop("y2")).to.eql(5);
+    expect(wrapper.find("line")).to.have.length(2);
   });
 
   it("should render a candle rectangle", () => {
@@ -39,7 +34,6 @@ describe("victory-primitives/candle", () => {
     expect(rect.prop("height")).to.eql(20);
     // x = x - width / 2
     expect(rect.prop("x")).to.eql(4);
-    expect(rect.prop("y")).to.eql(30);
   });
 
   it("should allow style to override width", () => {
@@ -56,6 +50,5 @@ describe("victory-primitives/candle", () => {
     expect(rect.prop("height")).to.eql(20);
     // x = x - width / 2
     expect(rect.prop("x")).to.eql(2.5);
-    expect(rect.prop("y")).to.eql(30);
   });
 });

--- a/test/client/spec/victory-primitives/candle.spec.js
+++ b/test/client/spec/victory-primitives/candle.spec.js
@@ -13,6 +13,8 @@ describe("victory-primitives/candle", () => {
     x: 5,
     high: 50,
     low: 5,
+    close: 30,
+    open: 10,
     candleHeight: 20,
     width: 10,
     padding: 1
@@ -34,6 +36,7 @@ describe("victory-primitives/candle", () => {
     expect(rect.prop("height")).to.eql(20);
     // x = x - width / 2
     expect(rect.prop("x")).to.eql(4);
+    expect(rect.prop("y")).to.eql(10);
   });
 
   it("should allow style to override width", () => {
@@ -50,5 +53,6 @@ describe("victory-primitives/candle", () => {
     expect(rect.prop("height")).to.eql(20);
     // x = x - width / 2
     expect(rect.prop("x")).to.eql(2.5);
+    expect(rect.prop("y")).to.eql(10);
   });
 });


### PR DESCRIPTION
## Overview

Supply a `wickStrokeWidth` value to see a difference between the candle's stroke width and the wick's stroke width.

When supplied a `wickStrokeWidth` without a separate `strokeWidth` assignment, the candlestick will fallback to the `wickStrokeWidth` for the candle's `strokeWidth`.

This PR is prerequisite to [this PR in victory-chart](https://github.com/FormidableLabs/victory-chart/pull/554).

## Example

```
<VictoryCandlestick
  wickStrokeWidth={12}
  style={{ data: { 
    fill: "#c43a31", 
    fillOpacity: 0.7, 
    stroke: "#c43a31", 
    strokeWidth: 3 
  }, parent: style.parent }}
  data={data}
/>
```

renders this chart:

<img width="452" alt="screen shot 2018-01-25 at 1 17 56 pm" src="https://user-images.githubusercontent.com/30479228/35410292-304a40b4-01d2-11e8-9bd5-661b55ee57dc.png">

## Original Issue:
[Victory Issue #886](https://github.com/FormidableLabs/victory/issues/886)
