### PR TITLE
Update tooltips rendered in portal. Fix #793.

### DIFF
--- a/src/victory-portal/portal.js
+++ b/src/victory-portal/portal.js
@@ -33,6 +33,7 @@ export default class Portal extends React.Component {
 
   portalDeregister(key) {
     delete this.map[key];
+    this.forceUpdate();
   }
 
   getChildren() {


### PR DESCRIPTION
This PR should fix [issue #793 Tooltips in VoronoiContainer stay showing after leaving chart](https://github.com/FormidableLabs/victory/issues/793). Tooltips rendered in a portal were not being removed because `render` was never being called on the `<Portal />` component after the portal was "deregistered." Calling `this.forceUpdate` after unregistering the portal forces a re-render, which returns an empty object for the `children` that should be rendered in the portal and removes the tooltip. For example:

![formidable-victory-portal-tooltip](https://user-images.githubusercontent.com/19421190/35177418-1568bd18-fd34-11e7-911a-5e9d2939c1ca.gif)

Notice that the tooltips are being rendered in the `<Portal />`, but they are properly unmounting when the user leaves the bounding area.

Local tests for this code were performed using the `lank` workflow, i.e. changes were made to `victory-core` and tested using `victory-voronoi-container-demo.js` from a sibling local version of `victory-chart`. To get the tooltips to render in the portal, comment out [this line](https://github.com/FormidableLabs/victory-chart/blob/d61c97ab5e1c133120ae0c6c132679892d68e316/src/components/containers/victory-voronoi-container.js#L198) from `victory-voronoi-container.js` in your local install of `victory-chart`.