### PR TITLE
Whitelist for SVG style attributes on data objects

### DIFF
--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,7 +1,7 @@
 import React from "react";
-import { defaults, isFunction, property, omit, reduce, pick } from "lodash";
+import { defaults, isFunction, property, omit, reduce } from "lodash";
 import Collection from "./collection";
-import styleHelpers from "./style";
+import { sanitizeStyleProps } from "./style";
 
 export default {
   getPoint(datum) {
@@ -55,9 +55,8 @@ export default {
     if (!style) {
       return defaults({ parent: { height, width } }, defaultStyles);
     }
-
     const { data, labels, parent } = style;
-    const cleanData = this.sanitizeStyleProps(data);
+    const cleanData = sanitizeStyleProps(data);
     const defaultParent = defaultStyles && defaultStyles.parent || {};
     const defaultLabels = defaultStyles && defaultStyles.labels || {};
     const defaultData = defaultStyles && defaultStyles.data || {};
@@ -66,10 +65,6 @@ export default {
       labels: defaults({}, labels, defaultLabels),
       data: defaults({}, cleanData, defaultData)
     };
-  },
-
-  sanitizeStyleProps(data) {
-    return pick(data, styleHelpers.styleWhitelist);
   },
 
   evaluateProp(prop, data, active) {

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { defaults, isFunction, property, omit, reduce } from "lodash";
 import Collection from "./collection";
-import { sanitizeStyleProps } from "./style";
+import Style from "./style";
 
 export default {
   getPoint(datum) {
@@ -56,7 +56,7 @@ export default {
       return defaults({ parent: { height, width } }, defaultStyles);
     }
     const { data, labels, parent } = style;
-    const cleanData = sanitizeStyleProps(data);
+    const cleanData = Style.sanitizeStyleProps(data);
     const defaultParent = defaultStyles && defaultStyles.parent || {};
     const defaultLabels = defaultStyles && defaultStyles.labels || {};
     const defaultData = defaultStyles && defaultStyles.data || {};

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { defaults, isFunction, property, omit, reduce } from "lodash";
+import { defaults, isFunction, property, omit, reduce, pick } from "lodash";
 import Collection from "./collection";
+import styleHelpers from "./style";
 
 export default {
   getPoint(datum) {
@@ -56,14 +57,19 @@ export default {
     }
 
     const { data, labels, parent } = style;
+    const cleanData = this.sanitizeStyleProps(data);
     const defaultParent = defaultStyles && defaultStyles.parent || {};
     const defaultLabels = defaultStyles && defaultStyles.labels || {};
     const defaultData = defaultStyles && defaultStyles.data || {};
     return {
       parent: defaults({}, parent, defaultParent, { width, height }),
       labels: defaults({}, labels, defaultLabels),
-      data: defaults({}, data, defaultData)
+      data: defaults({}, cleanData, defaultData)
     };
+  },
+
+  sanitizeStyleProps(data) {
+    return pick(data, styleHelpers.styleWhitelist);
   },
 
   evaluateProp(prop, data, active) {

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -21,7 +21,7 @@ const styleWhitelist = [
  * @param {Object} data An object of user-input style attributes.
  * @returns {Object} An object containing only valid style data.
  */
-export const sanitizeStyleProps = function (data) {
+const sanitizeStyleProps = function (data) {
   return pick(data, styleWhitelist);
 };
 

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -1,3 +1,5 @@
+import { pick } from "lodash";
+
 /**
  * Acceptable CSS/SVG style attributes
  * https://react-cn.github.io/react/docs/tags-and-attributes.html#svg-attributes
@@ -12,6 +14,16 @@ const styleWhitelist = [
   "xlinkArcrole", "xlinkHref", "xlinkRole", "xlinkShow", "xlinkTitle", "xlinkType", "xmlBase",
   "xmlLang", "xmlSpace", "y1", "y2", "y"
 ];
+
+/**
+ * Given an object with CSS/SVG style attributes, return a new object containing
+ * only keys that are also on our SVG style whitelist.
+ * @param {Object} data An object of user-input style attributes.
+ * @returns {Object} An object containing only valid style data.
+ */
+export const sanitizeStyleProps = function (data) {
+  return pick(data, styleWhitelist);
+};
 
 /**
  * Given an object with CSS/SVG transform definitions, return the string value
@@ -44,8 +56,8 @@ const toTransformString = function (obj, ...more) {
 
 export default {
 
+  sanitizeStyleProps,
   toTransformString,
-  styleWhitelist,
 
   /**
    * Given the name of a color scale, getColorScale will return an array

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -1,4 +1,19 @@
 /**
+ * Acceptable CSS/SVG style attributes
+ * https://react-cn.github.io/react/docs/tags-and-attributes.html#svg-attributes
+ */
+const styleWhitelist = [
+  "angle", "clipPath", "cx", "cy", "d", "dx", "dy", "fill", "fillOpacity", "fontFamily",
+  "fontSize", "fx", "fy", "gradientTransform", "gradientUnits", "height", "markerEnd",
+  "markerMid", "markerStart", "offset", "opacity", "patternContentUnits", "patternUnits",
+  "points", "preserveAspectRatio", "r", "rx", "ry", "spreadMethod", "stopColor", "stopOpacity",
+  "stroke", "strokeDasharray", "strokeLinecap", "strokeOpacity", "strokeWidth", "textAnchor",
+  "transform", "version", "verticalAnchor", "viewBox", "width", "x1", "x2", "x", "xlinkActuate",
+  "xlinkArcrole", "xlinkHref", "xlinkRole", "xlinkShow", "xlinkTitle", "xlinkType", "xmlBase",
+  "xmlLang", "xmlSpace", "y1", "y2", "y"
+];
+
+/**
  * Given an object with CSS/SVG transform definitions, return the string value
  * for use with the `transform` CSS property or SVG attribute. Note that we
  * can't always guarantee the order will match the author's intended order, so

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -45,6 +45,7 @@ const toTransformString = function (obj, ...more) {
 export default {
 
   toTransformString,
+  styleWhitelist,
 
   /**
    * Given the name of a color scale, getColorScale will return an array

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -56,13 +56,6 @@ describe("helpers", () => {
     });
   });
 
-  describe("sanitizeStyleProps", () => {
-    it("drop invalid svg attributes", () => {
-      const data = { tree: "blue", stroke: "#c43a31" };
-      expect(Helpers.sanitizeStyleProps(data)).to.deep.equal({ stroke: "#c43a31" });
-    });
-  });
-
   describe("getPadding", () => {
     it("sets padding from a single number", () => {
       const props = { padding: 40 };

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -56,6 +56,13 @@ describe("helpers", () => {
     });
   });
 
+  describe("sanitizeStyleProps", () => {
+    it("drop invalid svg attributes", () => {
+      const data = { tree: "blue", stroke: "#c43a31" };
+      expect(Helpers.sanitizeStyleProps(data)).to.deep.equal({ stroke: "#c43a31" });
+    });
+  });
+
   describe("getPadding", () => {
     it("sets padding from a single number", () => {
       const props = { padding: 40 };

--- a/test/client/spec/victory-util/style.spec.js
+++ b/test/client/spec/victory-util/style.spec.js
@@ -1,5 +1,12 @@
 import { Style } from "src/index";
 
+describe("sanitizeStyleProps", () => {
+  it("drop invalid svg attributes", () => {
+    const data = { tree: "blue", stroke: "#c43a31" };
+    expect(Style.sanitizeStyleProps(data)).to.deep.equal({ stroke: "#c43a31" });
+  });
+});
+
 describe("toTransformString", () => {
   it("returns an empty string if no transform definitions are given", () => {
     expect(Style.toTransformString({})).to.equal("");


### PR DESCRIPTION
`sanitizeStyleProps` is running all user-input style data against a whitelist of valid SVG attributes and returning an object that contains only valid styles, dropping the rest.

Should resolve [Victory Issue #610](https://github.com/FormidableLabs/victory/issues/610)