### PR TITLE
WIP: Export helper methods as named exports

### DIFF
--- a/src/victory-clip-container/victory-clip-container.js
+++ b/src/victory-clip-container/victory-clip-container.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "../victory-util/prop-types";
-import Helpers from "../victory-util/helpers";
+import { getPadding, getRadius } from "../victory-util/helpers";
 import { assign, defaults, isFunction, isObject, uniqueId } from "lodash";
 import ClipPath from "../victory-primitives/clip-path";
 import Circle from "../victory-primitives/circle";
@@ -53,8 +53,8 @@ export default class VictoryClipContainer extends React.Component {
     const {
       polar, origin, clipWidth = 0, clipHeight = 0, translateX = 0, translateY = 0
     } = props;
-    const clipPadding = Helpers.getPadding({ padding: props.clipPadding });
-    const radius = props.radius || Helpers.getRadius(props);
+    const clipPadding = getPadding({ padding: props.clipPadding });
+    const radius = props.radius || getRadius(props);
     return {
       x: (polar ? origin.x : translateX) - clipPadding.left,
       y: (polar ? origin.y : translateY) - clipPadding.top,
@@ -88,10 +88,10 @@ export default class VictoryClipContainer extends React.Component {
       polar, origin, clipWidth = 0, clipHeight = 0, translateX = 0, translateY = 0,
       circleComponent, rectComponent, clipPathComponent
     } = props;
-    const { top, bottom, left, right } = Helpers.getPadding({ padding: props.clipPadding });
+    const { top, bottom, left, right } = getPadding({ padding: props.clipPadding });
     let child;
     if (polar) {
-      const radius = props.radius || Helpers.getRadius(props);
+      const radius = props.radius || getRadius(props);
       const circleProps = {
         r: Math.max((radius + left + right), (radius + top + bottom), 0),
         cx: origin.x - left,

--- a/src/victory-label/victory-label.js
+++ b/src/victory-label/victory-label.js
@@ -2,10 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import VictoryPortal from "../victory-portal/victory-portal";
 import CustomPropTypes from "../victory-util/prop-types";
-import Helpers from "../victory-util/helpers";
+import { scalePoint, evaluateStyle, evaluateProp } from "../victory-util/helpers";
 import LabelHelpers from "../victory-util/label-helpers";
 import Style from "../victory-util/style";
-import Log from "../victory-util/log";
+import { warn } from "../victory-util/log";
 import TSpan from "../victory-primitives/tspan";
 import Text from "../victory-primitives/text";
 import { assign, merge, isEmpty } from "lodash";
@@ -115,14 +115,14 @@ export default class VictoryLabel extends React.Component {
     if (!props.datum) {
       return 0;
     }
-    const scaledPoint = Helpers.scalePoint(props, props.datum);
+    const scaledPoint = scalePoint(props, props.datum);
     return scaledPoint[dimension];
   }
 
   getStyle(props, style) {
     style = style ? merge({}, defaultStyles, style) : defaultStyles;
     const datum = props.datum || props.data;
-    const baseStyles = Helpers.evaluateStyle(style, datum, props.active);
+    const baseStyles = evaluateStyle(style, datum, props.active);
     return assign({}, baseStyles, { fontSize: this.getFontSize(baseStyles) });
   }
 
@@ -133,7 +133,7 @@ export default class VictoryLabel extends React.Component {
 
   getHeight(props, type) {
     const datum = props.datum || props.data;
-    return Helpers.evaluateProp(props[type], datum, props.active);
+    return evaluateProp(props[type], datum, props.active);
   }
 
   getContent(props) {
@@ -142,9 +142,9 @@ export default class VictoryLabel extends React.Component {
     }
     const datum = props.datum || props.data;
     if (Array.isArray(props.text)) {
-      return props.text.map((line) => Helpers.evaluateProp(line, datum, props.active));
+      return props.text.map((line) => evaluateProp(line, datum, props.active));
     }
-    const child = Helpers.evaluateProp(props.text, datum, props.active);
+    const child = evaluateProp(props.text, datum, props.active);
     return `${child}`.split("\n");
   }
 
@@ -153,12 +153,12 @@ export default class VictoryLabel extends React.Component {
     lineHeight = this.checkLineHeight(lineHeight, lineHeight[0], 1);
     const fontSize = style.fontSize;
     const datum = props.datum || props.data;
-    const dy = props.dy ? Helpers.evaluateProp(props.dy, datum, props.active) : 0;
+    const dy = props.dy ? evaluateProp(props.dy, datum, props.active) : 0;
     const length = content.length;
     const capHeight = this.getHeight(props, "capHeight");
     const verticalAnchor = style.verticalAnchor || props.verticalAnchor;
     const anchor = verticalAnchor ?
-      Helpers.evaluateProp(verticalAnchor, datum) : "middle";
+      evaluateProp(verticalAnchor, datum) : "middle";
     switch (anchor) {
     case "end":
       return dy + (capHeight / 2 + (0.5 - length) * lineHeight) * fontSize;
@@ -181,7 +181,7 @@ export default class VictoryLabel extends React.Component {
     const defaultAngle = polar ? LabelHelpers.getPolarAngle(props) : 0;
     const angle = style.angle || props.angle || defaultAngle;
     const transform = props.transform || style.transform;
-    const transformPart = transform && Helpers.evaluateProp(transform, datum, active);
+    const transformPart = transform && evaluateProp(transform, datum, active);
     const rotatePart = angle && { rotate: [angle, x, y] };
     return transformPart || angle ?
       Style.toTransformString(transformPart, rotatePart) : undefined;
@@ -198,7 +198,7 @@ export default class VictoryLabel extends React.Component {
       if (!isNaN(fontSize)) {
         return fontSize;
       } else {
-        Log.warn("fontSize should be expressed as a number of pixels");
+        warn("fontSize should be expressed as a number of pixels");
         return defaultStyles.fontSize;
       }
     }
@@ -210,9 +210,9 @@ export default class VictoryLabel extends React.Component {
     const style = this.getStyles(props);
     const lineHeight = this.getHeight(props, "lineHeight");
     const textAnchor = props.textAnchor ?
-      Helpers.evaluateProp(props.textAnchor, datum, active) : "start";
+      evaluateProp(props.textAnchor, datum, active) : "start";
     const content = this.getContent(props);
-    const dx = props.dx ? Helpers.evaluateProp(props.dx, datum, active) : 0;
+    const dx = props.dx ? evaluateProp(props.dx, datum, active) : 0;
     const dy = this.getDy(props, style, content, lineHeight);
     const transform = this.getTransform(props, style);
     const x = typeof props.x !== "undefined" ? props.x : this.getPosition(props, "x");

--- a/src/victory-legend/helper-methods.js
+++ b/src/victory-legend/helper-methods.js
@@ -1,275 +1,272 @@
 import { defaults, assign, groupBy, keys, sum, range } from "lodash";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle, formatPadding, modifyProps } from "../victory-util/helpers";
 import Style from "../victory-util/style";
 import TextSize from "../victory-util/textsize";
 
-export default {
-  getColorScale(props) {
-    const { colorScale } = props;
-    return typeof colorScale === "string" ? Style.getColorScale(colorScale) : colorScale || [];
-  },
+export const getColorScale = (props) => {
+  const { colorScale } = props;
+  return typeof colorScale === "string" ? Style.getColorScale(colorScale) : colorScale || [];
+};
 
-  getLabelStyles(props) {
-    const { data, style } = props;
-    return data.map((datum) => {
-      const baseLabelStyles = defaults({}, datum.labels, style.labels);
-      return Helpers.evaluateStyle(baseLabelStyles, datum);
-    });
-  },
+export const getLabelStyles = (props) => {
+  const { data, style } = props;
+  return data.map((datum) => {
+    const baseLabelStyles = defaults({}, datum.labels, style.labels);
+    return evaluateStyle(baseLabelStyles, datum);
+  });
+};
 
-  getStyles(props, styleObject) {
-    const style = props.style || {};
-    styleObject = styleObject || {};
-    const parentStyleProps = { height: "100%", width: "100%" };
+export const getStyles = (props, styleObject) => {
+  const style = props.style || {};
+  styleObject = styleObject || {};
+  const parentStyleProps = { height: "100%", width: "100%" };
+  return {
+    parent: defaults(style.parent, styleObject.parent, parentStyleProps),
+    data: defaults({}, style.data, styleObject.data),
+    labels: defaults({}, style.labels, styleObject.labels),
+    border: defaults({}, style.border, styleObject.border),
+    title: defaults({}, style.title, styleObject.title)
+  };
+};
+
+export const getCalculatedValues = (props) => {
+  const { orientation, theme } = props;
+  const defaultStyles = theme && theme.legend && theme.legend.style ? theme.legend.style : {};
+  const style = getStyles(props, defaultStyles);
+  const colorScale = getColorScale(props);
+  const isHorizontal = orientation === "horizontal";
+  const borderPadding = formatPadding(props.borderPadding);
+  return assign({}, props, { style, isHorizontal, colorScale, borderPadding });
+};
+
+export const getColumn = (props, index) => {
+  const { itemsPerRow, isHorizontal } = props;
+  if (!itemsPerRow) {
+    return isHorizontal ? index : 0;
+  }
+  return isHorizontal ? index % itemsPerRow : Math.floor(index / itemsPerRow);
+};
+
+export const getRow = (props, index) => {
+  const { itemsPerRow, isHorizontal } = props;
+  if (!itemsPerRow) {
+    return isHorizontal ? 0 : index;
+  }
+  return isHorizontal ? Math.floor(index / itemsPerRow) : index % itemsPerRow;
+};
+
+export const groupData = (props) => {
+  const { data } = props;
+  const style = props.style && props.style.data || {};
+  const labelStyles = getLabelStyles(props);
+  return data.map((datum, index) => {
+    const symbol = datum.symbol || {};
+    const { fontSize } = labelStyles[index];
+    // eslint-disable-next-line no-magic-numbers
+    const size = symbol.size || style.size || fontSize / 2.5;
+    const symbolSpacer = props.symbolSpacer || Math.max(size, fontSize);
     return {
-      parent: defaults(style.parent, styleObject.parent, parentStyleProps),
-      data: defaults({}, style.data, styleObject.data),
-      labels: defaults({}, style.labels, styleObject.labels),
-      border: defaults({}, style.border, styleObject.border),
-      title: defaults({}, style.title, styleObject.title)
+      ...datum, size, symbolSpacer, fontSize,
+      textSize: TextSize.approximateTextSize(datum.name, labelStyles[index]),
+      column: getColumn(props, index),
+      row: getRow(props, index)
     };
-  },
+  });
+};
 
-  getCalculatedValues(props) {
-    const { orientation, theme } = props;
-    const defaultStyles = theme && theme.legend && theme.legend.style ? theme.legend.style : {};
-    const style = this.getStyles(props, defaultStyles);
-    const colorScale = this.getColorScale(props);
-    const isHorizontal = orientation === "horizontal";
-    const borderPadding = Helpers.formatPadding(props.borderPadding);
-    return assign({}, props, { style, isHorizontal, colorScale, borderPadding });
-  },
-
-  getColumn(props, index) {
-    const { itemsPerRow, isHorizontal } = props;
-    if (!itemsPerRow) {
-      return isHorizontal ? index : 0;
-    }
-    return isHorizontal ? index % itemsPerRow : Math.floor(index / itemsPerRow);
-  },
-
-  getRow(props, index) {
-    const { itemsPerRow, isHorizontal } = props;
-    if (!itemsPerRow) {
-      return isHorizontal ? 0 : index;
-    }
-    return isHorizontal ? Math.floor(index / itemsPerRow) : index % itemsPerRow;
-  },
-
-  groupData(props) {
-    const { data } = props;
-    const style = props.style && props.style.data || {};
-    const labelStyles = this.getLabelStyles(props);
-    return data.map((datum, index) => {
-      const symbol = datum.symbol || {};
-      const { fontSize } = labelStyles[index];
-      // eslint-disable-next-line no-magic-numbers
-      const size = symbol.size || style.size || fontSize / 2.5;
-      const symbolSpacer = props.symbolSpacer || Math.max(size, fontSize);
-      return {
-        ...datum, size, symbolSpacer, fontSize,
-        textSize: TextSize.approximateTextSize(datum.name, labelStyles[index]),
-        column: this.getColumn(props, index),
-        row: this.getRow(props, index)
-      };
+export const getColumnWidths = (props, data) => {
+  const gutter = props.gutter || {};
+  const gutterWidth = typeof gutter === "object" ?
+    (gutter.left || 0) + (gutter.right || 0) :
+    (gutter || 0);
+  const dataByColumn = groupBy(data, "column");
+  const columns = keys(dataByColumn);
+  return columns.reduce((memo, curr, index) => {
+    const lengths = dataByColumn[curr].map((d) => {
+      return d.textSize.width + d.size + d.symbolSpacer + gutterWidth;
     });
-  },
+    memo[index] = Math.max(...lengths);
+    return memo;
+  }, []);
+};
 
-  getColumnWidths(props, data) {
-    const gutter = props.gutter || {};
-    const gutterWidth = typeof gutter === "object" ?
-      (gutter.left || 0) + (gutter.right || 0) :
-      (gutter || 0);
-    const dataByColumn = groupBy(data, "column");
-    const columns = keys(dataByColumn);
-    return columns.reduce((memo, curr, index) => {
-      const lengths = dataByColumn[curr].map((d) => {
-        return d.textSize.width + d.size + d.symbolSpacer + gutterWidth;
-      });
-      memo[index] = Math.max(...lengths);
+export const getRowHeights = (props, data) => {
+  const gutter = props.rowGutter || {};
+  const gutterHeight = typeof gutter === "object" ?
+    (gutter.top || 0) + (gutter.bottom || 0) :
+    (gutter || 0);
+  const dataByRow = groupBy(data, "row");
+  return keys(dataByRow).reduce((memo, curr, index) => {
+    const rows = dataByRow[curr];
+    const lengths = rows.map((d) => {
+      return d.textSize.height + d.symbolSpacer + gutterHeight;
+    });
+    memo[index] = Math.max(...lengths);
+    return memo;
+  }, []);
+};
+
+export const getTitleDimensions = (props) => {
+  const style = props.style && props.style.title || {};
+  const textSize = TextSize.approximateTextSize(props.title, style);
+  const padding = style.padding || 0;
+  return { height: textSize.height + 2 * padding || 0, width: textSize.width + 2 * padding || 0 };
+};
+
+export const getOffset = (datum, rowHeights, columnWidths) => {
+  const { column, row } = datum;
+  return {
+    x: range(column).reduce((memo, curr) => {
+      memo += columnWidths[curr];
       return memo;
-    }, []);
-  },
-
-  getRowHeights(props, data) {
-    const gutter = props.rowGutter || {};
-    const gutterHeight = typeof gutter === "object" ?
-      (gutter.top || 0) + (gutter.bottom || 0) :
-      (gutter || 0);
-    const dataByRow = groupBy(data, "row");
-    return keys(dataByRow).reduce((memo, curr, index) => {
-      const rows = dataByRow[curr];
-      const lengths = rows.map((d) => {
-        return d.textSize.height + d.symbolSpacer + gutterHeight;
-      });
-      memo[index] = Math.max(...lengths);
+    }, 0),
+    y: range(row).reduce((memo, curr) => {
+      memo += rowHeights[curr];
       return memo;
-    }, []);
-  },
+    }, 0)
+  };
+};
 
-  getTitleDimensions(props) {
-    const style = props.style && props.style.title || {};
-    const textSize = TextSize.approximateTextSize(props.title, style);
-    const padding = style.padding || 0;
-    return { height: textSize.height + 2 * padding || 0, width: textSize.width + 2 * padding || 0 };
-  },
-
-  getOffset(datum, rowHeights, columnWidths) {
-    const { column, row } = datum;
-    return {
-      x: range(column).reduce((memo, curr) => {
-        memo += columnWidths[curr];
-        return memo;
-      }, 0),
-      y: range(row).reduce((memo, curr) => {
-        memo += rowHeights[curr];
-        return memo;
-      }, 0)
-    };
-  },
-
-  getAnchors(titleOrientation, centerTitle) {
-    const standardAnchors = {
-      textAnchor: titleOrientation === "right" ? "end" : "start",
-      verticalAnchor: titleOrientation === "bottom" ? "end" : "start"
-    };
-    if (centerTitle) {
-      const horizontal = titleOrientation === "top" || titleOrientation === "bottom";
-      return {
-        textAnchor: horizontal ? "middle" : standardAnchors.textAnchor,
-        verticalAnchor: horizontal ? standardAnchors.verticalAnchor : "middle"
-      };
-    } else {
-      return standardAnchors;
-    }
-  },
-
-  getTitleStyle(props) {
-    const { titleOrientation, centerTitle, titleComponent } = props;
-    const baseStyle = props.style && props.style.title || {};
-    const componentStyle = titleComponent.props && titleComponent.props.style || {};
-    const anchors = this.getAnchors(titleOrientation, centerTitle);
-    return Array.isArray(componentStyle) ?
-      componentStyle.map((obj) => defaults({}, obj, baseStyle, anchors)) :
-      defaults({}, componentStyle, baseStyle, anchors);
-  },
-
-  // eslint-disable-next-line complexity
-  getTitleProps(props, borderProps) {
-    const { title, titleOrientation, centerTitle, borderPadding } = props;
-    const { height, width } = borderProps;
-    const style = this.getTitleStyle(props);
-    const padding = Array.isArray(style) ? style[0].padding : style.padding;
+export const getAnchors = (titleOrientation, centerTitle) => {
+  const standardAnchors = {
+    textAnchor: titleOrientation === "right" ? "end" : "start",
+    verticalAnchor: titleOrientation === "bottom" ? "end" : "start"
+  };
+  if (centerTitle) {
     const horizontal = titleOrientation === "top" || titleOrientation === "bottom";
-    const xOrientation = titleOrientation === "bottom" ? "bottom" : "top";
-    const yOrientation = titleOrientation === "right" ? "right" : "left";
-    const standardPadding = {
-      x: centerTitle ? width / 2 : borderPadding[xOrientation] + (padding || 0),
-      y: centerTitle ? height / 2 : borderPadding[yOrientation] + (padding || 0)
-    };
-    const getPadding = () => {
-      return borderPadding[titleOrientation] + (padding || 0);
-    };
-    const xOffset = horizontal ? standardPadding.x : getPadding();
-    const yOffset = horizontal ? getPadding() : standardPadding.y;
-
     return {
-      x: titleOrientation === "right" ? props.x + width - xOffset : props.x + xOffset,
-      y: titleOrientation === "bottom" ? props.y + height - yOffset : props.y + yOffset,
-      style,
-      text: title
+      textAnchor: horizontal ? "middle" : standardAnchors.textAnchor,
+      verticalAnchor: horizontal ? standardAnchors.verticalAnchor : "middle"
     };
-  },
-
-  getBorderProps(props, contentHeight, contentWidth) {
-    const { x, y, borderPadding, style } = props;
-    const height = contentHeight + borderPadding.top + borderPadding.bottom;
-    const width = contentWidth + borderPadding.left + borderPadding.right;
-    return { x, y, height, width, style: assign({ fill: "none" }, style.border) };
-  },
-
-  getDimensions(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "legend");
-    props = assign({}, modifiedProps, this.getCalculatedValues(modifiedProps));
-    const { title, titleOrientation } = props;
-    const groupedData = this.groupData(props);
-    const columnWidths = this.getColumnWidths(props, groupedData);
-    const rowHeights = this.getRowHeights(props, groupedData);
-    const titleDimensions = title ? this.getTitleDimensions(props) : { height: 0, width: 0 };
-
-    return {
-      height: titleOrientation === "left" || titleOrientation === "right" ?
-        Math.max(sum(rowHeights), titleDimensions.height) :
-        sum(rowHeights) + titleDimensions.height,
-      width: titleOrientation === "left" || titleOrientation === "right" ?
-        sum(columnWidths) + titleDimensions.width :
-        Math.max(sum(columnWidths), titleDimensions.width)
-    };
-  },
-
-  getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "legend");
-    props = assign({}, modifiedProps, this.getCalculatedValues(modifiedProps));
-    const {
-      data, standalone, theme, padding, style, colorScale, gutter, rowGutter,
-      borderPadding, title, titleOrientation, x = 0, y = 0
-    } = props;
-    const groupedData = this.groupData(props);
-    const columnWidths = this.getColumnWidths(props, groupedData);
-    const rowHeights = this.getRowHeights(props, groupedData);
-    const labelStyles = this.getLabelStyles(props);
-    const titleDimensions = title ? this.getTitleDimensions(props) : { height: 0, width: 0 };
-    const titleOffset = {
-      x: titleOrientation === "left" ? titleDimensions.width : 0,
-      y: titleOrientation === "top" ? titleDimensions.height : 0
-    };
-    const gutterOffset = {
-      x: gutter && typeof gutter === "object" ? gutter.left || 0 : 0,
-      y: rowGutter && typeof rowGutter === "object" ? rowGutter.top || 0 : 0
-    };
-    const { height, width } = this.getDimensions(props, fallbackProps);
-    const initialProps = {
-      parent: {
-        data, standalone, theme, padding,
-        height: props.height,
-        width: props.width,
-        style: style.parent
-      }
-    };
-    const borderProps = this.getBorderProps(props, height, width);
-    const titleProps = this.getTitleProps(props, borderProps);
-    return groupedData.reduce((childProps, datum, i) => {
-      const color = colorScale[i % colorScale.length];
-      const dataStyle = defaults({}, datum.symbol, style.data, { fill: color });
-      const eventKey = datum.eventKey || i;
-      const offset = this.getOffset(datum, rowHeights, columnWidths);
-      const originY = y + borderPadding.top + datum.symbolSpacer;
-      const originX = x + borderPadding.left + datum.symbolSpacer;
-      const dataProps = {
-        index: i,
-        data, datum,
-        key: `legend-symbol-${i}`,
-        symbol: dataStyle.type || dataStyle.symbol || "circle",
-        size: datum.size,
-        style: dataStyle,
-        y: originY + offset.y + titleOffset.y + gutterOffset.y,
-        x: originX + offset.x + titleOffset.x + gutterOffset.x
-      };
-
-      const labelProps = {
-        datum, data,
-        key: `legend-label-${i}`,
-        text: datum.name,
-        style: labelStyles[i],
-        y: dataProps.y,
-        x: dataProps.x + datum.symbolSpacer + (datum.size / 2)
-      };
-      childProps[eventKey] = eventKey === 0 ?
-        { data: dataProps, labels: labelProps, border: borderProps, title: titleProps } :
-        { data: dataProps, labels: labelProps };
-
-      return childProps;
-    }, initialProps);
+  } else {
+    return standardAnchors;
   }
 };
 
+export const getTitleStyle = (props) => {
+  const { titleOrientation, centerTitle, titleComponent } = props;
+  const baseStyle = props.style && props.style.title || {};
+  const componentStyle = titleComponent.props && titleComponent.props.style || {};
+  const anchors = getAnchors(titleOrientation, centerTitle);
+  return Array.isArray(componentStyle) ?
+    componentStyle.map((obj) => defaults({}, obj, baseStyle, anchors)) :
+    defaults({}, componentStyle, baseStyle, anchors);
+};
+
+  // eslint-disable-next-line complexity
+export const getTitleProps = (props, borderProps) => {
+  const { title, titleOrientation, centerTitle, borderPadding } = props;
+  const { height, width } = borderProps;
+  const style = getTitleStyle(props);
+  const padding = Array.isArray(style) ? style[0].padding : style.padding;
+  const horizontal = titleOrientation === "top" || titleOrientation === "bottom";
+  const xOrientation = titleOrientation === "bottom" ? "bottom" : "top";
+  const yOrientation = titleOrientation === "right" ? "right" : "left";
+  const standardPadding = {
+    x: centerTitle ? width / 2 : borderPadding[xOrientation] + (padding || 0),
+    y: centerTitle ? height / 2 : borderPadding[yOrientation] + (padding || 0)
+  };
+  const getPadding = () => {
+    return borderPadding[titleOrientation] + (padding || 0);
+  };
+  const xOffset = horizontal ? standardPadding.x : getPadding();
+  const yOffset = horizontal ? getPadding() : standardPadding.y;
+
+  return {
+    x: titleOrientation === "right" ? props.x + width - xOffset : props.x + xOffset,
+    y: titleOrientation === "bottom" ? props.y + height - yOffset : props.y + yOffset,
+    style,
+    text: title
+  };
+};
+
+export const getBorderProps = (props, contentHeight, contentWidth) => {
+  const { x, y, borderPadding, style } = props;
+  const height = contentHeight + borderPadding.top + borderPadding.bottom;
+  const width = contentWidth + borderPadding.left + borderPadding.right;
+  return { x, y, height, width, style: assign({ fill: "none" }, style.border) };
+};
+
+export const getDimensions = (props, fallbackProps) => {
+  const modifiedProps = modifyProps(props, fallbackProps, "legend");
+  props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const { title, titleOrientation } = props;
+  const groupedData = groupData(props);
+  const columnWidths = getColumnWidths(props, groupedData);
+  const rowHeights = getRowHeights(props, groupedData);
+  const titleDimensions = title ? getTitleDimensions(props) : { height: 0, width: 0 };
+
+  return {
+    height: titleOrientation === "left" || titleOrientation === "right" ?
+      Math.max(sum(rowHeights), titleDimensions.height) :
+      sum(rowHeights) + titleDimensions.height,
+    width: titleOrientation === "left" || titleOrientation === "right" ?
+      sum(columnWidths) + titleDimensions.width :
+      Math.max(sum(columnWidths), titleDimensions.width)
+  };
+};
+
+export const getBaseProps = (props, fallbackProps) => {
+  const modifiedProps = modifyProps(props, fallbackProps, "legend");
+  props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const {
+    data, standalone, theme, padding, style, colorScale, gutter, rowGutter,
+    borderPadding, title, titleOrientation, x = 0, y = 0
+  } = props;
+  const groupedData = groupData(props);
+  const columnWidths = getColumnWidths(props, groupedData);
+  const rowHeights = getRowHeights(props, groupedData);
+  const labelStyles = getLabelStyles(props);
+  const titleDimensions = title ? getTitleDimensions(props) : { height: 0, width: 0 };
+  const titleOffset = {
+    x: titleOrientation === "left" ? titleDimensions.width : 0,
+    y: titleOrientation === "top" ? titleDimensions.height : 0
+  };
+  const gutterOffset = {
+    x: gutter && typeof gutter === "object" ? gutter.left || 0 : 0,
+    y: rowGutter && typeof rowGutter === "object" ? rowGutter.top || 0 : 0
+  };
+  const { height, width } = getDimensions(props, fallbackProps);
+  const initialProps = {
+    parent: {
+      data, standalone, theme, padding,
+      height: props.height,
+      width: props.width,
+      style: style.parent
+    }
+  };
+  const borderProps = getBorderProps(props, height, width);
+  const titleProps = getTitleProps(props, borderProps);
+  return groupedData.reduce((childProps, datum, i) => {
+    const color = colorScale[i % colorScale.length];
+    const dataStyle = defaults({}, datum.symbol, style.data, { fill: color });
+    const eventKey = datum.eventKey || i;
+    const offset = getOffset(datum, rowHeights, columnWidths);
+    const originY = y + borderPadding.top + datum.symbolSpacer;
+    const originX = x + borderPadding.left + datum.symbolSpacer;
+    const dataProps = {
+      index: i,
+      data, datum,
+      key: `legend-symbol-${i}`,
+      symbol: dataStyle.type || dataStyle.symbol || "circle",
+      size: datum.size,
+      style: dataStyle,
+      y: originY + offset.y + titleOffset.y + gutterOffset.y,
+      x: originX + offset.x + titleOffset.x + gutterOffset.x
+    };
+
+    const labelProps = {
+      datum, data,
+      key: `legend-label-${i}`,
+      text: datum.name,
+      style: labelStyles[i],
+      y: dataProps.y,
+      x: dataProps.x + datum.symbolSpacer + (datum.size / 2)
+    };
+    childProps[eventKey] = eventKey === 0 ?
+      { data: dataProps, labels: labelProps, border: borderProps, title: titleProps } :
+      { data: dataProps, labels: labelProps };
+
+    return childProps;
+  }, initialProps);
+};

--- a/src/victory-legend/helper-methods.js
+++ b/src/victory-legend/helper-methods.js
@@ -3,12 +3,12 @@ import { evaluateStyle, formatPadding, modifyProps } from "../victory-util/helpe
 import Style from "../victory-util/style";
 import TextSize from "../victory-util/textsize";
 
-export const getColorScale = (props) => {
+const getColorScale = (props) => {
   const { colorScale } = props;
   return typeof colorScale === "string" ? Style.getColorScale(colorScale) : colorScale || [];
 };
 
-export const getLabelStyles = (props) => {
+const getLabelStyles = (props) => {
   const { data, style } = props;
   return data.map((datum) => {
     const baseLabelStyles = defaults({}, datum.labels, style.labels);
@@ -16,7 +16,7 @@ export const getLabelStyles = (props) => {
   });
 };
 
-export const getStyles = (props, styleObject) => {
+const getStyles = (props, styleObject) => {
   const style = props.style || {};
   styleObject = styleObject || {};
   const parentStyleProps = { height: "100%", width: "100%" };
@@ -29,7 +29,7 @@ export const getStyles = (props, styleObject) => {
   };
 };
 
-export const getCalculatedValues = (props) => {
+const getCalculatedValues = (props) => {
   const { orientation, theme } = props;
   const defaultStyles = theme && theme.legend && theme.legend.style ? theme.legend.style : {};
   const style = getStyles(props, defaultStyles);
@@ -39,7 +39,7 @@ export const getCalculatedValues = (props) => {
   return assign({}, props, { style, isHorizontal, colorScale, borderPadding });
 };
 
-export const getColumn = (props, index) => {
+const getColumn = (props, index) => {
   const { itemsPerRow, isHorizontal } = props;
   if (!itemsPerRow) {
     return isHorizontal ? index : 0;
@@ -47,7 +47,7 @@ export const getColumn = (props, index) => {
   return isHorizontal ? index % itemsPerRow : Math.floor(index / itemsPerRow);
 };
 
-export const getRow = (props, index) => {
+const getRow = (props, index) => {
   const { itemsPerRow, isHorizontal } = props;
   if (!itemsPerRow) {
     return isHorizontal ? 0 : index;
@@ -55,7 +55,7 @@ export const getRow = (props, index) => {
   return isHorizontal ? Math.floor(index / itemsPerRow) : index % itemsPerRow;
 };
 
-export const groupData = (props) => {
+const groupData = (props) => {
   const { data } = props;
   const style = props.style && props.style.data || {};
   const labelStyles = getLabelStyles(props);
@@ -74,7 +74,7 @@ export const groupData = (props) => {
   });
 };
 
-export const getColumnWidths = (props, data) => {
+const getColumnWidths = (props, data) => {
   const gutter = props.gutter || {};
   const gutterWidth = typeof gutter === "object" ?
     (gutter.left || 0) + (gutter.right || 0) :
@@ -90,7 +90,7 @@ export const getColumnWidths = (props, data) => {
   }, []);
 };
 
-export const getRowHeights = (props, data) => {
+const getRowHeights = (props, data) => {
   const gutter = props.rowGutter || {};
   const gutterHeight = typeof gutter === "object" ?
     (gutter.top || 0) + (gutter.bottom || 0) :
@@ -106,14 +106,14 @@ export const getRowHeights = (props, data) => {
   }, []);
 };
 
-export const getTitleDimensions = (props) => {
+const getTitleDimensions = (props) => {
   const style = props.style && props.style.title || {};
   const textSize = TextSize.approximateTextSize(props.title, style);
   const padding = style.padding || 0;
   return { height: textSize.height + 2 * padding || 0, width: textSize.width + 2 * padding || 0 };
 };
 
-export const getOffset = (datum, rowHeights, columnWidths) => {
+const getOffset = (datum, rowHeights, columnWidths) => {
   const { column, row } = datum;
   return {
     x: range(column).reduce((memo, curr) => {
@@ -127,7 +127,7 @@ export const getOffset = (datum, rowHeights, columnWidths) => {
   };
 };
 
-export const getAnchors = (titleOrientation, centerTitle) => {
+const getAnchors = (titleOrientation, centerTitle) => {
   const standardAnchors = {
     textAnchor: titleOrientation === "right" ? "end" : "start",
     verticalAnchor: titleOrientation === "bottom" ? "end" : "start"
@@ -143,7 +143,7 @@ export const getAnchors = (titleOrientation, centerTitle) => {
   }
 };
 
-export const getTitleStyle = (props) => {
+const getTitleStyle = (props) => {
   const { titleOrientation, centerTitle, titleComponent } = props;
   const baseStyle = props.style && props.style.title || {};
   const componentStyle = titleComponent.props && titleComponent.props.style || {};
@@ -154,7 +154,7 @@ export const getTitleStyle = (props) => {
 };
 
   // eslint-disable-next-line complexity
-export const getTitleProps = (props, borderProps) => {
+const getTitleProps = (props, borderProps) => {
   const { title, titleOrientation, centerTitle, borderPadding } = props;
   const { height, width } = borderProps;
   const style = getTitleStyle(props);
@@ -180,14 +180,14 @@ export const getTitleProps = (props, borderProps) => {
   };
 };
 
-export const getBorderProps = (props, contentHeight, contentWidth) => {
+const getBorderProps = (props, contentHeight, contentWidth) => {
   const { x, y, borderPadding, style } = props;
   const height = contentHeight + borderPadding.top + borderPadding.bottom;
   const width = contentWidth + borderPadding.left + borderPadding.right;
   return { x, y, height, width, style: assign({ fill: "none" }, style.border) };
 };
 
-export const getDimensions = (props, fallbackProps) => {
+const getDimensions = (props, fallbackProps) => {
   const modifiedProps = modifyProps(props, fallbackProps, "legend");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const { title, titleOrientation } = props;
@@ -206,7 +206,7 @@ export const getDimensions = (props, fallbackProps) => {
   };
 };
 
-export const getBaseProps = (props, fallbackProps) => {
+const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = modifyProps(props, fallbackProps, "legend");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
@@ -269,4 +269,24 @@ export const getBaseProps = (props, fallbackProps) => {
 
     return childProps;
   }, initialProps);
+};
+
+export {
+  getColorScale,
+  getLabelStyles,
+  getStyles,
+  getCalculatedValues,
+  getColumn,
+  getRow,
+  groupData,
+  getColumnWidths,
+  getRowHeights,
+  getTitleDimensions,
+  getOffset,
+  getAnchors,
+  getTitleStyle,
+  getTitleProps,
+  getBorderProps,
+  getDimensions,
+  getBaseProps
 };

--- a/src/victory-legend/victory-legend.js
+++ b/src/victory-legend/victory-legend.js
@@ -1,10 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { partialRight } from "lodash";
-import LegendHelpers from "./helper-methods";
+import { getBaseProps, getDimensions } from "./helper-methods";
 import CustomPropTypes from "../victory-util/prop-types";
 import addEvents from "../victory-util/add-events";
-import Helpers from "../victory-util/helpers";
+import { modifyProps } from "../victory-util/helpers";
 import VictoryLabel from "../victory-label/victory-label";
 import VictoryContainer from "../victory-container/victory-container";
 import VictoryTheme from "../victory-theme/victory-theme";
@@ -150,9 +150,9 @@ class VictoryLegend extends React.Component {
     titleComponent: <VictoryLabel/>
   };
 
-  static getBaseProps = partialRight(LegendHelpers.getBaseProps.bind(LegendHelpers), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
   static getDimensions = partialRight(
-    LegendHelpers.getDimensions.bind(LegendHelpers), fallbackProps
+    getDimensions.bind(getDimensions), fallbackProps
   );
   static expectedComponents = [
     "borderComponent", "containerComponent", "dataComponent",
@@ -186,7 +186,7 @@ class VictoryLegend extends React.Component {
 
   render() {
     const { role } = this.constructor;
-    const props = Helpers.modifyProps((this.props), fallbackProps, role);
+    const props = modifyProps((this.props), fallbackProps, role);
     const children = [this.renderChildren(props)];
     return props.standalone ?
       this.renderContainer(props.containerComponent, children) :

--- a/src/victory-portal/victory-portal.js
+++ b/src/victory-portal/victory-portal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Log from "../victory-util/log";
+import { warn } from "../victory-util/log";
 import { defaults, omit } from "lodash";
 
 export default class VictoryPortal extends React.Component {
@@ -28,7 +28,7 @@ export default class VictoryPortal extends React.Component {
       if (typeof this.context.portalUpdate !== "function") {
         const msg = "`renderInPortal` is not supported outside of `VictoryContainer`. " +
           "Component will be rendered in place";
-        Log.warn(msg);
+        warn(msg);
         this.renderInPlace = true;
       }
       this.checkedContext = true;
@@ -71,4 +71,3 @@ export default class VictoryPortal extends React.Component {
     return this.renderPortal(child);
   }
 }
-

--- a/src/victory-primitives/arc.js
+++ b/src/victory-primitives/arc.js
@@ -1,7 +1,7 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [0, 1, 2, 180] }]*/
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle, degreesToRadians } from "../victory-util/helpers";
 import { assign } from "lodash";
 import CommonProps from "./common-props";
 import Path from "./path";
@@ -25,19 +25,19 @@ export default class Arc extends React.Component {
 
   getStyle(props) {
     const { style, datum, active } = props;
-    return Helpers.evaluateStyle(assign({ stroke: "black", fill: "none" }, style), datum, active);
+    return evaluateStyle(assign({ stroke: "black", fill: "none" }, style), datum, active);
   }
 
   getArcPath(props) {
     const { cx, cy, r, startAngle, endAngle, closedPath } = props;
     // Always draw the path as two arcs so that complete circles may be rendered.
     const halfAngle = (Math.abs(endAngle - startAngle) / 2) + startAngle;
-    const x1 = cx + r * Math.cos(Helpers.degreesToRadians(startAngle));
-    const y1 = cy - r * Math.sin(Helpers.degreesToRadians(startAngle));
-    const x2 = cx + r * Math.cos(Helpers.degreesToRadians(halfAngle));
-    const y2 = cy - r * Math.sin(Helpers.degreesToRadians(halfAngle));
-    const x3 = cx + r * Math.cos(Helpers.degreesToRadians(endAngle));
-    const y3 = cy - r * Math.sin(Helpers.degreesToRadians(endAngle));
+    const x1 = cx + r * Math.cos(degreesToRadians(startAngle));
+    const y1 = cy - r * Math.sin(degreesToRadians(startAngle));
+    const x2 = cx + r * Math.cos(degreesToRadians(halfAngle));
+    const y2 = cy - r * Math.sin(degreesToRadians(halfAngle));
+    const x3 = cx + r * Math.cos(degreesToRadians(endAngle));
+    const y3 = cy - r * Math.sin(degreesToRadians(endAngle));
     const largerArcFlag1 = halfAngle - startAngle <= 180 ? 0 : 1;
     const largerArcFlag2 = endAngle - halfAngle <= 180 ? 0 : 1;
     const arcStart = closedPath ? ` M ${cx}, ${cy} L ${x1}, ${y1}` : `M ${x1}, ${y1}`;

--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -1,7 +1,7 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import { defined, getXAccessor, getYAccessor, getY0Accessor, getAngleAccessor } from "./helpers";
 import { assign } from "lodash";
 import * as d3Shape from "d3-shape";
@@ -66,7 +66,7 @@ export default class Area extends React.Component {
       role, shapeRendering, className, polar, origin, data, active, pathComponent, events,
       groupComponent
     } = this.props;
-    const style = Helpers.evaluateStyle(assign({ fill: "black" }, this.props.style), data, active);
+    const style = evaluateStyle(assign({ fill: "black" }, this.props.style), data, active);
     const transform = polar && origin ? `translate(${origin.x}, ${origin.y})` : undefined;
 
     const renderLine = style.stroke && style.stroke !== "none" && style.stroke !== "transparent";

--- a/src/victory-primitives/axis.js
+++ b/src/victory-primitives/axis.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import { assign } from "lodash";
 import CommonProps from "./common-props";
 import Line from "./line";
@@ -24,7 +24,7 @@ export default class Axis extends React.Component {
     const {
       x1, x2, y1, y2, events, datum, active, lineComponent, className, role, shapeRendering
     } = this.props;
-    const style = Helpers.evaluateStyle(
+    const style = evaluateStyle(
       assign({ stroke: "black" }, this.props.style), datum, active
     );
     return React.cloneElement(lineComponent, {

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import { assign } from "lodash";
 import CommonProps from "./common-props";
 import Path from "./path";
@@ -203,7 +203,7 @@ export default class Bar extends React.Component {
     } = this.props;
     const stroke = this.props.style && this.props.style.fill || "black";
     const baseStyle = { fill: "black", stroke };
-    const style = Helpers.evaluateStyle(assign(baseStyle, this.props.style), datum, active);
+    const style = evaluateStyle(assign(baseStyle, this.props.style), datum, active);
     const width = this.getBarWidth(this.props, style);
     const path = polar ?
       this.getPolarBarPath(this.props, width) : this.getBarPath(this.props, width);

--- a/src/victory-primitives/border.js
+++ b/src/victory-primitives/border.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import { assign } from "lodash";
 import CommonProps from "./common-props";
 import Rect from "./rect";
@@ -23,7 +23,7 @@ export default class Border extends React.Component {
     const {
        x, y, width, height, events, datum, active, role, className, shapeRendering, rectComponent
       } = this.props;
-    const style = Helpers.evaluateStyle(assign({ fill: "none" }, this.props.style), datum, active);
+    const style = evaluateStyle(assign({ fill: "none" }, this.props.style), datum, active);
     return React.cloneElement(rectComponent, {
       style, className, x, y, width, height, events, role, shapeRendering
     });

--- a/src/victory-primitives/candle.js
+++ b/src/victory-primitives/candle.js
@@ -1,7 +1,7 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [0.5, 2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import { assign, defaults } from "lodash";
 import CommonProps from "./common-props";
 import Rect from "./rect";
@@ -40,7 +40,7 @@ export default class Candle extends React.Component {
       x, high, low, open, close, data, datum, active, width, candleHeight, events, groupComponent,
       rectComponent, lineComponent, role, shapeRendering, className, wickStrokeWidth
     } = this.props;
-    const style = Helpers.evaluateStyle(
+    const style = evaluateStyle(
       assign({ stroke: "black" }, this.props.style), datum, active
     );
     const wickStyle = defaults({ strokeWidth: wickStrokeWidth }, style);

--- a/src/victory-primitives/curve.js
+++ b/src/victory-primitives/curve.js
@@ -1,7 +1,7 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import { defined, getXAccessor, getYAccessor, getAngleAccessor } from "./helpers";
 import { assign } from "lodash";
 import * as d3Shape from "d3-shape";
@@ -51,7 +51,7 @@ export default class Curve extends React.Component {
     const {
       data, active, events, role, shapeRendering, className, polar, origin, pathComponent
     } = this.props;
-    const style = Helpers.evaluateStyle(
+    const style = evaluateStyle(
       assign({ fill: "none", stroke: "black" }, this.props.style), data, active
     );
     const lineFunction = this.getLineFunction(this.props);

--- a/src/victory-primitives/error-bar.js
+++ b/src/victory-primitives/error-bar.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import { assign } from "lodash";
 import CommonProps from "./common-props";
 import Line from "./line";
@@ -35,7 +35,7 @@ export default class ErrorBar extends React.Component {
 
   getStyle(props) {
     const { style, datum, active } = props;
-    return Helpers.evaluateStyle(assign({ stroke: "black" }, style), datum, active);
+    return evaluateStyle(assign({ stroke: "black" }, style), datum, active);
   }
 
   renderBorder(props, error, type) {

--- a/src/victory-primitives/flyout.js
+++ b/src/victory-primitives/flyout.js
@@ -1,7 +1,7 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import CommonProps from "./common-props";
 import Path from "./path";
 
@@ -85,7 +85,7 @@ export default class Flyout extends React.Component {
 
   render() {
     const { datum, active, role, shapeRendering, className, events, pathComponent } = this.props;
-    const style = Helpers.evaluateStyle(this.props.style, datum, active);
+    const style = evaluateStyle(this.props.style, datum, active);
     const path = this.getFlyoutPath(this.props);
     return React.cloneElement(
       pathComponent, { style, className, shapeRendering, role, events, d: path }

--- a/src/victory-primitives/point.js
+++ b/src/victory-primitives/point.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateProp, evaluateStyle } from "../victory-util/helpers";
 import pathHelpers from "./path-helpers";
 import CommonProps from "./common-props";
 import Path from "./path";
@@ -32,7 +32,7 @@ export default class Point extends React.Component {
 
   getPath(props) {
     const { datum, active, x, y } = props;
-    const size = Helpers.evaluateProp(props.size, datum, active);
+    const size = evaluateProp(props.size, datum, active);
     if (props.getPath) {
       return props.getPath(x, y, size);
     }
@@ -46,7 +46,7 @@ export default class Point extends React.Component {
       minus: pathHelpers.minus,
       star: pathHelpers.star
     };
-    const symbol = Helpers.evaluateProp(props.symbol, datum, active);
+    const symbol = evaluateProp(props.symbol, datum, active);
     const symbolFunction = typeof pathFunctions[symbol] === "function" ?
       pathFunctions[symbol] : pathFunctions.circle;
     return symbolFunction(x, y, size);
@@ -54,7 +54,7 @@ export default class Point extends React.Component {
 
   render() {
     const { active, datum, role, shapeRendering, className, events, pathComponent } = this.props;
-    const style = Helpers.evaluateStyle(this.props.style, datum, active);
+    const style = evaluateStyle(this.props.style, datum, active);
     const d = this.getPath(this.props);
     return React.cloneElement(
       pathComponent, { style, role, shapeRendering, className, events, d }

--- a/src/victory-primitives/slice.js
+++ b/src/victory-primitives/slice.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle } from "../victory-util/helpers";
 import CommonProps from "./common-props";
 import Path from "./path";
 import { isFunction } from "lodash";
@@ -26,7 +26,7 @@ export default class Slice extends React.Component {
     return React.cloneElement(pathComponent, {
       className, role, shapeRendering, events,
       transform: origin ? `translate(${origin.x}, ${origin.y})` : undefined,
-      style: Helpers.evaluateStyle(style, datum, active),
+      style: evaluateStyle(style, datum, active),
       d: isFunction(pathFunction) ? pathFunction(slice) : undefined
     });
   }

--- a/src/victory-primitives/voronoi.js
+++ b/src/victory-primitives/voronoi.js
@@ -2,7 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { isObject, uniqueId } from "lodash";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle, evaluateProp } from "../victory-util/helpers";
 import CommonProps from "./common-props";
 import ClipPath from "../victory-primitives/clip-path";
 import Path from "../victory-primitives/path";
@@ -49,8 +49,8 @@ export default class Voronoi extends React.Component {
       pathComponent, clipPathComponent, groupComponent, circleComponent
     } = this.props;
     const voronoiPath = this.getVoronoiPath(this.props);
-    const style = Helpers.evaluateStyle(this.props.style, datum, active);
-    const size = Helpers.evaluateProp(this.props.size, datum, active);
+    const style = evaluateStyle(this.props.style, datum, active);
+    const size = evaluateProp(this.props.size, datum, active);
 
     if (size) {
       const circle = React.cloneElement(circleComponent, {

--- a/src/victory-shared-events/victory-shared-events.js
+++ b/src/victory-shared-events/victory-shared-events.js
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "../victory-util/prop-types";
 import Events from "../victory-util/events";
-import Helpers from "../victory-util/helpers";
+import { reduceChildren } from "../victory-util/helpers";
 import Timer from "../victory-util/timer";
 
 export default class VictorySharedEvents extends React.Component {
@@ -147,7 +147,7 @@ export default class VictorySharedEvents extends React.Component {
       }
     };
 
-    const baseProps = Helpers.reduceChildren(childComponents, iteratee);
+    const baseProps = reduceChildren(childComponents, iteratee);
     return fromPairs(baseProps);
   }
 

--- a/src/victory-tooltip/victory-tooltip.js
+++ b/src/victory-tooltip/victory-tooltip.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "../victory-util/prop-types";
 import TextSize from "../victory-util/textsize";
-import Helpers from "../victory-util/helpers";
+import { evaluateStyle, evaluateProp, modifyProps } from "../victory-util/helpers";
 import Collection from "../victory-util/collection";
 import LabelHelpers from "../victory-util/label-helpers";
 import VictoryLabel from "../victory-label/victory-label";
@@ -179,13 +179,13 @@ export default class VictoryTooltip extends React.Component {
     } = props;
 
     const style = Array.isArray(props.style) ?
-      props.style.map((s) => Helpers.evaluateStyle(s, datum, active)) :
-      Helpers.evaluateStyle(props.style, datum, active);
-    const flyoutStyle = Helpers.evaluateStyle(props.flyoutStyle, datum, active);
+      props.style.map((s) => evaluateStyle(s, datum, active)) :
+      evaluateStyle(props.style, datum, active);
+    const flyoutStyle = evaluateStyle(props.flyoutStyle, datum, active);
     const padding = flyoutStyle && flyoutStyle.padding || 0;
     const defaultDx = horizontal ? padding : 0;
     const defaultDy = horizontal ? 0 : padding;
-    const orientation = Helpers.evaluateProp(props.orientation, datum, active) ||
+    const orientation = evaluateProp(props.orientation, datum, active) ||
       this.getDefaultOrientation(props);
     return assign(
       {},
@@ -194,15 +194,15 @@ export default class VictoryTooltip extends React.Component {
         style,
         flyoutStyle,
         orientation,
-        dx: dx !== undefined ? Helpers.evaluateProp(dx, datum, active) : defaultDx,
-        dy: dy !== undefined ? Helpers.evaluateProp(dy, datum, active) : defaultDy,
-        cornerRadius: Helpers.evaluateProp(cornerRadius, datum, active),
-        pointerLength: Helpers.evaluateProp(pointerLength, datum, active),
-        pointerWidth: Helpers.evaluateProp(pointerWidth, datum, active),
-        width: Helpers.evaluateProp(width, datum, active),
-        height: Helpers.evaluateProp(height, datum, active),
-        active: Helpers.evaluateProp(active, datum, active),
-        text: Helpers.evaluateProp(text, datum, active)
+        dx: dx !== undefined ? evaluateProp(dx, datum, active) : defaultDx,
+        dy: dy !== undefined ? evaluateProp(dy, datum, active) : defaultDy,
+        cornerRadius: evaluateProp(cornerRadius, datum, active),
+        pointerLength: evaluateProp(pointerLength, datum, active),
+        pointerWidth: evaluateProp(pointerWidth, datum, active),
+        width: evaluateProp(width, datum, active),
+        height: evaluateProp(height, datum, active),
+        active: evaluateProp(active, datum, active),
+        text: evaluateProp(text, datum, active)
       }
     );
   }
@@ -220,8 +220,8 @@ export default class VictoryTooltip extends React.Component {
     const flyoutStyle = props.flyoutStyle ?
       defaults({}, props.flyoutStyle, defaultFlyoutStyles) : defaultFlyoutStyles;
     const labelStyle = Array.isArray(baseLabelStyle) ?
-      baseLabelStyle.map((s) => Helpers.evaluateStyle(s, datum, active)) :
-      Helpers.evaluateStyle(baseLabelStyle, datum, active);
+      baseLabelStyle.map((s) => evaluateStyle(s, datum, active)) :
+      evaluateStyle(baseLabelStyle, datum, active);
     const labelSize = TextSize.approximateTextSize(text, labelStyle);
     const flyoutDimensions = this.getDimensions(props, labelSize, labelStyle);
     const flyoutCenter = this.getFlyoutCenter(props, flyoutDimensions);
@@ -367,7 +367,7 @@ export default class VictoryTooltip extends React.Component {
   }
 
   render() {
-    const props = Helpers.modifyProps((this.props), fallbackProps, "tooltip");
+    const props = modifyProps((this.props), fallbackProps, "tooltip");
     return this.renderTooltip(props);
   }
 }

--- a/src/victory-transition/victory-transition.js
+++ b/src/victory-transition/victory-transition.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import VictoryAnimation from "../victory-animation/victory-animation";
 import Collection from "../victory-util/collection";
-import Helpers from "../victory-util/helpers";
+import { getRange } from "../victory-util/helpers";
 import Timer from "../victory-util/timer";
 import Transitions from "../victory-util/transitions";
 import { defaults, isFunction, pick, isObject } from "lodash";
@@ -126,7 +126,7 @@ export default class VictoryTransition extends React.Component {
 
   getClipWidth(props, child) {
     const getDefaultClipWidth = () => {
-      const range = Helpers.getRange(child.props, "x");
+      const range = getRange(child.props, "x");
       return range ? Math.abs(range[1] - range[0]) : props.width;
     };
     const clipWidth = this.transitionProps ? this.transitionProps.clipWidth : undefined;

--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -1,5 +1,5 @@
 import { assign, uniq, range, last, isFunction, property, sortBy } from "lodash";
-import Helpers from "./helpers";
+import { createAccessor } from "./helpers";
 import Collection from "./collection";
 import Scale from "./scale";
 import Immutable from "./immutable";
@@ -81,9 +81,9 @@ export default {
     };
 
     const accessor = {
-      x: Helpers.createAccessor(props.x !== undefined ? props.x : "x"),
-      y: Helpers.createAccessor(props.y !== undefined ? props.y : "y"),
-      y0: Helpers.createAccessor(props.y0 !== undefined ? props.y0 : "y0")
+      x: createAccessor(props.x !== undefined ? props.x : "x"),
+      y: createAccessor(props.y !== undefined ? props.y : "y"),
+      y0: createAccessor(props.y0 !== undefined ? props.y0 : "y0")
     };
 
     const data = dataset.reduce((dataArr, datum, index) => { // eslint-disable-line complexity
@@ -220,7 +220,7 @@ export default {
     }
 
     const key = typeof props[axis] === "undefined" ? axis : props[axis];
-    const accessor = Helpers.createAccessor(key);
+    const accessor = createAccessor(key);
 
     const dataStrings = props.data.reduce((dataArr, datum) => {
       datum = this.parseDatum(datum);

--- a/src/victory-util/default-transitions.js
+++ b/src/victory-util/default-transitions.js
@@ -1,66 +1,65 @@
 /* eslint-disable func-style */
-export default {
-  continuousTransitions() {
-    return {
-      onLoad: {
-        duration: 2000
-      },
-      onExit: {
-        duration: 500
-      },
-      onEnter: {
-        duration: 500
-      }
-    };
-  },
 
-  continuousPolarTransitions() {
-    return {
-      onLoad: {
-        duration: 2000,
-        before: () => ({ _y: 0, _y1: 0, _y0: 0 }),
-        after: (datum) => ({ _y: datum._y, _y1: datum._y1, _y0: datum._y0 })
-      },
-      onExit: {
-        duration: 500,
-        before: (datum, index, data) => {
-          const adjacent = (attr) => {
-            const adj = index === 0 ? data[index + 1] : data[index - 1];
-            return adj[attr];
-          };
-          return { _x: adjacent("_x"), _y: adjacent("_y"), _y0: adjacent("_y0") };
-        }
-      },
-      onEnter: {
-        duration: 500,
-        before: (datum, index, data) => {
-          const adjacent = (attr) => {
-            const adj = index === 0 ? data[index + 1] : data[index - 1];
-            return adj[attr];
-          };
-          return { _x: adjacent("_x"), _y: adjacent("_y"), _y0: adjacent("_y0") };
-        },
-        after: (datum) => ({ _x: datum._x, _y: datum._y, _y1: datum._y1, _y0: datum._y0 })
-      }
-    };
-  },
+export const continuousTransitions = () => {
+  return {
+    onLoad: {
+      duration: 2000
+    },
+    onExit: {
+      duration: 500
+    },
+    onEnter: {
+      duration: 500
+    }
+  };
+};
 
-  discreteTransitions() {
-    return {
-      onLoad: {
-        duration: 2000,
-        before: () => ({ opacity: 0 }),
-        after: (datum) => datum
-      },
-      onExit: {
-        duration: 600,
-        before: () => ({ opacity: 0 })
-      },
-      onEnter: {
-        duration: 600,
-        before: () => ({ opacity: 0 }),
-        after: (datum) => datum
+export const continuousPolarTransitions = () => {
+  return {
+    onLoad: {
+      duration: 2000,
+      before: () => ({ _y: 0, _y1: 0, _y0: 0 }),
+      after: (datum) => ({ _y: datum._y, _y1: datum._y1, _y0: datum._y0 })
+    },
+    onExit: {
+      duration: 500,
+      before: (datum, index, data) => {
+        const adjacent = (attr) => {
+          const adj = index === 0 ? data[index + 1] : data[index - 1];
+          return adj[attr];
+        };
+        return { _x: adjacent("_x"), _y: adjacent("_y"), _y0: adjacent("_y0") };
       }
-    };
-  }
+    },
+    onEnter: {
+      duration: 500,
+      before: (datum, index, data) => {
+        const adjacent = (attr) => {
+          const adj = index === 0 ? data[index + 1] : data[index - 1];
+          return adj[attr];
+        };
+        return { _x: adjacent("_x"), _y: adjacent("_y"), _y0: adjacent("_y0") };
+      },
+      after: (datum) => ({ _x: datum._x, _y: datum._y, _y1: datum._y1, _y0: datum._y0 })
+    }
+  };
+};
+
+export const discreteTransitions = () => {
+  return {
+    onLoad: {
+      duration: 2000,
+      before: () => ({ opacity: 0 }),
+      after: (datum) => datum
+    },
+    onExit: {
+      duration: 600,
+      before: () => ({ opacity: 0 })
+    },
+    onEnter: {
+      duration: 600,
+      before: () => ({ opacity: 0 }),
+      after: (datum) => datum
+    }
+  };
 };

--- a/src/victory-util/default-transitions.js
+++ b/src/victory-util/default-transitions.js
@@ -1,6 +1,6 @@
 /* eslint-disable func-style */
 
-export const continuousTransitions = () => {
+const continuousTransitions = () => {
   return {
     onLoad: {
       duration: 2000
@@ -14,7 +14,7 @@ export const continuousTransitions = () => {
   };
 };
 
-export const continuousPolarTransitions = () => {
+const continuousPolarTransitions = () => {
   return {
     onLoad: {
       duration: 2000,
@@ -45,7 +45,7 @@ export const continuousPolarTransitions = () => {
   };
 };
 
-export const discreteTransitions = () => {
+const discreteTransitions = () => {
   return {
     onLoad: {
       duration: 2000,
@@ -62,4 +62,10 @@ export const discreteTransitions = () => {
       after: (datum) => datum
     }
   };
+};
+
+export {
+  continuousTransitions,
+  continuousPolarTransitions,
+  discreteTransitions
 };

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -1,7 +1,7 @@
 import { flatten, includes, isPlainObject, sortedUniq } from "lodash";
 import Data from "./data";
 import Scale from "./scale";
-import Helpers from "./helpers";
+import { getCurrentAxis, stringTicks, isVertical, getRange } from "./helpers";
 import Collection from "./collection";
 
 export default {
@@ -67,7 +67,7 @@ export default {
     }
     const { horizontal } = props;
     const ensureZero = (domain, dataset) => {
-      const currentAxis = Helpers.getCurrentAxis(axis, horizontal);
+      const currentAxis = getCurrentAxis(axis, horizontal);
       if (currentAxis === "x") {
         return domain;
       } else if (!dataset) {
@@ -114,7 +114,7 @@ export default {
    * @returns {Array} the domain based on data
    */
   getDomainFromData(props, axis, dataset) {
-    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
+    const currentAxis = getCurrentAxis(axis, props.horizontal);
     const flatData = flatten(dataset);
     const allData = flatData.map((datum) => {
       return typeof datum[`_${currentAxis}1`] === "undefined" ?
@@ -165,7 +165,7 @@ export default {
    */
   getDomainFromTickValues(props, axis) {
     let domain;
-    if (Helpers.stringTicks(props)) {
+    if (stringTicks(props)) {
       domain = [1, props.tickValues.length];
     } else {
       // coerce ticks to numbers
@@ -174,7 +174,7 @@ export default {
       domain = props.polar && axis === "x" ?
         this.getSymmetricDomain(initialDomain, ticks) : initialDomain;
     }
-    if (Helpers.isVertical(props)) {
+    if (isVertical(props)) {
       domain.reverse();
     }
     return domain;
@@ -251,7 +251,7 @@ export default {
    * @returns {Array} an array of data arrays grouped by index or category
    */
   getCumulativeData(props, axis, datasets) {
-    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
+    const currentAxis = getCurrentAxis(axis, props.horizontal);
     const otherAxis = currentAxis === "x" ? "y" : "x";
     const categories = [];
     const axisValues = [];
@@ -316,7 +316,7 @@ export default {
 
     const domainMin = Collection.getMinValue(domain);
     const domainMax = Collection.getMaxValue(domain);
-    const range = Helpers.getRange(props, axis);
+    const range = getRange(props, axis);
     const rangeExtent = Math.abs(Math.max(...range) - Math.min(...range));
 
     // Naive initial padding calculation

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -2,155 +2,154 @@ import React from "react";
 import { defaults, isFunction, property, omit, reduce } from "lodash";
 import Collection from "./collection";
 
-export default {
-  getPoint(datum) {
-    const exists = (val) => val !== undefined;
-    const { _x, _x1, _x0, _voronoiX, _y, _y1, _y0, _voronoiY } = datum;
-    const defaultX = exists(_x1) ? _x1 : _x;
-    const defaultY = exists(_y1) ? _y1 : _y;
-    const point = {
-      x: exists(_voronoiX) ? _voronoiX : defaultX,
-      x0: exists(_x0) ? _x0 : _x,
-      y: exists(_voronoiY) ? _voronoiY : defaultY,
-      y0: exists(_y0) ? _y0 : _y
-    };
-    return defaults({}, point, datum);
-  },
+export const getPoint = (datum) => {
+  const exists = (val) => val !== undefined;
+  const { _x, _x1, _x0, _voronoiX, _y, _y1, _y0, _voronoiY } = datum;
+  const defaultX = exists(_x1) ? _x1 : _x;
+  const defaultY = exists(_y1) ? _y1 : _y;
+  const point = {
+    x: exists(_voronoiX) ? _voronoiX : defaultX,
+    x0: exists(_x0) ? _x0 : _x,
+    y: exists(_voronoiY) ? _voronoiY : defaultY,
+    y0: exists(_y0) ? _y0 : _y
+  };
+  return defaults({}, point, datum);
+};
 
-  scalePoint(props, datum) {
-    const { scale, polar } = props;
-    const d = this.getPoint(datum);
-    const origin = props.origin || { x: 0, y: 0 };
-    const x = scale.x(d.x);
-    const x0 = scale.x(d.x0);
-    const y = scale.y(d.y);
-    const y0 = scale.y(d.y0);
-    return {
-      x: polar ? y * Math.cos(x) + origin.x : x,
-      x0: polar ? y0 * Math.cos(x0) + origin.x : x0,
-      y: polar ? -y * Math.sin(x) + origin.y : y,
-      y0: polar ? -y0 * Math.sin(x0) + origin.x : y0
-    };
-  },
+export const scalePoint = (props, datum) => {
+  const { scale, polar } = props;
+  const d = getPoint(datum);
+  const origin = props.origin || { x: 0, y: 0 };
+  const x = scale.x(d.x);
+  const x0 = scale.x(d.x0);
+  const y = scale.y(d.y);
+  const y0 = scale.y(d.y0);
+  return {
+    x: polar ? y * Math.cos(x) + origin.x : x,
+    x0: polar ? y0 * Math.cos(x0) + origin.x : x0,
+    y: polar ? -y * Math.sin(x) + origin.y : y,
+    y0: polar ? -y0 * Math.sin(x0) + origin.x : y0
+  };
+};
 
-  formatPadding(padding) {
-    const paddingVal = typeof padding === "number" ? padding : 0;
-    const paddingObj = typeof padding === "object" ? padding : {};
-    return {
-      top: paddingObj.top || paddingVal,
-      bottom: paddingObj.bottom || paddingVal,
-      left: paddingObj.left || paddingVal,
-      right: paddingObj.right || paddingVal
-    };
-  },
+export const formatPadding = (padding) => {
+  const paddingVal = typeof padding === "number" ? padding : 0;
+  const paddingObj = typeof padding === "object" ? padding : {};
+  return {
+    top: paddingObj.top || paddingVal,
+    bottom: paddingObj.bottom || paddingVal,
+    left: paddingObj.left || paddingVal,
+    right: paddingObj.right || paddingVal
+  };
+};
 
-  getPadding(props) {
-    return this.formatPadding(props.padding);
-  },
+export const getPadding = (props) => {
+  return formatPadding(props.padding);
+};
 
-  getStyles(style, defaultStyles) {
-    const width = "100%";
-    const height = "100%";
-    if (!style) {
-      return defaults({ parent: { height, width } }, defaultStyles);
-    }
-    const { data, labels, parent } = style;
-    const defaultParent = defaultStyles && defaultStyles.parent || {};
-    const defaultLabels = defaultStyles && defaultStyles.labels || {};
-    const defaultData = defaultStyles && defaultStyles.data || {};
-    return {
-      parent: defaults({}, parent, defaultParent, { width, height }),
-      labels: defaults({}, labels, defaultLabels),
-      data: defaults({}, data, defaultData)
-    };
-  },
+export const getStyles = (style, defaultStyles) => {
+  const width = "100%";
+  const height = "100%";
+  if (!style) {
+    return defaults({ parent: { height, width } }, defaultStyles);
+  }
+  const { data, labels, parent } = style;
+  const defaultParent = defaultStyles && defaultStyles.parent || {};
+  const defaultLabels = defaultStyles && defaultStyles.labels || {};
+  const defaultData = defaultStyles && defaultStyles.data || {};
+  return {
+    parent: defaults({}, parent, defaultParent, { width, height }),
+    labels: defaults({}, labels, defaultLabels),
+    data: defaults({}, data, defaultData)
+  };
+};
 
-  evaluateProp(prop, data, active) {
-    return isFunction(prop) ? prop(data, active) : prop;
-  },
+export const evaluateProp = (prop, data, active) => {
+  return isFunction(prop) ? prop(data, active) : prop;
+};
 
-  evaluateStyle(style, data, active) {
-    if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
-      return style;
-    }
-    return Object.keys(style).reduce((prev, curr) => {
-      prev[curr] = this.evaluateProp(style[curr], data, active);
-      return prev;
-    }, {});
-  },
+export const evaluateStyle = (style, data, active) => {
+  if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
+    return style;
+  }
+  return Object.keys(style).reduce((prev, curr) => {
+    prev[curr] = evaluateProp(style[curr], data, active);
+    return prev;
+  }, {});
+};
 
-  degreesToRadians(degrees) {
-    return degrees * (Math.PI / 180);
-  },
+export const degreesToRadians = (degrees) => {
+  return degrees * (Math.PI / 180);
+};
 
-  radiansToDegrees(radians) {
-    return radians / (Math.PI / 180);
-  },
+export const radiansToDegrees = (radians) => {
+  return radians / (Math.PI / 180);
+};
 
-  getRadius(props) {
-    const { left, right, top, bottom } = this.getPadding(props);
-    const { width, height } = props;
-    return Math.min(width - left - right, height - top - bottom) / 2;
-  },
+export const getRadius = (props) => {
+  const { left, right, top, bottom } = getPadding(props);
+  const { width, height } = props;
+  return Math.min(width - left - right, height - top - bottom) / 2;
+};
 
-  getPolarOrigin(props) {
-    const { width, height } = props;
-    const { top, bottom, left, right } = this.getPadding(props);
-    const radius = Math.min(width - left - right, height - top - bottom) / 2;
-    const offsetWidth = width / 2 + left - right;
-    const offsetHeight = height / 2 + top - bottom;
-    return {
-      x: offsetWidth + radius > width ? radius + left - right : offsetWidth,
-      y: offsetHeight + radius > height ? radius + top - bottom : offsetHeight
-    };
-  },
+export const getPolarOrigin = (props) => {
+  const { width, height } = props;
+  const { top, bottom, left, right } = getPadding(props);
+  const radius = Math.min(width - left - right, height - top - bottom) / 2;
+  const offsetWidth = width / 2 + left - right;
+  const offsetHeight = height / 2 + top - bottom;
+  return {
+    x: offsetWidth + radius > width ? radius + left - right : offsetWidth,
+    y: offsetHeight + radius > height ? radius + top - bottom : offsetHeight
+  };
+};
 
-  getRange(props, axis) {
-    if (props.range && props.range[axis]) {
-      return props.range[axis];
-    } else if (props.range && Array.isArray(props.range)) {
-      return props.range;
-    }
-    return props.polar ? this.getPolarRange(props, axis) : this.getCartesianRange(props, axis);
-  },
+export const getCartesianRange = (props, axis) => {
+  // determine how to lay the axis and what direction positive and negative are
+  const isVertical = axis !== "x";
+  const padding = getPadding(props);
+  if (isVertical) {
+    return [props.height - padding.bottom, padding.top];
+  }
+  return [padding.left, props.width - padding.right];
+};
 
-  getCartesianRange(props, axis) {
-    // determine how to lay the axis and what direction positive and negative are
-    const isVertical = axis !== "x";
-    const padding = this.getPadding(props);
-    if (isVertical) {
-      return [props.height - padding.bottom, padding.top];
-    }
-    return [padding.left, props.width - padding.right];
-  },
+export const getPolarRange = (props, axis) => {
+  if (axis === "x") {
+    const startAngle = degreesToRadians(props.startAngle || 0);
+    const endAngle = degreesToRadians(props.endAngle || 360);
+    return [startAngle, endAngle];
+  }
+  return [props.innerRadius || 0, getRadius(props)];
+};
 
-  getPolarRange(props, axis) {
-    if (axis === "x") {
-      const startAngle = this.degreesToRadians(props.startAngle || 0);
-      const endAngle = this.degreesToRadians(props.endAngle || 360);
-      return [startAngle, endAngle];
-    }
-    return [props.innerRadius || 0, this.getRadius(props)];
-  },
+export const getRange = (props, axis) => {
+  if (props.range && props.range[axis]) {
+    return props.range[axis];
+  } else if (props.range && Array.isArray(props.range)) {
+    return props.range;
+  }
+  return props.polar ? getPolarRange(props, axis) : getCartesianRange(props, axis);
+};
 
-  createAccessor(key) {
-    // creates a data accessor function
-    // given a property key, path, array index, or null for identity.
-    if (isFunction(key)) {
-      return key;
-    } else if (key === null || typeof key === "undefined") {
-      // null/undefined means "return the data item itself"
-      return (x) => x;
-    }
-    // otherwise, assume it is an array index, property key or path (_.property handles all three)
-    return property(key);
-  },
+export const createAccessor = (key) => {
+  // creates a data accessor function
+  // given a property key, path, array index, or null for identity.
+  if (isFunction(key)) {
+    return key;
+  } else if (key === null || typeof key === "undefined") {
+    // null/undefined means "return the data item itself"
+    return (x) => x;
+  }
+  // otherwise, assume it is an array index, property key or path (_.property handles all three)
+  return property(key);
+};
 
-  modifyProps(props, fallbackProps, role) {
-    const theme = props.theme && props.theme[role] ? props.theme[role] : {};
-    const themeProps = omit(theme, ["style"]);
-    return defaults({}, props, themeProps, fallbackProps);
-  },
+export const modifyProps = (props, fallbackProps, role) => {
+  const theme = props.theme && props.theme[role] ? props.theme[role] : {};
+  const themeProps = omit(theme, ["style"]);
+  return defaults({}, props, themeProps, fallbackProps);
+};
 
   // Axis helpers
 
@@ -160,51 +159,50 @@ export default {
    * @param {Boolean} horizontal: true when the chart is flipped to the horizontal orientation
    * @returns {String} the dimension appropriate for the axis given its props "x" or "y"
    */
-  getCurrentAxis(axis, horizontal) {
-    const otherAxis = axis === "x" ? "y" : "x";
-    return horizontal ? otherAxis : axis;
-  },
+export const getCurrentAxis = (axis, horizontal) => {
+  const otherAxis = axis === "x" ? "y" : "x";
+  return horizontal ? otherAxis : axis;
+};
 
   /**
    * @param {Object} props: axis component props
    * @returns {Boolean} true when the axis is vertical
    */
-  isVertical(props) {
-    const orientation = props.orientation || (props.dependentAxis ? "left" : "bottom");
-    const vertical = { top: false, bottom: false, left: true, right: true };
-    return vertical[orientation];
-  },
+export const isVertical = (props) => {
+  const orientation = props.orientation || (props.dependentAxis ? "left" : "bottom");
+  const vertical = { top: false, bottom: false, left: true, right: true };
+  return vertical[orientation];
+};
 
   /**
    * @param {Object} props: axis component props
    * @returns {Boolean} true when tickValues contain strings
    */
-  stringTicks(props) {
-    return props.tickValues !== undefined && Collection.containsStrings(props.tickValues);
-  },
+export const stringTicks = (props) => {
+  return props.tickValues !== undefined && Collection.containsStrings(props.tickValues);
+};
 
   /**
    * @param {Array} children: an array of child components
    * @param {Function} iteratee: a function with arguments "child", "childName", and "parent"
    * @returns {Array} returns an array of results from calling the iteratee on all nested children
    */
-  reduceChildren(children, iteratee) {
-    let childIndex = 0;
-    const traverseChildren = (childArray, parent) => {
-      return reduce(childArray, (memo, child) => {
-        const childName = child.props.name || childIndex;
-        childIndex++;
-        if (child.props && child.props.children) {
-          const nestedChildren = React.Children.toArray(child.props.children);
-          const nestedResults = traverseChildren(nestedChildren, child);
-          memo = memo.concat(nestedResults);
-        } else {
-          const result = iteratee(child, childName, parent);
-          memo = result ? memo.concat(result) : memo;
-        }
-        return memo;
-      }, []);
-    };
-    return traverseChildren(children);
-  }
+export const reduceChildren = (children, iteratee) => {
+  let childIndex = 0;
+  const traverseChildren = (childArray, parent) => {
+    return reduce(childArray, (memo, child) => {
+      const childName = child.props.name || childIndex;
+      childIndex++;
+      if (child.props && child.props.children) {
+        const nestedChildren = React.Children.toArray(child.props.children);
+        const nestedResults = traverseChildren(nestedChildren, child);
+        memo = memo.concat(nestedResults);
+      } else {
+        const result = iteratee(child, childName, parent);
+        memo = result ? memo.concat(result) : memo;
+      }
+      return memo;
+    }, []);
+  };
+  return traverseChildren(children);
 };

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -2,7 +2,7 @@ import React from "react";
 import { defaults, isFunction, property, omit, reduce } from "lodash";
 import Collection from "./collection";
 
-export const getPoint = (datum) => {
+const getPoint = (datum) => {
   const exists = (val) => val !== undefined;
   const { _x, _x1, _x0, _voronoiX, _y, _y1, _y0, _voronoiY } = datum;
   const defaultX = exists(_x1) ? _x1 : _x;
@@ -16,7 +16,7 @@ export const getPoint = (datum) => {
   return defaults({}, point, datum);
 };
 
-export const scalePoint = (props, datum) => {
+const scalePoint = (props, datum) => {
   const { scale, polar } = props;
   const d = getPoint(datum);
   const origin = props.origin || { x: 0, y: 0 };
@@ -32,7 +32,7 @@ export const scalePoint = (props, datum) => {
   };
 };
 
-export const formatPadding = (padding) => {
+const formatPadding = (padding) => {
   const paddingVal = typeof padding === "number" ? padding : 0;
   const paddingObj = typeof padding === "object" ? padding : {};
   return {
@@ -43,11 +43,11 @@ export const formatPadding = (padding) => {
   };
 };
 
-export const getPadding = (props) => {
+const getPadding = (props) => {
   return formatPadding(props.padding);
 };
 
-export const getStyles = (style, defaultStyles) => {
+const getStyles = (style, defaultStyles) => {
   const width = "100%";
   const height = "100%";
   if (!style) {
@@ -64,11 +64,11 @@ export const getStyles = (style, defaultStyles) => {
   };
 };
 
-export const evaluateProp = (prop, data, active) => {
+const evaluateProp = (prop, data, active) => {
   return isFunction(prop) ? prop(data, active) : prop;
 };
 
-export const evaluateStyle = (style, data, active) => {
+const evaluateStyle = (style, data, active) => {
   if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
     return style;
   }
@@ -78,21 +78,21 @@ export const evaluateStyle = (style, data, active) => {
   }, {});
 };
 
-export const degreesToRadians = (degrees) => {
+const degreesToRadians = (degrees) => {
   return degrees * (Math.PI / 180);
 };
 
-export const radiansToDegrees = (radians) => {
+const radiansToDegrees = (radians) => {
   return radians / (Math.PI / 180);
 };
 
-export const getRadius = (props) => {
+const getRadius = (props) => {
   const { left, right, top, bottom } = getPadding(props);
   const { width, height } = props;
   return Math.min(width - left - right, height - top - bottom) / 2;
 };
 
-export const getPolarOrigin = (props) => {
+const getPolarOrigin = (props) => {
   const { width, height } = props;
   const { top, bottom, left, right } = getPadding(props);
   const radius = Math.min(width - left - right, height - top - bottom) / 2;
@@ -104,7 +104,7 @@ export const getPolarOrigin = (props) => {
   };
 };
 
-export const getCartesianRange = (props, axis) => {
+const getCartesianRange = (props, axis) => {
   // determine how to lay the axis and what direction positive and negative are
   const isVertical = axis !== "x";
   const padding = getPadding(props);
@@ -114,7 +114,7 @@ export const getCartesianRange = (props, axis) => {
   return [padding.left, props.width - padding.right];
 };
 
-export const getPolarRange = (props, axis) => {
+const getPolarRange = (props, axis) => {
   if (axis === "x") {
     const startAngle = degreesToRadians(props.startAngle || 0);
     const endAngle = degreesToRadians(props.endAngle || 360);
@@ -123,7 +123,7 @@ export const getPolarRange = (props, axis) => {
   return [props.innerRadius || 0, getRadius(props)];
 };
 
-export const getRange = (props, axis) => {
+const getRange = (props, axis) => {
   if (props.range && props.range[axis]) {
     return props.range[axis];
   } else if (props.range && Array.isArray(props.range)) {
@@ -132,7 +132,7 @@ export const getRange = (props, axis) => {
   return props.polar ? getPolarRange(props, axis) : getCartesianRange(props, axis);
 };
 
-export const createAccessor = (key) => {
+const createAccessor = (key) => {
   // creates a data accessor function
   // given a property key, path, array index, or null for identity.
   if (isFunction(key)) {
@@ -145,7 +145,7 @@ export const createAccessor = (key) => {
   return property(key);
 };
 
-export const modifyProps = (props, fallbackProps, role) => {
+const modifyProps = (props, fallbackProps, role) => {
   const theme = props.theme && props.theme[role] ? props.theme[role] : {};
   const themeProps = omit(theme, ["style"]);
   return defaults({}, props, themeProps, fallbackProps);
@@ -159,7 +159,7 @@ export const modifyProps = (props, fallbackProps, role) => {
    * @param {Boolean} horizontal: true when the chart is flipped to the horizontal orientation
    * @returns {String} the dimension appropriate for the axis given its props "x" or "y"
    */
-export const getCurrentAxis = (axis, horizontal) => {
+const getCurrentAxis = (axis, horizontal) => {
   const otherAxis = axis === "x" ? "y" : "x";
   return horizontal ? otherAxis : axis;
 };
@@ -168,7 +168,7 @@ export const getCurrentAxis = (axis, horizontal) => {
    * @param {Object} props: axis component props
    * @returns {Boolean} true when the axis is vertical
    */
-export const isVertical = (props) => {
+const isVertical = (props) => {
   const orientation = props.orientation || (props.dependentAxis ? "left" : "bottom");
   const vertical = { top: false, bottom: false, left: true, right: true };
   return vertical[orientation];
@@ -178,7 +178,7 @@ export const isVertical = (props) => {
    * @param {Object} props: axis component props
    * @returns {Boolean} true when tickValues contain strings
    */
-export const stringTicks = (props) => {
+const stringTicks = (props) => {
   return props.tickValues !== undefined && Collection.containsStrings(props.tickValues);
 };
 
@@ -187,7 +187,7 @@ export const stringTicks = (props) => {
    * @param {Function} iteratee: a function with arguments "child", "childName", and "parent"
    * @returns {Array} returns an array of results from calling the iteratee on all nested children
    */
-export const reduceChildren = (children, iteratee) => {
+const reduceChildren = (children, iteratee) => {
   let childIndex = 0;
   const traverseChildren = (childArray, parent) => {
     return reduce(childArray, (memo, child) => {
@@ -205,4 +205,27 @@ export const reduceChildren = (children, iteratee) => {
     }, []);
   };
   return traverseChildren(children);
+};
+
+export {
+  getPoint,
+  scalePoint,
+  getPadding,
+  formatPadding,
+  getStyles,
+  evaluateProp,
+  evaluateStyle,
+  degreesToRadians,
+  radiansToDegrees,
+  getRadius,
+  getPolarOrigin,
+  getCartesianRange,
+  getPolarRange,
+  getRange,
+  createAccessor,
+  modifyProps,
+  getCurrentAxis,
+  isVertical,
+  stringTicks,
+  reduceChildren
 };

--- a/src/victory-util/label-helpers.js
+++ b/src/victory-util/label-helpers.js
@@ -1,162 +1,160 @@
-import Helpers from "./helpers";
+import { evaluateProp, scalePoint, degreesToRadians, radiansToDegrees, getPoint } from "./helpers";
 
-export default {
-  getText(props, datum, index) {
-    if (datum.label !== undefined) {
-      return datum.label;
-    }
-    return Array.isArray(props.labels) ? props.labels[index] : props.labels;
-  },
+export const getText = (props, datum, index) => {
+  if (datum.label !== undefined) {
+    return datum.label;
+  }
+  return Array.isArray(props.labels) ? props.labels[index] : props.labels;
+};
 
-  getVerticalAnchor(props, datum) {
-    const sign = datum._y >= 0 ? 1 : -1;
-    const labelStyle = props.style && props.style.labels || {};
-    if (datum.getVerticalAnchor || labelStyle.verticalAnchor) {
-      return datum.getVerticalAnchor || labelStyle.verticalAnchor;
-    } else if (!props.horizontal) {
-      return sign >= 0 ? "end" : "start";
-    } else {
-      return "middle";
-    }
-  },
+export const getVerticalAnchor = (props, datum) => {
+  const sign = datum._y >= 0 ? 1 : -1;
+  const labelStyle = props.style && props.style.labels || {};
+  if (datum.getVerticalAnchor || labelStyle.verticalAnchor) {
+    return datum.getVerticalAnchor || labelStyle.verticalAnchor;
+  } else if (!props.horizontal) {
+    return sign >= 0 ? "end" : "start";
+  } else {
+    return "middle";
+  }
+};
 
-  getTextAnchor(props, datum) {
-    const { style, horizontal } = props;
-    const sign = datum._y >= 0 ? 1 : -1;
-    const labelStyle = style && style.labels || {};
-    if (datum.getVerticalAnchor || labelStyle.verticalAnchor) {
-      return datum.getVerticalAnchor || labelStyle.verticalAnchor;
-    } else if (!horizontal) {
-      return "middle";
-    } else {
-      return sign >= 0 ? "start" : "end";
-    }
-  },
+export const getTextAnchor = (props, datum) => {
+  const { style, horizontal } = props;
+  const sign = datum._y >= 0 ? 1 : -1;
+  const labelStyle = style && style.labels || {};
+  if (datum.getVerticalAnchor || labelStyle.verticalAnchor) {
+    return datum.getVerticalAnchor || labelStyle.verticalAnchor;
+  } else if (!horizontal) {
+    return "middle";
+  } else {
+    return sign >= 0 ? "start" : "end";
+  }
+};
 
-  getAngle(props, datum) {
-    const labelStyle = props.style && props.style.labels || {};
-    return datum.angle || labelStyle.angle;
-  },
+export const getAngle = (props, datum) => {
+  const labelStyle = props.style && props.style.labels || {};
+  return datum.angle || labelStyle.angle;
+};
 
-  getPadding(props, datum) {
-    const { horizontal, style, active } = props;
-    const labelStyle = style.labels || {};
-    const defaultPadding = Helpers.evaluateProp(labelStyle.padding, datum, active) || 0;
-    const sign = datum._y < 0 ? -1 : 1;
+export const getPadding = (props, datum) => {
+  const { horizontal, style, active } = props;
+  const labelStyle = style.labels || {};
+  const defaultPadding = evaluateProp(labelStyle.padding, datum, active) || 0;
+  const sign = datum._y < 0 ? -1 : 1;
+  return {
+    x: horizontal ? sign * defaultPadding : 0,
+    y: horizontal ? 0 : sign * defaultPadding
+  };
+};
+
+export const getDegrees = (props, datum) => {
+  const { x } = getPoint(datum);
+  return radiansToDegrees(props.scale.x(x));
+};
+
+export const getPolarPadding = (props, datum) => {
+  const { active, style } = props;
+  const degrees = getDegrees(props, datum);
+  const labelStyle = style.labels || {};
+  const padding = evaluateProp(labelStyle.padding, datum, active) || 0;
+  const angle = degreesToRadians(degrees);
+  return {
+    x: padding * Math.cos(angle), y: -padding * Math.sin(angle)
+  };
+};
+
+export const getPosition = (props, datum) => {
+  const { horizontal, polar } = props;
+  const { x, y } = scalePoint(props, datum);
+  const padding = getPadding(props, datum);
+  if (!polar) {
     return {
-      x: horizontal ? sign * defaultPadding : 0,
-      y: horizontal ? 0 : sign * defaultPadding
+      x: horizontal ? y + padding.x : x + padding.x,
+      y: horizontal ? x + padding.y : y - padding.y
     };
-  },
-
-  getPosition(props, datum) {
-    const { horizontal, polar } = props;
-    const { x, y } = Helpers.scalePoint(props, datum);
-    const padding = this.getPadding(props, datum);
-    if (!polar) {
-      return {
-        x: horizontal ? y + padding.x : x + padding.x,
-        y: horizontal ? x + padding.y : y - padding.y
-      };
-    } else {
-      const polarPadding = this.getPolarPadding(props, datum);
-      return {
-        x: x + polarPadding.x,
-        y: y + polarPadding.y
-      };
-    }
-  },
-
-  getPolarPadding(props, datum) {
-    const { active, style } = props;
-    const degrees = this.getDegrees(props, datum);
-    const labelStyle = style.labels || {};
-    const padding = Helpers.evaluateProp(labelStyle.padding, datum, active) || 0;
-    const angle = Helpers.degreesToRadians(degrees);
+  } else {
+    const polarPadding = getPolarPadding(props, datum);
     return {
-      x: padding * Math.cos(angle), y: -padding * Math.sin(angle)
-    };
-  },
-
-  getLabelPlacement(props) {
-    const { labelComponent, labelPlacement, polar } = props;
-    const defaultLabelPlacement = polar ? "perpendicular" : "vertical";
-    return labelPlacement ?
-      labelPlacement :
-      labelComponent.props && labelComponent.props.labelPlacement || defaultLabelPlacement;
-  },
-
-  getPolarOrientation(degrees) {
-    if (degrees < 45 || degrees > 315) { // eslint-disable-line no-magic-numbers
-      return "right";
-    } else if (degrees >= 45 && degrees <= 135) { // eslint-disable-line no-magic-numbers
-      return "top";
-    } else if (degrees > 135 && degrees < 225) { // eslint-disable-line no-magic-numbers
-      return "left";
-    } else {
-      return "bottom";
-    }
-  },
-
-  getPolarTextAnchor(props, degrees) {
-    const labelPlacement = this.getLabelPlacement(props);
-    if (
-      labelPlacement === "perpendicular" ||
-      labelPlacement === "vertical" && (degrees === 90 || degrees === 270)
-    ) {
-      return "middle";
-    }
-    return degrees <= 90 || degrees > 270 ? "start" : "end";
-  },
-
-  getPolarVerticalAnchor(props, degrees) {
-    const labelPlacement = this.getLabelPlacement(props);
-    const orientation = this.getPolarOrientation(degrees);
-    if (labelPlacement === "parallel" || orientation === "left" || orientation === "right") {
-      return "middle";
-    }
-    return orientation === "top" ? "end" : "start";
-  },
-
-  getPolarAngle(props, baseAngle) {
-    const { labelPlacement, datum } = props;
-    if (!labelPlacement || labelPlacement === "vertical") {
-      return 0;
-    }
-    const degrees = baseAngle !== undefined ? baseAngle : this.getDegrees(props, datum);
-    const sign = (degrees > 90 && degrees < 180 || degrees > 270) ? 1 : -1;
-    let angle;
-    if (degrees === 0 || degrees === 180) {
-      angle = 90;
-    } else if (degrees > 0 && degrees < 180) {
-      angle = 90 - degrees;
-    } else if (degrees > 180 && degrees < 360) {
-      angle = 270 - degrees;
-    }
-    const labelRotation = labelPlacement === "perpendicular" ? 0 : 90;
-    return angle + sign * labelRotation;
-  },
-
-  getDegrees(props, datum) {
-    const { x } = Helpers.getPoint(datum);
-    return Helpers.radiansToDegrees(props.scale.x(x));
-  },
-
-  getProps(props, index) {
-    const { scale, data, style, horizontal, polar } = props;
-    const datum = data[index];
-    const degrees = this.getDegrees(props, datum);
-    const textAnchor = polar ?
-      this.getPolarTextAnchor(props, degrees) : this.getTextAnchor(props, datum);
-    const verticalAnchor = polar ?
-       this.getPolarVerticalAnchor(props, degrees) : this.getVerticalAnchor(props, datum);
-    const angle = this.getAngle(props, datum);
-    const text = this.getText(props, datum, index);
-    const labelPlacement = this.getLabelPlacement(props);
-    const { x, y } = this.getPosition(props, datum);
-    return {
-      angle, data, datum, horizontal, index, polar, scale, labelPlacement,
-      text, textAnchor, verticalAnchor, x, y, style: style.labels
+      x: x + polarPadding.x,
+      y: y + polarPadding.y
     };
   }
+};
+
+export const getLabelPlacement = (props) => {
+  const { labelComponent, labelPlacement, polar } = props;
+  const defaultLabelPlacement = polar ? "perpendicular" : "vertical";
+  return labelPlacement ?
+    labelPlacement :
+    labelComponent.props && labelComponent.props.labelPlacement || defaultLabelPlacement;
+};
+
+export const getPolarOrientation = (degrees) => {
+  if (degrees < 45 || degrees > 315) { // eslint-disable-line no-magic-numbers
+    return "right";
+  } else if (degrees >= 45 && degrees <= 135) { // eslint-disable-line no-magic-numbers
+    return "top";
+  } else if (degrees > 135 && degrees < 225) { // eslint-disable-line no-magic-numbers
+    return "left";
+  } else {
+    return "bottom";
+  }
+};
+
+export const getPolarTextAnchor = (props, degrees) => {
+  const labelPlacement = getLabelPlacement(props);
+  if (
+    labelPlacement === "perpendicular" ||
+    labelPlacement === "vertical" && (degrees === 90 || degrees === 270)
+  ) {
+    return "middle";
+  }
+  return degrees <= 90 || degrees > 270 ? "start" : "end";
+};
+
+export const getPolarVerticalAnchor = (props, degrees) => {
+  const labelPlacement = getLabelPlacement(props);
+  const orientation = getPolarOrientation(degrees);
+  if (labelPlacement === "parallel" || orientation === "left" || orientation === "right") {
+    return "middle";
+  }
+  return orientation === "top" ? "end" : "start";
+};
+
+export const getPolarAngle = (props, baseAngle) => {
+  const { labelPlacement, datum } = props;
+  if (!labelPlacement || labelPlacement === "vertical") {
+    return 0;
+  }
+  const degrees = baseAngle !== undefined ? baseAngle : getDegrees(props, datum);
+  const sign = (degrees > 90 && degrees < 180 || degrees > 270) ? 1 : -1;
+  let angle;
+  if (degrees === 0 || degrees === 180) {
+    angle = 90;
+  } else if (degrees > 0 && degrees < 180) {
+    angle = 90 - degrees;
+  } else if (degrees > 180 && degrees < 360) {
+    angle = 270 - degrees;
+  }
+  const labelRotation = labelPlacement === "perpendicular" ? 0 : 90;
+  return angle + sign * labelRotation;
+};
+
+export const getProps = (props, index) => {
+  const { scale, data, style, horizontal, polar } = props;
+  const datum = data[index];
+  const degrees = getDegrees(props, datum);
+  const textAnchor = polar ?
+    getPolarTextAnchor(props, degrees) : getTextAnchor(props, datum);
+  const verticalAnchor = polar ?
+     getPolarVerticalAnchor(props, degrees) : getVerticalAnchor(props, datum);
+  const angle = getAngle(props, datum);
+  const text = getText(props, datum, index);
+  const labelPlacement = getLabelPlacement(props);
+  const { x, y } = getPosition(props, datum);
+  return {
+    angle, data, datum, horizontal, index, polar, scale, labelPlacement,
+    text, textAnchor, verticalAnchor, x, y, style: style.labels
+  };
 };

--- a/src/victory-util/label-helpers.js
+++ b/src/victory-util/label-helpers.js
@@ -1,4 +1,10 @@
-import { evaluateProp, scalePoint, degreesToRadians, radiansToDegrees, getPoint } from "./helpers";
+import {
+  evaluateProp,
+  scalePoint,
+  degreesToRadians,
+  radiansToDegrees,
+  getPoint
+} from "./helpers";
 
 const getText = (props, datum, index) => {
   if (datum.label !== undefined) {

--- a/src/victory-util/label-helpers.js
+++ b/src/victory-util/label-helpers.js
@@ -1,13 +1,13 @@
 import { evaluateProp, scalePoint, degreesToRadians, radiansToDegrees, getPoint } from "./helpers";
 
-export const getText = (props, datum, index) => {
+const getText = (props, datum, index) => {
   if (datum.label !== undefined) {
     return datum.label;
   }
   return Array.isArray(props.labels) ? props.labels[index] : props.labels;
 };
 
-export const getVerticalAnchor = (props, datum) => {
+const getVerticalAnchor = (props, datum) => {
   const sign = datum._y >= 0 ? 1 : -1;
   const labelStyle = props.style && props.style.labels || {};
   if (datum.getVerticalAnchor || labelStyle.verticalAnchor) {
@@ -19,7 +19,7 @@ export const getVerticalAnchor = (props, datum) => {
   }
 };
 
-export const getTextAnchor = (props, datum) => {
+const getTextAnchor = (props, datum) => {
   const { style, horizontal } = props;
   const sign = datum._y >= 0 ? 1 : -1;
   const labelStyle = style && style.labels || {};
@@ -32,12 +32,12 @@ export const getTextAnchor = (props, datum) => {
   }
 };
 
-export const getAngle = (props, datum) => {
+const getAngle = (props, datum) => {
   const labelStyle = props.style && props.style.labels || {};
   return datum.angle || labelStyle.angle;
 };
 
-export const getPadding = (props, datum) => {
+const getPadding = (props, datum) => {
   const { horizontal, style, active } = props;
   const labelStyle = style.labels || {};
   const defaultPadding = evaluateProp(labelStyle.padding, datum, active) || 0;
@@ -48,12 +48,12 @@ export const getPadding = (props, datum) => {
   };
 };
 
-export const getDegrees = (props, datum) => {
+const getDegrees = (props, datum) => {
   const { x } = getPoint(datum);
   return radiansToDegrees(props.scale.x(x));
 };
 
-export const getPolarPadding = (props, datum) => {
+const getPolarPadding = (props, datum) => {
   const { active, style } = props;
   const degrees = getDegrees(props, datum);
   const labelStyle = style.labels || {};
@@ -64,7 +64,7 @@ export const getPolarPadding = (props, datum) => {
   };
 };
 
-export const getPosition = (props, datum) => {
+const getPosition = (props, datum) => {
   const { horizontal, polar } = props;
   const { x, y } = scalePoint(props, datum);
   const padding = getPadding(props, datum);
@@ -82,7 +82,7 @@ export const getPosition = (props, datum) => {
   }
 };
 
-export const getLabelPlacement = (props) => {
+const getLabelPlacement = (props) => {
   const { labelComponent, labelPlacement, polar } = props;
   const defaultLabelPlacement = polar ? "perpendicular" : "vertical";
   return labelPlacement ?
@@ -90,7 +90,7 @@ export const getLabelPlacement = (props) => {
     labelComponent.props && labelComponent.props.labelPlacement || defaultLabelPlacement;
 };
 
-export const getPolarOrientation = (degrees) => {
+const getPolarOrientation = (degrees) => {
   if (degrees < 45 || degrees > 315) { // eslint-disable-line no-magic-numbers
     return "right";
   } else if (degrees >= 45 && degrees <= 135) { // eslint-disable-line no-magic-numbers
@@ -102,7 +102,7 @@ export const getPolarOrientation = (degrees) => {
   }
 };
 
-export const getPolarTextAnchor = (props, degrees) => {
+const getPolarTextAnchor = (props, degrees) => {
   const labelPlacement = getLabelPlacement(props);
   if (
     labelPlacement === "perpendicular" ||
@@ -113,7 +113,7 @@ export const getPolarTextAnchor = (props, degrees) => {
   return degrees <= 90 || degrees > 270 ? "start" : "end";
 };
 
-export const getPolarVerticalAnchor = (props, degrees) => {
+const getPolarVerticalAnchor = (props, degrees) => {
   const labelPlacement = getLabelPlacement(props);
   const orientation = getPolarOrientation(degrees);
   if (labelPlacement === "parallel" || orientation === "left" || orientation === "right") {
@@ -122,7 +122,7 @@ export const getPolarVerticalAnchor = (props, degrees) => {
   return orientation === "top" ? "end" : "start";
 };
 
-export const getPolarAngle = (props, baseAngle) => {
+const getPolarAngle = (props, baseAngle) => {
   const { labelPlacement, datum } = props;
   if (!labelPlacement || labelPlacement === "vertical") {
     return 0;
@@ -141,7 +141,7 @@ export const getPolarAngle = (props, baseAngle) => {
   return angle + sign * labelRotation;
 };
 
-export const getProps = (props, index) => {
+const getProps = (props, index) => {
   const { scale, data, style, horizontal, polar } = props;
   const datum = data[index];
   const degrees = getDegrees(props, datum);
@@ -157,4 +157,21 @@ export const getProps = (props, index) => {
     angle, data, datum, horizontal, index, polar, scale, labelPlacement,
     text, textAnchor, verticalAnchor, x, y, style: style.labels
   };
+};
+
+export {
+  getText,
+  getVerticalAnchor,
+  getTextAnchor,
+  getAngle,
+  getPadding,
+  getDegrees,
+  getPolarPadding,
+  getPosition,
+  getLabelPlacement,
+  getPolarOrientation,
+  getPolarTextAnchor,
+  getPolarVerticalAnchor,
+  getPolarAngle,
+  getProps
 };

--- a/src/victory-util/log.js
+++ b/src/victory-util/log.js
@@ -2,12 +2,10 @@
 /* eslint-disable no-console */
 
 // TODO: Use "warning" npm module like React is switching to.
-export default {
-  warn(message) {
-    if (process.env.NODE_ENV !== "production") {
-      if (console && console.warn) {
-        console.warn(message);
-      }
+export const warn = (message) => {
+  if (process.env.NODE_ENV !== "production") {
+    if (console && console.warn) {
+      console.warn(message);
     }
   }
 };

--- a/src/victory-util/prop-types.js
+++ b/src/victory-util/prop-types.js
@@ -1,6 +1,6 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]*/
 import { isFunction, find } from "lodash";
-import Log from "./log";
+import { warn } from "./log";
 import PropTypes from "prop-types";
 
 /**
@@ -76,7 +76,7 @@ export default {
     return (props, propName, componentName) => {
       const value = props[propName];
       if (value !== null && value !== undefined) {
-        Log.warn(
+        warn(
           `"${propName}" property of "${componentName}" has been deprecated ${explanation}`
         );
       }

--- a/src/victory-util/scale.js
+++ b/src/victory-util/scale.js
@@ -1,5 +1,5 @@
 import { includes, isFunction } from "lodash";
-import Helpers from "./helpers";
+import { createAccessor } from "./helpers";
 import Collection from "./collection";
 import * as d3Scale from "d3-scale";
 
@@ -72,7 +72,7 @@ export default {
     if (!props.data) {
       return "linear";
     }
-    const accessor = Helpers.createAccessor(props[axis]);
+    const accessor = createAccessor(props[axis]);
     const axisData = props.data.map(accessor);
     return Collection.containsDates(axisData) ? "time" : "linear";
   },

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -2,7 +2,7 @@
 /* eslint max-nested-callbacks: 0 */
 /* global sinon */
 
-import { Data, Domain, Helpers } from "src/index";
+import { Data, Domain } from "src/index";
 
 describe("helpers/domain", () => {
   describe("padDomain", () => {
@@ -92,38 +92,22 @@ describe("helpers/domain", () => {
   });
 
   describe("getDomainFromTickValues", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Helpers, "isVertical");
-      sandbox.spy(Helpers, "stringTicks");
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
 
     it("determines a domain from tickValues", () => {
       const props = { tickValues: [1, 2, 3] };
       const domainResult = Domain.getDomainFromTickValues(props);
-      expect(Helpers.stringTicks).calledWith(props).and.returned(false);
-      expect(Helpers.isVertical).calledWith(props).and.returned(false);
       expect(domainResult).to.eql([1, 3]);
     });
 
     it("determines a domain from string tick values", () => {
       const props = { tickValues: ["a", "b", "c", "d"] };
       const domainResult = Domain.getDomainFromTickValues(props);
-      expect(Helpers.stringTicks).calledWith(props).and.returned(true);
-      expect(Helpers.isVertical).calledWith(props).and.returned(false);
       expect(domainResult).to.eql([1, 4]);
     });
 
     it("reverses a domain from tickValues when the axis is vertical", () => {
       const props = { tickValues: [1, 2, 3], dependentAxis: true };
       const domainResult = Domain.getDomainFromTickValues(props);
-      expect(Helpers.stringTicks).calledWith(props).and.returned(false);
-      expect(Helpers.isVertical).calledWith(props).and.returned(true);
       expect(domainResult).to.eql([3, 1]);
     });
   });

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -1,16 +1,18 @@
 /* eslint no-unused-expressions: 0 */
-import Helpers from "src/victory-util/helpers";
+import { evaluateProp, evaluateStyle,
+         getRange, getStyles, getPadding,
+         createAccessor, isVertical } from "src/victory-util/helpers";
 
 describe("helpers", () => {
   describe("evaluateProp", () => {
     const data = { x: 3, y: 2 };
     it("evaluates functional props", () => {
       const testProp = (datum) => datum.y > 0 ? "red" : "blue";
-      expect(Helpers.evaluateProp(testProp, data)).to.equal("red");
+      expect(evaluateProp(testProp, data)).to.equal("red");
     });
     it("doesn't alter non-functional props", () => {
       const testProp = "blue";
-      expect(Helpers.evaluateProp(testProp, data)).to.equal("blue");
+      expect(evaluateProp(testProp, data)).to.equal("blue");
     });
   });
 
@@ -21,7 +23,7 @@ describe("helpers", () => {
         color: (datum) => datum.y > 0 ? "red" : "blue",
         size: 5
       };
-      expect(Helpers.evaluateStyle(style, data)).to.deep.equal({ color: "red", size: 5 });
+      expect(evaluateStyle(style, data)).to.deep.equal({ color: "red", size: 5 });
     });
   });
 
@@ -32,10 +34,10 @@ describe("helpers", () => {
       padding: 0
     };
     it("returns a range based on props and axis", () => {
-      expect(Helpers.getRange(props, "x")).to.be.an("array")
+      expect(getRange(props, "x")).to.be.an("array")
         .and.to.have.length(2)
         .and.to.include.members([0, 100]);
-      expect(Helpers.getRange(props, "y")).to.be.an("array")
+      expect(getRange(props, "y")).to.be.an("array")
         .and.to.have.length(2)
         .and.to.include.members([0, 200]);
     });
@@ -49,7 +51,7 @@ describe("helpers", () => {
     };
     it("merges styles", () => {
       const style = { data: { fill: "red" }, labels: { fontSize: 12 } };
-      const styles = Helpers.getStyles(style, defaultStyles);
+      const styles = getStyles(style, defaultStyles);
       expect(styles.parent).to.deep.equal({ border: "black", width: "100%", height: "100%" });
       expect(styles.data).to.deep.equal({ fill: "red", stroke: "black" });
       expect(styles.labels).to.deep.equal({ fontSize: 12, fontFamily: "Helvetica" });
@@ -59,41 +61,41 @@ describe("helpers", () => {
   describe("getPadding", () => {
     it("sets padding from a single number", () => {
       const props = { padding: 40 };
-      expect(Helpers.getPadding(props)).to.deep.equal({ top: 40, bottom: 40, left: 40, right: 40 });
+      expect(getPadding(props)).to.deep.equal({ top: 40, bottom: 40, left: 40, right: 40 });
     });
     it("sets padding from a complete object", () => {
       const props = {
         padding: { top: 20, bottom: 40, left: 60, right: 80 }
       };
-      expect(Helpers.getPadding(props)).to.deep.equal(props.padding);
+      expect(getPadding(props)).to.deep.equal(props.padding);
     });
     it("fills missing values with 0", () => {
       const props = {
         padding: { top: 40, bottom: 40 }
       };
-      expect(Helpers.getPadding(props)).to.deep.equal({ top: 40, bottom: 40, left: 0, right: 0 });
+      expect(getPadding(props)).to.deep.equal({ top: 40, bottom: 40, left: 0, right: 0 });
     });
   });
 
   describe("createAccessor", () => {
     it("creates a valid object accessor from a property key", () => {
-      const accessor = Helpers.createAccessor("k");
+      const accessor = createAccessor("k");
       expect(accessor({ k: 42 })).to.eql(42);
     });
 
     it("creates a valid array accessor from an index", () => {
-      const accessor = Helpers.createAccessor(2);
+      const accessor = createAccessor(2);
       expect(accessor([3, 4, 5])).to.eql(5);
     });
 
     it("creates a valid array accessor from a deeply nested path", () => {
-      const accessor = Helpers.createAccessor("x.y[0].0.z");
+      const accessor = createAccessor("x.y[0].0.z");
       expect(accessor({ x: { y: [[{ z: 1987 }]] } })).to.eql(1987);
     });
 
     it("creates a value (passthrough) accessor from null/undefined", () => {
-      const nullAccessor = Helpers.createAccessor(null);
-      const undefinedAccessor = Helpers.createAccessor(undefined);
+      const nullAccessor = createAccessor(null);
+      const undefinedAccessor = createAccessor(undefined);
       expect(nullAccessor("ok")).to.eql("ok");
       expect(undefinedAccessor(14)).to.eql(14);
     });
@@ -102,13 +104,13 @@ describe("helpers", () => {
   describe("isVertical", () => {
     it("returns true when the orientation is vertical", () => {
       const props = { orientation: "left" };
-      const verticalResult = Helpers.isVertical(props);
+      const verticalResult = isVertical(props);
       expect(verticalResult).to.equal(true);
     });
 
     it("returns false when the orientation is horizontal", () => {
       const props = { orientation: "bottom" };
-      const verticalResult = Helpers.isVertical(props);
+      const verticalResult = isVertical(props);
       expect(verticalResult).to.equal(false);
     });
   });

--- a/test/client/spec/victory-util/helpers.spec.js
+++ b/test/client/spec/victory-util/helpers.spec.js
@@ -1,7 +1,13 @@
 /* eslint no-unused-expressions: 0 */
-import { evaluateProp, evaluateStyle,
-         getRange, getStyles, getPadding,
-         createAccessor, isVertical } from "src/victory-util/helpers";
+import {
+  evaluateProp,
+  evaluateStyle,
+  getRange,
+  getStyles,
+  getPadding,
+  createAccessor,
+  isVertical
+} from "src/victory-util/helpers";
 
 describe("helpers", () => {
   describe("evaluateProp", () => {


### PR DESCRIPTION
Issue:  [#650](https://github.com/FormidableLabs/victory/issues/650)

Export all standalone methods individually as named exports, instead of export all helpers as a default export in the form of an object. This made some reordering of the functions necessary as all functions called by other functions in the same file needs to be defined above the calling functions.

Just as in [#574](https://github.com/FormidableLabs/victory-chart/pull/574), all classes with tests that use sinon.stub() and sinon.spy() were skipped.