### PR TITLE
Render line on top of area so it isn't partially hidden

### DIFF
--- a/src/victory-primitives/area.js
+++ b/src/victory-primitives/area.js
@@ -84,6 +84,6 @@ export default class Area extends React.Component {
       key: "area-stroke", style: assign({}, style, { fill: "none" }), d: lineFunction(data)
     }, sharedProps)) : null;
 
-    return renderLine ? React.cloneElement(groupComponent, {}, [line, area]) : area;
+    return renderLine ? React.cloneElement(groupComponent, {}, [area, line]) : area;
   }
 }


### PR DESCRIPTION
The Area component currently renders the stroke element below the area. This causes weird effects like this:

<img width="703" alt="screen shot 2018-03-05 at 11 50 54 am" src="https://user-images.githubusercontent.com/17031/36988797-bdeda3f2-206d-11e8-9404-0d7732ef477d.png">

Don't see here? Here, let me bump up the stroke width:

<img width="650" alt="screen shot 2018-03-05 at 11 51 22 am" src="https://user-images.githubusercontent.com/17031/36988808-c6909870-206d-11e8-97dd-42772ed69ff8.png">

The issue is that half of the bar is hidden underneath the area. Even without this visual glitch, if you give it a `strokeWidth` of 10 it's only going to show 5 pixels because the area is hiding half of it.

Here's how it looks with my fix:

<img width="685" alt="screen shot 2018-03-05 at 11 50 14 am" src="https://user-images.githubusercontent.com/17031/36988870-f1606468-206d-11e8-9b7c-2779dd15281c.png">

I can't see why this was intentional, so hopefully this is an easy merge. Let me know if there's anything else I can do!