### PR TITLE
Fix exception when number of children reduces in transition

### DIFF
--- a/src/victory-util/transitions.js
+++ b/src/victory-util/transitions.js
@@ -92,7 +92,7 @@ function getInitialTransitionState(oldChildren, nextChildren) {
 
   const getTransitionsFromChildren = (old, next) => {
     return old.map((child, idx) => {
-      if (child && child.props && child.props.children) {
+      if (child && child.props && child.props.children && next[idx]) {
         return getTransitionsFromChildren(
           React.Children.toArray(old[idx].props.children),
           React.Children.toArray(next[idx].props.children)


### PR DESCRIPTION
I have an animated `<VictoryChart />` with a list of `<VictoryGroup />`s. When reducing the list of groups, I got an exception in this line, that `next[idx]` is `null` and therefore `props` are not accessible. This addition fixes the problem and returns the behaviour back to what's expected.