### PR TITLE
Use sanitizeStyle on Primitive Components

### DIFF
--- a/src/victory-primitives/circle.js
+++ b/src/victory-primitives/circle.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
+import { sanitizeStyle } from "../victory-util/style";
 
 export default class Circle extends React.Component {
   static propTypes = {
@@ -30,7 +31,7 @@ export default class Circle extends React.Component {
         className={className}
         clipPath={clipPath}
         transform={transform}
-        style={style}
+        style={sanitizeStyle(style)}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         vectorEffect="non-scaling-stroke"

--- a/src/victory-primitives/circle.js
+++ b/src/victory-primitives/circle.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
-import { sanitizeStyle } from "../victory-util/style";
+import { sanitizeSvgStyle } from "../victory-util/style";
 
 export default class Circle extends React.Component {
   static propTypes = {
@@ -31,7 +31,7 @@ export default class Circle extends React.Component {
         className={className}
         clipPath={clipPath}
         transform={transform}
-        style={sanitizeStyle(style)}
+        style={sanitizeSvgStyle(style)}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         vectorEffect="non-scaling-stroke"

--- a/src/victory-primitives/line.js
+++ b/src/victory-primitives/line.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
-import { sanitizeStyle } from "../victory-util/style";
+import { sanitizeSvgStyle } from "../victory-util/style";
 
 export default class Line extends React.Component {
   static propTypes = {
@@ -32,7 +32,7 @@ export default class Line extends React.Component {
         className={className}
         clipPath={clipPath}
         transform={transform}
-        style={sanitizeStyle(style)}
+        style={sanitizeSvgStyle(style)}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         vectorEffect="non-scaling-stroke"

--- a/src/victory-primitives/line.js
+++ b/src/victory-primitives/line.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
+import { sanitizeStyle } from "../victory-util/style";
 
 export default class Line extends React.Component {
   static propTypes = {
@@ -31,7 +32,7 @@ export default class Line extends React.Component {
         className={className}
         clipPath={clipPath}
         transform={transform}
-        style={style}
+        style={sanitizeStyle(style)}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         vectorEffect="non-scaling-stroke"

--- a/src/victory-primitives/path.js
+++ b/src/victory-primitives/path.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
+import { sanitizeStyle } from "../victory-util/style";
 
 export default class Path extends React.Component {
   static propTypes = {
@@ -26,7 +27,7 @@ export default class Path extends React.Component {
         transform={transform}
         className={className}
         clipPath={clipPath}
-        style={style}
+        style={sanitizeStyle(style)}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         {...events}

--- a/src/victory-primitives/path.js
+++ b/src/victory-primitives/path.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
-import { sanitizeStyle } from "../victory-util/style";
+import { sanitizeSvgStyle } from "../victory-util/style";
 
 export default class Path extends React.Component {
   static propTypes = {
@@ -27,7 +27,7 @@ export default class Path extends React.Component {
         transform={transform}
         className={className}
         clipPath={clipPath}
-        style={sanitizeStyle(style)}
+        style={sanitizeSvgStyle(style)}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
         {...events}

--- a/src/victory-primitives/rect.js
+++ b/src/victory-primitives/rect.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
+import { sanitizeStyle } from "../victory-util/style";
 
 export default class Rect extends React.Component {
   static propTypes = {
@@ -33,7 +34,7 @@ export default class Rect extends React.Component {
         x={x} y={y} rx={rx} ry={ry} width={width} height={height}
         className={className}
         clipPath={clipPath}
-        style={style}
+        style={sanitizeStyle(style)}
         transform={transform}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}

--- a/src/victory-primitives/rect.js
+++ b/src/victory-primitives/rect.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
-import { sanitizeStyle } from "../victory-util/style";
+import { sanitizeSvgStyle } from "../victory-util/style";
 
 export default class Rect extends React.Component {
   static propTypes = {
@@ -34,7 +34,7 @@ export default class Rect extends React.Component {
         x={x} y={y} rx={rx} ry={ry} width={width} height={height}
         className={className}
         clipPath={clipPath}
-        style={sanitizeStyle(style)}
+        style={sanitizeSvgStyle(style)}
         transform={transform}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}

--- a/src/victory-primitives/text.js
+++ b/src/victory-primitives/text.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
-import { sanitizeStyle } from "../victory-util/style";
+import { sanitizeSvgStyle } from "../victory-util/style";
 
 export default class Text extends React.Component {
   static propTypes = {
@@ -29,7 +29,7 @@ export default class Text extends React.Component {
     return (
       <text
         className={className} x={x} dx={dx} y={y} dy={dy}
-        transform={transform} style={sanitizeStyle(style)}
+        transform={transform} style={sanitizeSvgStyle(style)}
         {...events}
       >
         {title && <title>{title}</title>}

--- a/src/victory-primitives/text.js
+++ b/src/victory-primitives/text.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
+import { sanitizeStyle } from "../victory-util/style";
 
 export default class Text extends React.Component {
   static propTypes = {
@@ -28,7 +29,7 @@ export default class Text extends React.Component {
     return (
       <text
         className={className} x={x} dx={dx} y={y} dy={dy}
-        transform={transform} style={style}
+        transform={transform} style={sanitizeStyle(style)}
         {...events}
       >
         {title && <title>{title}</title>}

--- a/src/victory-primitives/tspan.js
+++ b/src/victory-primitives/tspan.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
-import { sanitizeStyle } from "../victory-util/style";
+import { sanitizeSvgStyle } from "../victory-util/style";
 
 export default class TSpan extends React.Component {
   static propTypes = {
@@ -28,7 +28,7 @@ export default class TSpan extends React.Component {
       <tspan
         x={x} y={y} dx={dx} dy={dy} textAnchor={textAnchor}
         className={className}
-        style={sanitizeStyle(style)}
+        style={sanitizeSvgStyle(style)}
         {...events}
       >
         {content}

--- a/src/victory-primitives/tspan.js
+++ b/src/victory-primitives/tspan.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collection from "../victory-util/collection";
+import { sanitizeStyle } from "../victory-util/style";
 
 export default class TSpan extends React.Component {
   static propTypes = {
@@ -27,7 +28,7 @@ export default class TSpan extends React.Component {
       <tspan
         x={x} y={y} dx={dx} dy={dy} textAnchor={textAnchor}
         className={className}
-        style={style}
+        style={sanitizeStyle(style)}
         {...events}
       >
         {content}

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -3,6 +3,7 @@ import { pick } from "lodash";
 /**
  * Acceptable CSS/SVG style attributes
  * https://react-cn.github.io/react/docs/tags-and-attributes.html#svg-attributes
+ * "x" and "y" are not on this whitelist, as they are sent by separate props
  */
 const styleWhitelist = [
   "angle", "clipPath", "cx", "cy", "d", "dx", "dy", "fill", "fillOpacity", "fontFamily",
@@ -10,9 +11,9 @@ const styleWhitelist = [
   "markerMid", "markerStart", "offset", "opacity", "patternContentUnits", "patternUnits",
   "points", "preserveAspectRatio", "r", "rx", "ry", "spreadMethod", "stopColor", "stopOpacity",
   "stroke", "strokeDasharray", "strokeLinecap", "strokeOpacity", "strokeWidth", "textAnchor",
-  "transform", "version", "verticalAnchor", "viewBox", "width", "x1", "x2", "x", "xlinkActuate",
+  "transform", "version", "verticalAnchor", "viewBox", "width", "x1", "x2", "xlinkActuate",
   "xlinkArcrole", "xlinkHref", "xlinkRole", "xlinkShow", "xlinkTitle", "xlinkType", "xmlBase",
-  "xmlLang", "xmlSpace", "y1", "y2", "y"
+  "xmlLang", "xmlSpace", "y1", "y2"
 ];
 
 /**

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -22,7 +22,7 @@ const styleWhitelist = [
  * @param {Object} data An object of user-input style attributes.
  * @returns {Object} An object containing only valid style data.
  */
-export const sanitizeStyle = function (data) {
+export const sanitizeSvgStyle = function (data) {
   return pick(data, styleWhitelist);
 };
 

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -3,27 +3,36 @@ import { pick } from "lodash";
 /**
  * Acceptable CSS/SVG style attributes
  * https://react-cn.github.io/react/docs/tags-and-attributes.html#svg-attributes
- * "x" and "y" are not on this whitelist, as they are sent by separate props
+ * non-style properties have been removed from this list
  */
-const styleWhitelist = [
-  "angle", "clipPath", "cx", "cy", "d", "dx", "dy", "fill", "fillOpacity", "fontFamily",
-  "fontSize", "fx", "fy", "gradientTransform", "gradientUnits", "height", "markerEnd",
-  "markerMid", "markerStart", "offset", "opacity", "patternContentUnits", "patternUnits",
-  "points", "preserveAspectRatio", "r", "rx", "ry", "spreadMethod", "stopColor", "stopOpacity",
-  "stroke", "strokeDasharray", "strokeLinecap", "strokeOpacity", "strokeWidth", "textAnchor",
-  "transform", "version", "verticalAnchor", "viewBox", "width", "x1", "x2", "xlinkActuate",
-  "xlinkArcrole", "xlinkHref", "xlinkRole", "xlinkShow", "xlinkTitle", "xlinkType", "xmlBase",
-  "xmlLang", "xmlSpace", "y1", "y2"
+const svgStyleWhitelist = [
+  "fill",
+  "fillOpacity",
+  "fontFamily",
+  "fontSize",
+  "height",
+  "markerEnd",
+  "markerMid",
+  "markerStart",
+  "opacity",
+  "points",
+  "stroke",
+  "strokeDasharray",
+  "strokeLinecap",
+  "strokeOpacity",
+  "strokeWidth",
+  "textAnchor",
+  "transform"
 ];
 
 /**
  * Given an object with CSS/SVG style attributes, return a new object containing
  * only keys that are also on our SVG style whitelist.
- * @param {Object} data An object of user-input style attributes.
+ * @param {Object} style An object of user-input style attributes.
  * @returns {Object} An object containing only valid style data.
  */
-export const sanitizeSvgStyle = function (data) {
-  return pick(data, styleWhitelist);
+export const sanitizeSvgStyle = function (style) {
+  return pick(style, svgStyleWhitelist);
 };
 
 /**

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -22,7 +22,7 @@ const styleWhitelist = [
  * @param {Object} data An object of user-input style attributes.
  * @returns {Object} An object containing only valid style data.
  */
-export const sanitizeStyleProps = function (data) {
+export const sanitizeStyle = function (data) {
   return pick(data, styleWhitelist);
 };
 

--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -22,7 +22,7 @@ const styleWhitelist = [
  * @param {Object} data An object of user-input style attributes.
  * @returns {Object} An object containing only valid style data.
  */
-const sanitizeStyleProps = function (data) {
+export const sanitizeStyleProps = function (data) {
   return pick(data, styleWhitelist);
 };
 
@@ -57,7 +57,6 @@ const toTransformString = function (obj, ...more) {
 
 export default {
 
-  sanitizeStyleProps,
   toTransformString,
 
   /**

--- a/test/client/spec/victory-util/style.spec.js
+++ b/test/client/spec/victory-util/style.spec.js
@@ -1,9 +1,9 @@
-import { Style } from "src/index";
+import Style, { sanitizeStyle } from "src/victory-util/style";
 
-describe("sanitizeStyleProps", () => {
+describe("sanitizeStyle", () => {
   it("drop invalid svg attributes", () => {
     const data = { tree: "blue", stroke: "#c43a31" };
-    expect(Style.sanitizeStyleProps(data)).to.deep.equal({ stroke: "#c43a31" });
+    expect(sanitizeStyle(data)).to.deep.equal({ stroke: "#c43a31" });
   });
 });
 

--- a/test/client/spec/victory-util/style.spec.js
+++ b/test/client/spec/victory-util/style.spec.js
@@ -1,9 +1,9 @@
-import Style, { sanitizeStyle } from "src/victory-util/style";
+import Style, { sanitizeSvgStyle } from "src/victory-util/style";
 
-describe("sanitizeStyle", () => {
+describe("sanitizeSvgStyle", () => {
   it("drop invalid svg attributes", () => {
     const data = { tree: "blue", stroke: "#c43a31" };
-    expect(sanitizeStyle(data)).to.deep.equal({ stroke: "#c43a31" });
+    expect(sanitizeSvgStyle(data)).to.deep.equal({ stroke: "#c43a31" });
   });
 });
 


### PR DESCRIPTION
## First Approach (not current anymore)

### `Helpers.evaluateStyle` now uses `sanitizeStyle`

This will ensure proper a `style` prop for _most_ victory primitives

### What about primitives that don't call `Helpers.evaluateStyle`?

Not all primitives call `Helpers.evaluateStyle`. We could replace `style={style}` in their renders, BUT I believe this is a needless expense (and would cause `style` to run through `sanitizeStyle` twice (once in the parent primitive and once in the child primitive).

#### used only internally and `Helpers.evaluateStyle` is always called on `style` before sent to primitive

- Circle
- Path
- Rect

#### used only internally and aren't called with data style

- TSpan
- Text

#### are used externally but not with arbitrary style

- Line (victory-boxplot)
- Whisker (victory-boxplot)
