### PR TITLE
Replace Collection.checkEquality with "fast-deep-equal"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
       "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
@@ -3522,9 +3522,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.2.0",
     "d3-timer": "^1.0.0",
+    "fast-deep-equal": "^1.1.0",
     "lodash": "^4.17.5"
   },
   "devDependencies": {

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -101,7 +101,6 @@ export default {
   `areVictoryPropsEqual` does the following:
     - marks any two Functions as equal
     - returns false when checking the equality of things like `1` vs. `Object(1)`
-    - ignores circular references in objects and arrays and returns false
     (see the tests for more specifics)
   */
   areVictoryPropsEqual(a, b) {

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -1,4 +1,5 @@
 import { isEqual, keys, isEmpty, isPlainObject } from "lodash";
+import fastDeepEqual from "fast-deep-equal";
 
 export default {
   isNonEmptyArray(collection) {
@@ -106,7 +107,7 @@ export default {
     - Does not handle circular references in objects and arrays
   */
   areVictoryPropsEqual(a, b) {
-    return this.checkEquality(a, b);
+    return fastDeepEqual(a, b);
   },
 
   // Broken into a separate method for ease of unit testing

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -1,4 +1,3 @@
-import { isEqual, keys, isEmpty, isPlainObject } from "lodash";
 import fastDeepEqual from "fast-deep-equal";
 
 export default {
@@ -94,7 +93,7 @@ export default {
    */
   allSetsEqual(itemSets) {
     return itemSets.every((comparisonSet) => {
-      return isEqual(comparisonSet[0], comparisonSet[1]);
+      return fastDeepEqual(comparisonSet[0], comparisonSet[1]);
     });
   },
 

--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -99,51 +99,13 @@ export default {
   },
 
   /*
-  Custom equality checking for props in shouldComponentUpdate.
-  `areVictoryPropsEqual` differs from lodash `isEqual` in the following ways:
-    - Functions are marked as equal (this was the main impetus for writing a new function)
-    - Does not handle symbols or maps
-    - Returns false when checking the equality of things like `1` vs. `Object(1)`
-    - Does not handle circular references in objects and arrays
+  `areVictoryPropsEqual` does the following:
+    - marks any two Functions as equal
+    - returns false when checking the equality of things like `1` vs. `Object(1)`
+    - ignores circular references in objects and arrays and returns false
+    (see the tests for more specifics)
   */
   areVictoryPropsEqual(a, b) {
     return fastDeepEqual(a, b);
-  },
-
-  // Broken into a separate method for ease of unit testing
-  checkEquality(o1, o2) {
-    /*
-      tri-state equality checker: returns `true`, `false`, or `undefined`. When `undefined` is
-      returned this indicates that further (resursive) equality checking is required
-    */
-    const basicEqualityCheck = (a, b) => {
-      if (a === b) { return true; }
-      if (typeof a !== typeof b) { return false; }
-      // isEqual does not support equality checking on functions
-      // return true if a and b are both functions
-      if (typeof a === "function") { return true; }
-      if (typeof a === "object" && keys(a).length !== keys(b).length) { return false; }
-      if (typeof a !== "object" || keys(a).length === 0) { return isEqual(a, b); }
-      return undefined;
-    };
-
-    const initialEquality = basicEqualityCheck(o1, o2);
-    if (typeof initialEquality === "boolean") { return initialEquality; }
-    return keys(o1).reduce((equal, key) => {
-      if (!equal) { return false; }
-      const val1 = o1[key];
-      const val2 = o2[key];
-      const equality = basicEqualityCheck(val1, val2);
-      if (typeof equality === "boolean") { return equality; }
-      if (isPlainObject(val1)) {
-        return !isPlainObject(val2) ?
-          false : (isEmpty(val1) && isEmpty(val2)) || this.checkEquality(val1, val2);
-      } else if (Array.isArray(val1)) {
-        return !Array.isArray(val2) ?
-          false : (isEmpty(val1) && isEmpty(val2)) || this.checkEquality(val1, val2);
-      } else {
-        return isEqual(val1, val2);
-      }
-    }, true);
   }
 };

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -327,6 +327,16 @@ describe("collections", () => {
       });
     });
 
+    it("does not hang on circular structures", () => {
+      const obj = {};
+      obj.self = obj;
+      const a = { x: obj };
+      const b = { x: obj };
+      const c = { y: obj };
+      expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
+      expect(Collection.areVictoryPropsEqual(a, c)).to.equal(false);
+    });
+
     it("correctly distinguishes null, NaN and undefined", () => {
       const pairs = [
         // a, b, shouldAEqualB

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -222,7 +222,7 @@ describe("collections", () => {
 
     it("returns true if values are functions", () => {
       const a = { test: () => "a" };
-      const b = { test: () => "a" };
+      const b = { test: () => "b" };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
     });
 
@@ -339,7 +339,6 @@ describe("collections", () => {
         [undefined, undefined, true],
         [undefined, null, false],
         [undefined, "", false],
-        [NaN, NaN, true],
         [NaN, "a", false],
         [NaN, Infinity, false]
       ];

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -184,7 +184,6 @@ describe("collections", () => {
     let sandbox;
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
-      sandbox.spy(Collection, "checkEquality");
     });
     afterEach(() => {
       sandbox.restore();

--- a/test/client/spec/victory-util/collection.spec.js
+++ b/test/client/spec/victory-util/collection.spec.js
@@ -194,35 +194,30 @@ describe("collections", () => {
       const a = { test: { nested: "a" } };
       const b = a;
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
-      expect(Collection.checkEquality).calledOnce.and.returned(true);
     });
 
     it("returns early when nested collections are not the same length", () => {
       const a = { test: { nested: "a" }, test2: { nested: "b" } };
       const b = { test: { nested: "a" } };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(false);
-      expect(Collection.checkEquality).calledOnce.and.returned(false);
     });
 
     it("returns early if values are not the same type", () => {
       const a = { test: { nested: "a" } };
       const b = { test: () => "a" };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(false);
-      expect(Collection.checkEquality).calledOnce.and.returned(false);
     });
 
     it("returns early when nested elements are empty", () => {
       const a = { a: [] };
       const b = { a: [] };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
-      expect(Collection.checkEquality).calledOnce.and.returned(true);
     });
 
     it("returns false for mixed objects and arrays", () => {
       const a = { a: [] };
       const b = { a: {} };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(false);
-      expect(Collection.checkEquality).calledOnce.and.returned(false);
     });
 
     it("returns true if values are functions", () => {
@@ -235,49 +230,42 @@ describe("collections", () => {
       const a = { test: { nested: "a" }, test2: { nested: "a" } };
       const b = { test: { nested: "a" }, test2: { nested: "a" } };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
-      expect(Collection.checkEquality).calledThrice;
     });
 
     it("finds differences in deeply nested objects", () => {
       const a = { a: 1, b: 2, test: { nested: { deep: "a" } } };
       const b = { a: 1, b: 2, test: { nested: { deep: "b" } } };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(false);
-      expect(Collection.checkEquality).calledThrice;
     });
 
     it("returns early when shallow differences are found in deeply nested objects", () => {
       const a = { a: 1, b: 2, test: { nested: { deep: "a" } } };
       const b = { a: 2, b: 2, test: { nested: { deep: "b" } } };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(false);
-      expect(Collection.checkEquality).calledOnce;
     });
 
     it("recursively checks equality for nested arrays", () => {
       const a = [ 1, [2, "3", [4]]];
       const b = [ 1, [2, "3", [4]]];
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
-      expect(Collection.checkEquality).calledThrice;
     });
 
     it("finds differences in deeply nested arrays", () => {
       const a = [ 1, [2, "3", [4]]];
       const b = [ 1, [2, "3", [5]]];
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(false);
-      expect(Collection.checkEquality).calledThrice;
     });
 
     it("returns early when shallow differences are found in deeply nested arrays", () => {
       const a = [ 1, [2, "3", [4]]];
       const b = [ 2, [2, "3", [5]]];
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(false);
-      expect(Collection.checkEquality).calledOnce;
     });
 
     it("recursively checks equality for mixed collections", () => {
       const a = [ 1, [2, "3", { a: 4 }]];
       const b = [ 1, [2, "3", { a: 4 }]];
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
-      expect(Collection.checkEquality).calledThrice;
     });
 
     it("compares objects regardless of key order", () => {
@@ -290,7 +278,6 @@ describe("collections", () => {
       const a = { test: new Date(2010, 2, 1), test2: new Date(2010, 1, 1) };
       const b = { test: new Date(2010, 2, 1), test2: new Date(2010, 1, 1) };
       expect(Collection.areVictoryPropsEqual(a, b)).to.equal(true);
-      expect(Collection.checkEquality).calledOnce.and.returned(true);
     });
 
     it("returns equal for equivalent date objects", () => {
@@ -343,14 +330,21 @@ describe("collections", () => {
 
     it("correctly distinguishes null, NaN and undefined", () => {
       const pairs = [
-        [null, null, true], [null, undefined, false], [null, {}, false], [null, "", false],
-        [null, 0, false], [undefined, undefined, true], [undefined, null, false],
-        [undefined, "", false], [NaN, NaN, true], [NaN, "a", false], [NaN, Infinity, false]
+        // a, b, shouldAEqualB
+        [null, null, true],
+        [null, undefined, false],
+        [null, {}, false],
+        [null, "", false],
+        [null, 0, false],
+        [undefined, undefined, true],
+        [undefined, null, false],
+        [undefined, "", false],
+        [NaN, NaN, true],
+        [NaN, "a", false],
+        [NaN, Infinity, false]
       ];
       pairs.forEach((vals) => {
-        const a = vals[0];
-        const b = vals[1];
-        const expected = vals[2];
+        const [a, b, expected] = vals;
         expect(Collection.areVictoryPropsEqual(a, b)).to.equal(expected);
       });
     });


### PR DESCRIPTION
## Motivation

`Collection.checkEquality` is a performance bottleneck. This makes sense, as it saves us for an even bigger bottleneck: needless rerenders. Here's an example of the bottleneck: https://github.com/FormidableLabs/victory/issues/935.

## Proposed Solution

The https://github.com/epoberezkin/fast-deep-equal project has put a ton of work into make a very fast deep equals. If we could use this we might see a large perf improvement (spoiler: we do).

## Simple Benchmark

I compared `fast-deep-equal` with our `Collection.checkEquality` and `lodash.isEqual` with benchmarkjs:

`Collection.checkEquality` x _149,452 ops/sec_ ±0.79% (89 runs sampled)
`lodash.isEqual` x _189,525 ops/sec_ ±1.08% (87 runs sampled)
`fast-deep-equal` x _977,734 ops/sec_ ±1.04% (85 runs sampled)

The comparison featured one "large" set of props (15 key/value pairs, some nested) and one "small" set of props (1 key/value pair). This is a naive comparison, but even so it is very promising (6.5x faster!).

## Real-World Benchmark

Using the [example codepen](https://codepen.io/Eseb/pen/aqjRNy) from the aforementioned (https://github.com/FormidableLabs/victory/issues/935) I compared `Collection.checkEquality` to `fast-deep-equal` in `Collection.areVictoryPropsEqual`.

`Collection.checkEquality` _4.4 FPS_
`fast-deep-equal` _7.9 FPS_

## Correctness

`fast-deep-equal` is very very close to `checkEquality` logically. Out of the box it passes every one of the `checkEquality` tests *except one*.

The only difference concerns `NaN`:

```javascript
checkEquality(NaN, NaN); // true
fastDeepEqual(NaN, NaN); // false
NaN === NaN; // false
```

Which leads to...

## Open Question: NaN

(I wanted to make a garlic NaN joke but I just can't. I'm sorry)

### Should we keep our handling of `NaN === NaN`?

If we wanted to do this could have a custom version of `fast-deep-equal` (it's [very simple](https://github.com/epoberezkin/fast-deep-equal)) that handled `NaN`. If we wanted to keep perf up, we could remove the handling from the function that we don't need (e.g. RegEx).

There are pros and cons to each:

*Yes, keep the handling*: it will help us skip re-renders when dealing with `NaN` (if we have every `NaN` equal to every other). It won't be hard at all to maintain a fork of such a simple library.

*No*: It'd be best to just use `fast-deep-equal` off the shelf. Besides, how many real-world applications are performance bound by `NaN`? It's probably a bug if you are trying to render a lot of `NaN`s.

## Next Steps

- edit tests (they check for number of times `checkEquality` executes)
- replace the one use of `lodash.isEqual` with `fast-deep-equal`.
- remove `checkEquality` completely from the code.
- edit/remove comments from `areVictoryPropsEqual` (as we are using a library, and the tests specify what happens)