### PR TITLE
Bug in victory-util/add-events

### DIFF
--- a/src/victory-util/add-events.js
+++ b/src/victory-util/add-events.js
@@ -54,7 +54,7 @@ export default (WrappedComponent, options) => {
       }
 
       // check whether external mutations match
-      if (!Collection.areVictoryPropsEqual(this.externaMutations, externalMutations)) {
+      if (!Collection.areVictoryPropsEqual(this.externalMutations, externalMutations)) {
         this.cacheValues(calculatedValues);
         return true;
       }


### PR DESCRIPTION
the `shouldComponentUpdate` in `victory-util/add-events` has a clear typo, but I wanted to check before I fixed it. The bug causes the component to update anytime an external mutation is anything but `undefined`.

```javascript
if (!Collection.areVictoryPropsEqual(this.externaMutations, externalMutations)) {
```

No `this.externaMutations` exists; but if we corrected the spelling to `this.externalMutations` I don't think that would fix it either, as I cannot find that anywhere in this file (or anywhere in `victory-core`). 

`applyExternalMutations` has the only `setState` in the component:
```
this.setState(externalMutations, compiledCallbacks);
```

It _looks_ like `externalMutations` is the entire `this.state`, so the typo line in question should be 

```
if (!Collection.areVictoryPropsEqual(this.state, externalMutations)) {
```

Is that correct?