### PR TITLE
patch: fast-deep-equal will warn on call stack size exceeded, not crash

### DIFF
--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -104,6 +104,11 @@ export default {
     (see the tests for more specifics)
   */
   areVictoryPropsEqual(a, b) {
-    return fastDeepEqual(a, b);
+    try {
+      return fastDeepEqual(a, b);
+    } catch (err) {
+      console.warn("VictoryError: fastDeepEqual. https://github.com/FormidableLabs/victory/issues/964"); //eslint-disable-line
+      return false;
+    }
   }
 };


### PR DESCRIPTION
temporary fix for victory-pie while we get to the root of the issue. see https://github.com/FormidableLabs/victory/issues/964