### PR TITLE
add fast-deep-equal locally

### DIFF
--- a/src/victory-util/collection.js
+++ b/src/victory-util/collection.js
@@ -1,6 +1,4 @@
-import fastDeepEqual from "fast-deep-equal";
-
-import Log from "./log";
+import fastDeepEqual from "./fast-deep-equal";
 
 export default {
   isNonEmptyArray(collection) {
@@ -106,11 +104,6 @@ export default {
     (see the tests for more specifics)
   */
   areVictoryPropsEqual(a, b) {
-    try {
-      return fastDeepEqual(a, b);
-    } catch (err) {
-      Log.warn("VictoryError: fastDeepEqual. https://github.com/FormidableLabs/victory/issues/964");
-      return false;
-    }
+    return fastDeepEqual(a, b);
   }
 };

--- a/src/victory-util/fast-deep-equal.js
+++ b/src/victory-util/fast-deep-equal.js
@@ -1,0 +1,105 @@
+/*
+MIT License
+
+Copyright (c) 2018 Formidable Labs
+Copyright (c) 2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/* eslint-disable */
+var isArray = Array.isArray;
+var keyList = Object.keys;
+var hasProp = Object.prototype.hasOwnProperty;
+
+function equal(a, b) {
+  if (a === b) return true;
+
+  var arrA = isArray(a)
+    , arrB = isArray(b)
+    , i
+    , length
+    , key;
+
+  if (arrA && arrB) {
+    length = a.length;
+    if (length != b.length) return false;
+    for (i = 0; i < length; i++)
+      if (!equal(a[i], b[i])) return false;
+    return true;
+  }
+
+  if (arrA != arrB) return false;
+
+  var dateA = a instanceof Date
+    , dateB = b instanceof Date;
+  if (dateA != dateB) return false;
+  if (dateA && dateB) return a.getTime() == b.getTime();
+
+  var regexpA = a instanceof RegExp
+    , regexpB = b instanceof RegExp;
+  if (regexpA != regexpB) return false;
+  if (regexpA && regexpB) return a.toString() == b.toString();
+
+  if (a instanceof Object && b instanceof Object) {
+    var keys = keyList(a);
+    length = keys.length;
+
+    if (length !== keyList(b).length)
+      return false;
+
+    for (i = 0; i < length; i++)
+      if (!hasProp.call(b, keys[i])) return false;
+
+    for (i = 0; i < length; i++) {
+      key = keys[i];
+      if (key === '_owner' && a[key]) {
+        // React-specific.
+        // avoid traversing circular reference for React elements with non-null _owner
+        if (a[key] !== b[key]) return false;
+      } else {
+        // all other properties should be traversed as usual
+        if (!equal(a[key], b[key])) return false;
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = function exportedEqual(a, b) {
+  try {
+    return equal(a, b);
+  } catch (error) {
+    if (error.message && error.message.match(/stack|recursion/i)) {
+      // warn on circular references, don't crash
+      // browsers give this different errors name and messages:
+      // chrome/safari: "RangeError", "Maximum call stack size exceeded"
+      // firefox: "InternalError", too much recursion"
+      // edge: "Error", "Out of stack space"
+      console.warn('Warning: fast-deep-equal does not handle circular references.', error.name, error.message);
+      return false;
+    }
+    // some other error. we should definitely know about these
+    throw error;
+  }
+};
+/* eslint-enable */


### PR DESCRIPTION
`src/victory-util/fast-deep-equal.js` is exactly equal to https://github.com/FormidableLabs/fast-deep-equal/blob/master/index.js, with the addition on the license and `/* eslint-disable */`. This should finish our deep-equal work in `victory-core`. The final step will be to pull in Formidable's `fast-deep-equal` fork when it's published 