### PR TITLE
text primitive now accepts percentages for x and y

### DIFF
--- a/src/victory-primitives/text.js
+++ b/src/victory-primitives/text.js
@@ -14,8 +14,14 @@ export default class Text extends React.Component {
     style: PropTypes.object,
     title: PropTypes.string,
     transform: PropTypes.string,
-    x: PropTypes.number,
-    y: PropTypes.number
+    x: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
+    ]),
+    y: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
+    ])
   };
 
   shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
The `<Text />` component is the default `textComponent` for `<VictoryLabel />`. Since #269  allows the `<VictoryLabel />` to support strings for `x` and `y` props, the `<Text />` component should also. 

I did not find a test file for `<Text />` and so I did not add any tests for this.