### PR TITLE
add missing styles, update reference link

### DIFF
--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -2,28 +2,35 @@ import { pick } from "lodash";
 
 /**
  * Acceptable CSS/SVG style attributes
- * https://react-cn.github.io/react/docs/tags-and-attributes.html#svg-attributes
+ * https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes
  * non-style properties have been removed from this list
  */
+
 const svgStyleWhitelist = [
   "cursor",
   "fill",
   "fillOpacity",
+  "filter",
   "fontFamily",
   "fontSize",
+  "fontWeight",
   "height",
   "markerEnd",
   "markerMid",
   "markerStart",
+  "mask",
   "opacity",
   "pointerEvents",
   "points",
   "stroke",
   "strokeDasharray",
+  "strokeDashoffset",
   "strokeLinecap",
+  "strokeLinejoin",
   "strokeOpacity",
   "strokeWidth",
   "textAnchor",
+  "textDecoration",
   "transform"
 ];
 


### PR DESCRIPTION
I user pointed out that `fontWeight` was not getting applied to text. I realized that our reference for react svg attrs was incomplete. I've updated the reference link and added a few more attrs that I noticed were missing.