### PR TITLE
Add clip-path CSS property

### DIFF
--- a/src/victory-util/style.js
+++ b/src/victory-util/style.js
@@ -7,6 +7,7 @@ import { pick } from "lodash";
  */
 
 const svgStyleWhitelist = [
+  "clipPath",
   "cursor",
   "fill",
   "fillOpacity",


### PR DESCRIPTION
clip-path is a valid style property, and it's missing from the whitelist. (It can be either a CSS property or a DOM attribute).

My bigger question is: what's the point of this whitelist?