### PR TITLE
getScopedEvents: replace deep merge with shallow assign

### DIFF
--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -148,7 +148,7 @@ export default {
     const parseEventReturn = (eventReturn, eventKey) => {
       return Array.isArray(eventReturn) ?
         eventReturn.reduce((memo, props) => {
-          memo = merge({}, memo, parseEvent(props, eventKey));
+          memo = assign({}, memo, parseEvent(props, eventKey));
           return memo;
         }, {}) :
         parseEvent(eventReturn, eventKey);


### PR DESCRIPTION
`getScopedEvents`'s `parseEventReturn` performed a deep merge, which scales `n^2` for the data structures used. an `assign` will do.