### PR TITLE
compensate for Object.keys

### DIFF
--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -120,7 +120,7 @@ export default {
         const childState = baseState[childName] || {};
 
         const filterState = (state) => {
-          const stateTargets = state[key] && Object.keys(state[key]) || [];
+          const stateTargets = state[key] ? Object.keys(state[key]) : [];
           if (target === "parent" || stateTargets.length === 1 && stateTargets[0] === target) {
             delete state[key];
             return state;

--- a/src/victory-util/events.js
+++ b/src/victory-util/events.js
@@ -120,7 +120,7 @@ export default {
         const childState = baseState[childName] || {};
 
         const filterState = (state) => {
-          const stateTargets = Object.keys(state[key]);
+          const stateTargets = state[key] && Object.keys(state[key]) || [];
           if (target === "parent" || stateTargets.length === 1 && stateTargets[0] === target) {
             delete state[key];
             return state;


### PR DESCRIPTION
some checks for `Object.keys`. It's faster than _.keys, but missing these checks