### PR TITLE
Improvement/corner radius

### DIFF
--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -1,11 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Helpers from "../victory-util/helpers";
-import { assign } from "lodash";
+import { assign, isObject } from "lodash";
 import CommonProps from "./common-props";
 import Path from "./path";
 import * as d3Shape from "d3-shape";
-import { isObject } from "util";
 
 export default class Bar extends React.Component {
 

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -187,9 +187,9 @@ export default class Bar extends React.Component {
       this.getVerticalBarPath(props, width, cornerRadius);
   }
 
-  getPolarBarPath(props) {
+  getPolarBarPath(props, cornerRadius) {
     // TODO Radial bars
-    return this.getVerticalPolarBarPath(props);
+    return this.getVerticalPolarBarPath(props, cornerRadius);
   }
 
   getBarWidth(props, style) {

--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -57,13 +57,14 @@ export default class Bar extends React.Component {
     const direction = sign > 0 ? "0 0 1" : "0 0 0";
     const topArc = `${cornerRadius.top} ${cornerRadius.top} ${direction}`;
     const bottomArc = `${cornerRadius.bottom} ${cornerRadius.bottom} ${direction}`;
-    return `M ${x0}, ${y0}
+    return `M ${x0 + cornerRadius.bottom}, ${y0}
+      A ${bottomArc}, ${x0}, ${y0 - sign * cornerRadius.bottom}
       L ${x0}, ${y1 + sign * cornerRadius.top}
       A ${topArc}, ${x0 + cornerRadius.top}, ${y1}
       L ${x1 - cornerRadius.top}, ${y1}
       A ${topArc}, ${x1}, ${y1 + sign * cornerRadius.top}
-      L ${x1}, ${y0}
-      L ${x0}, ${y0}
+      L ${x1}, ${y0 - sign * cornerRadius.bottom}
+      A ${bottomArc}, ${x1 - cornerRadius.bottom}, ${y0}
       z`;
   }
 


### PR DESCRIPTION
This PR adds the ability to define top and bottom corner radius separately, and supports functional props for cornerRadius. Single values are still supported for cornerRadius. When single values are given, the cornerRadius will only be applied to the _top_ of the bar to avoid the breaking change.
Fixes https://github.com/FormidableLabs/victory/issues/867
