### PR TITLE
evaluate styles for polar bars

### DIFF
--- a/src/victory-primitives/bar.js
+++ b/src/victory-primitives/bar.js
@@ -136,7 +136,8 @@ export default class Bar extends React.Component {
   }
 
   getVerticalPolarBarPath(props, cornerRadius) { // eslint-disable-line max-statements
-    const { datum, scale, style, index, alignment } = props;
+    const { datum, scale, index, alignment } = props;
+    const style = Helpers.evaluateStyle(props.style, datum, props.active);
     const r1 = scale.y(datum._y0 || 0);
     const r2 = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
     const currentAngle = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);


### PR DESCRIPTION
This PR fix the style's evaluation for a polar chart type.  
Fixes [FormidableLabs/victory/#998](https://github.com/FormidableLabs/victory/issues/998)