### PR TITLE
Feature/domain improvements

### DIFF
--- a/src/victory-util/data.js
+++ b/src/victory-util/data.js
@@ -270,8 +270,9 @@ export default {
    * @returns {Array} an array of categories
    */
   getCategories(props, axis) {
+    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
     return props.categories && !Array.isArray(props.categories) ?
-      props.categories[axis] : props.categories;
+      props.categories[currentAxis] : props.categories;
   },
 
   /**

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -57,30 +57,6 @@ function getCumulativeData(props, axis, datasets) {
   return categories.length === 0 ? _dataByIndex() : _dataByCategory();
 }
 
-function getDomainFromCategories(props, axis, categories) {
-  categories = categories || Data.getCategories(props, axis);
-  const { polar, startAngle = 0, endAngle = 360 } = props;
-  if (!categories) {
-    return undefined;
-  }
-  const minDomain = getMinFromProps(props, axis);
-  const maxDomain = getMaxFromProps(props, axis);
-  const stringArray = Collection.containsStrings(categories) ?
-   Data.getStringsFromCategories(props, axis) : [];
-  const stringMap = stringArray.length === 0 ? null :
-    stringArray.reduce((memo, string, index) => {
-      memo[string] = index + 1;
-      return memo;
-    }, {});
-  const categoryValues = stringMap ?
-    categories.map((value) => stringMap[value]) : categories;
-  const min = minDomain !== undefined ? minDomain : Collection.getMinValue(categoryValues);
-  const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(categoryValues);
-  const categoryDomain = getDomainFromMinMax(min, max);
-  return polar && axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
-    getSymmetricDomain(categoryDomain, categoryValues) : categoryDomain;
-}
-
 function getDomainPadding(props, axis) {
   const formatPadding = (padding) => {
     return Array.isArray(padding) ?
@@ -213,6 +189,37 @@ function formatDomain(domain, props, axis) {
  */
 function getDomain(props, axis) {
   return createDomainFunction()(props, axis);
+}
+
+/**
+ * Returns a domain based on categories if they exist
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @param {Array} categories: an array of categories corresponding to a given axis
+ * @returns {Array|undefined} returns a domain from categories or undefined
+ */
+function getDomainFromCategories(props, axis, categories) {
+  categories = categories || Data.getCategories(props, axis);
+  const { polar, startAngle = 0, endAngle = 360 } = props;
+  if (!categories) {
+    return undefined;
+  }
+  const minDomain = getMinFromProps(props, axis);
+  const maxDomain = getMaxFromProps(props, axis);
+  const stringArray = Collection.containsStrings(categories) ?
+    Data.getStringsFromCategories(props, axis) : [];
+  const stringMap = stringArray.length === 0 ? null :
+    stringArray.reduce((memo, string, index) => {
+      memo[string] = index + 1;
+      return memo;
+    }, {});
+  const categoryValues = stringMap ?
+    categories.map((value) => stringMap[value]) : categories;
+  const min = minDomain !== undefined ? minDomain : Collection.getMinValue(categoryValues);
+  const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(categoryValues);
+  const categoryDomain = getDomainFromMinMax(min, max);
+  return polar && axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
+    getSymmetricDomain(categoryDomain, categoryValues) : categoryDomain;
 }
 
 /**
@@ -391,6 +398,7 @@ export default {
   createDomainFunction,
   formatDomain,
   getDomain,
+  getDomainFromCategories,
   getDomainFromData,
   getDomainFromGroupedData,
   getDomainFromMinMax,

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -96,33 +96,33 @@ function getMinFromData(dataset, axis) {
   return containsDate ? new Date(minValue) : minValue;
 }
 
+//eslint-disable-next-line max-statements
 function padDomain(domain, props, axis) {
   if (!props.domainPadding) {
     return domain;
   }
-
+  const minDomain = getMinFromProps(props, axis);
+  const maxDomain = getMaxFromProps(props, axis);
   const padding = getDomainPadding(props, axis);
   if (!padding.left && !padding.right) {
     return domain;
   }
 
-  const domainMin = Collection.getMinValue(domain);
-  const domainMax = Collection.getMaxValue(domain);
+  const min = Collection.getMinValue(domain);
+  const max = Collection.getMaxValue(domain);
   const range = Helpers.getRange(props, axis);
-  const rangeExtent = Math.abs(Math.max(...range) - Math.min(...range));
+  const rangeExtent = Math.abs(range[0] - range[1]);
 
   // Naive initial padding calculation
   const initialPadding = {
-    left: Math.abs(domainMax - domainMin) * padding.left / rangeExtent,
-    right: Math.abs(domainMax - domainMin) * padding.right / rangeExtent
+    left: Math.abs(max - min) * padding.left / rangeExtent,
+    right: Math.abs(max - min) * padding.right / rangeExtent
   };
 
   // Adjust the domain by the initial padding
   const adjustedDomain = {
-    min: (domainMin >= 0 && (domainMin - initialPadding.left) <= 0) ?
-      0 : domainMin.valueOf() - initialPadding.left,
-    max: (domainMax <= 0 && (domainMax + initialPadding.right) >= 0) ?
-      0 : domainMax.valueOf() + initialPadding.right
+    min: +min - initialPadding.left,
+    max: +max + initialPadding.right
   };
 
   // re-calculate padding, taking the adjusted domain into account
@@ -133,14 +133,13 @@ function padDomain(domain, props, axis) {
 
   // Adjust the domain by the final padding
   const finalDomain = {
-    min: (domainMin >= 0 && (domainMin - finalPadding.left) <= 0) ?
-      0 : domainMin.valueOf() - finalPadding.left,
-    max: (domainMax >= 0 && (domainMax + finalPadding.right) <= 0) ?
-      0 : domainMax.valueOf() + finalPadding.right
+    min: minDomain !== undefined ? minDomain : min.valueOf() - finalPadding.left,
+    max: maxDomain !== undefined ? maxDomain : max.valueOf() + finalPadding.right
   };
 
-  return domainMin instanceof Date || domainMax instanceof Date ?
-    [new Date(finalDomain.min), new Date(finalDomain.max)] : [finalDomain.min, finalDomain.max];
+  return min instanceof Date || max instanceof Date ?
+    getDomainFromMinMax(new Date(finalDomain.min), new Date(finalDomain.max)) :
+    getDomainFromMinMax(finalDomain.min, finalDomain.max);
 }
 
 // Public Methods

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -1,405 +1,402 @@
+/* eslint-disable func-style */
+/* eslint-disable no-use-before-define */
 import { flatten, includes, isPlainObject, sortedUniq, isFunction } from "lodash";
 import Data from "./data";
 import Scale from "./scale";
 import Helpers from "./helpers";
 import Collection from "./collection";
 
-export default {
-  createDomainFunction(formatDomain, getDomainFromData) {
-    getDomainFromData = isFunction(getDomainFromData) ?
-      getDomainFromData : this.getDomainFromData.bind(this);
-    formatDomain = isFunction(formatDomain) ? formatDomain : this.formatDomain.bind(this);
-    return (props, axis) => {
-      const propsDomain = this.getDomainFromProps(props, axis);
-      if (propsDomain) {
-        return formatDomain(propsDomain, props, axis);
-      }
-      const categories = Data.getCategories(props, axis);
-      const domain = categories ?
-        this.getDomainFromCategories(props, axis, categories) : getDomainFromData(props, axis);
-      return formatDomain(domain, props, axis);
-    };
-  },
+// Private Methods
 
-  formatDomain(domain, props, axis) {
-    return this.cleanDomain(this.padDomain(domain, props, axis), props, axis);
-  },
-  /**
-   * Returns a domain for a given axis based on props, category, or data
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @returns {Array} the domain for the given axis
-   */
-  getDomain(props, axis) {
-    const getDomain = this.createDomainFunction();
-    return getDomain(props, axis);
-  },
+function cleanDomain(domain, props, axis) {
+  const scaleType = Scale.getScaleType(props, axis);
 
-  /**
-   * Returns the cleaned domain. Some scale types break when certain data is supplied.
-   * This method will replace elements in the domain that break certain scales.
-   * So far this method only removes zeroes for log scales
-   * @param {Array} domain: the original domain
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @returns {Array} the cleaned domain
-   */
-  cleanDomain(domain, props, axis) {
-    const scaleType = Scale.getScaleType(props, axis);
-
-    if (scaleType !== "log") {
-      return domain;
-    }
-
-    const rules = (dom) => {
-      const almostZero = dom[0] < 0 || dom[1] < 0 ? -1 / Number.MAX_SAFE_INTEGER
-      : 1 / Number.MAX_SAFE_INTEGER;
-      const domainOne = dom[0] === 0 ? almostZero : dom[0];
-      const domainTwo = dom[1] === 0 ? almostZero : dom[1];
-      return [domainOne, domainTwo];
-    };
-
-    return rules(domain);
-  },
-
-  /**
-   * Returns a domain for a given axis. This method forces the domain to include
-   * zero unless the domain is explicitly specified in props.
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @returns {Array} the domain for the given axis
-   */
-  getDomainWithZero(props, axis) {
-    const ensureZero = (domain) => {
-      const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
-      const minDomain = this.getMinFromProps(props, axis);
-      const maxDomain = this.getMaxFromProps(props, axis);
-      if (currentAxis === "x") {
-        return domain;
-      }
-      const defaultMin = minDomain || 0;
-      const defaultMax = maxDomain || 0;
-      const min = minDomain !== undefined ? minDomain : Collection.getMinValue(domain, defaultMin);
-      const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(domain, defaultMax);
-      return this.getDomainFromMinMax(min, max);
-    };
-    const formatDomain = (domain) => {
-      return this.formatDomain(ensureZero(domain), props, axis);
-    };
-    const getDomain = this.createDomainFunction(formatDomain);
-    return getDomain(props, axis);
-  },
-
-  /**
-   * Returns a the domain for a given axis if domain is given in props
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @returns {Array|undefined} the domain based on props
-   */
-  getDomainFromProps(props, axis) {
-    const minDomain = this.getMinFromProps(props, axis);
-    const maxDomain = this.getMaxFromProps(props, axis);
-    if (props.domain && props.domain[axis]) {
-      return props.domain[axis];
-    } else if (props.domain && Array.isArray(props.domain)) {
-      return props.domain;
-    } else if (minDomain !== undefined && maxDomain !== undefined) {
-      return this.getDomainFromMinMax(minDomain, maxDomain);
-    }
-    return undefined;
-  },
-
-  getMinFromProps(props, axis) {
-    if (props.minDomain && props.minDomain[axis] !== undefined) {
-      return props.minDomain[axis];
-    }
-    return typeof props.minDomain === "number" ? props.minDomain : undefined;
-  },
-
-  getMaxFromProps(props, axis) {
-    if (props.maxDomain && props.maxDomain[axis] !== undefined) {
-      return props.maxDomain[axis];
-    }
-    return typeof props.maxDomain === "number" ? props.maxDomain : undefined;
-  },
-
-  getFlatData(dataset, axis) {
-    return flatten(dataset).map((datum) => {
-      return datum[`_${axis}`] && datum[`_${axis}`][1] !== undefined ?
-        datum[`_${axis}`][1] : datum[`_${axis}`];
-    });
-  },
-
-  getMinFromData(dataset, axis) {
-    let containsDate = false;
-    const minValue = flatten(dataset).reduce((memo, datum) => {
-      const current = datum[`_${axis}`] && datum[`_${axis}`][0] !== undefined ?
-        datum[`_${axis}`][0] : datum[`_${axis}`];
-      containsDate = containsDate || current instanceof Date;
-      return memo < current ? memo : current;
-    }, Infinity);
-    return containsDate ? new Date(minValue) : minValue;
-  },
-
-  getMaxFromData(dataset, axis) {
-    let containsDate = false;
-    const minValue = flatten(dataset).reduce((memo, datum) => {
-      const current = datum[`_${axis}`] && datum[`_${axis}`][1] !== undefined ?
-        datum[`_${axis}`][1] : datum[`_${axis}`];
-      containsDate = containsDate || current instanceof Date;
-      return memo > current ? memo : current;
-    }, -Infinity);
-    return containsDate ? new Date(minValue) : minValue;
-  },
-
-  getDomainFromMinMax(min, max) {
-    const getSinglePointDomain = (val) => {
-      // d3-scale does not properly resolve very small differences.
-      // eslint-disable-next-line no-magic-numbers
-      const verySmallNumber = Math.pow(10, -10);
-      const verySmallDate = 1;
-      const minVal = val instanceof Date ? new Date(+val - verySmallDate) : val - verySmallNumber;
-      const maxVal = val instanceof Date ? new Date(+val + verySmallDate) : val + verySmallNumber;
-      return [minVal, maxVal];
-    };
-    return +min === +max ? getSinglePointDomain(max) : [min, max];
-  },
-
-  /**
-   * Returns a domain from a dataset for a given axis
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @param {Array} dataset: an array of data
-   * @returns {Array} the domain based on data
-   */
-  getDomainFromData(props, axis, dataset) {
-    dataset = dataset || Data.getData(props, axis);
-    const { horizontal, polar, startAngle = 0, endAngle = 360 } = props;
-    const minDomain = this.getMinFromProps(props, axis);
-    const maxDomain = this.getMaxFromProps(props, axis);
-    if (dataset.length < 1) {
-      const scaleDomain = Scale.getBaseScale(props, axis).domain();
-      const min = minDomain !== undefined ? minDomain : Collection.getMinValue(scaleDomain);
-      const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(scaleDomain);
-      return this.getDomainFromMinMax(min, max);
-    }
-    const currentAxis = Helpers.getCurrentAxis(axis, horizontal);
-    const min = minDomain !== undefined ? minDomain : this.getMinFromData(dataset, currentAxis);
-    const max = maxDomain !== undefined ? maxDomain : this.getMaxFromData(dataset, currentAxis);
-    const domain = this.getDomainFromMinMax(min, max);
-
-    return polar && axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
-      this.getSymmetricDomain(domain, this.getFlatData(dataset, currentAxis)) : domain;
-  },
-
-  getSymmetricDomain(domain, data) {
-    const processedData = sortedUniq(data.sort((a, b) => a - b));
-    const step = processedData[1] - processedData[0];
-    return [domain[0], domain[1] + step];
-  },
-
-  /**
-   * Returns a domain based tickValues
-   * @param {Object} props: the props object
-   * @param {String} axis: either x or y
-   * @returns {Array} returns a domain from tickValues
-   */
-  getDomainFromTickValues(props, axis) {
-    const { tickValues, polar, startAngle = 0, endAngle = 360 } = props;
-    const minDomain = this.getMinFromProps(props, axis);
-    const maxDomain = this.getMaxFromProps(props, axis);
-    const stringTicks = Helpers.stringTicks(props);
-    const ticks = tickValues.map((value) => +value);
-    const defaultMin = stringTicks ? 1 : Collection.getMinValue(ticks);
-    const defaultMax = stringTicks ? tickValues.length : Collection.getMaxValue(ticks);
-    const min = minDomain !== undefined ? minDomain : defaultMin;
-    const max = maxDomain !== undefined ? maxDomain : defaultMax;
-    const initialDomain = this.getDomainFromMinMax(min, max);
-    const domain = polar && axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
-      this.getSymmetricDomain(initialDomain, ticks) : initialDomain;
-    if (Helpers.isVertical(props)) {
-      domain.reverse();
-    }
+  if (scaleType !== "log") {
     return domain;
-  },
-
-  /**
-   * Returns a domain based on categories if they exist
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @param {Array} categories: an array of categories
-   * @returns {Array|undefined} returns a domain from categories or undefined
-   */
-  getDomainFromCategories(props, axis, categories) {
-    categories = categories || Data.getCategories(props, axis);
-    const { polar, startAngle = 0, endAngle = 360 } = props;
-    if (!categories) {
-      return undefined;
-    }
-    const minDomain = this.getMinFromProps(props, axis);
-    const maxDomain = this.getMaxFromProps(props, axis);
-    const stringArray = Collection.containsStrings(categories) ?
-     Data.getStringsFromCategories(props, axis) : [];
-    const stringMap = stringArray.length === 0 ? null :
-      stringArray.reduce((memo, string, index) => {
-        memo[string] = index + 1;
-        return memo;
-      }, {});
-    const categoryValues = stringMap ?
-      categories.map((value) => stringMap[value]) : categories;
-    const min = minDomain !== undefined ? minDomain : Collection.getMinValue(categoryValues);
-    const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(categoryValues);
-    const categoryDomain = this.getDomainFromMinMax(min, max);
-    return polar && axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
-      this.getSymmetricDomain(categoryDomain, categoryValues) : categoryDomain;
-  },
-
-  /**
-   * Returns a cumulative domain for a set of grouped datasets (i.e. stacked charts)
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @param {Array} datasets: an array of data arrays
-   * @returns {Array} the cumulative domain
-   */
-  getDomainFromGroupedData(props, axis, datasets) {
-    const { horizontal } = props;
-    const dependent = (axis === "x" && !horizontal) || (axis === "y" && horizontal);
-    const categories = isPlainObject(props.categories) ? props.categories.axis : props.categories;
-    if (dependent && categories) {
-      return this.getDomainFromCategories(props, axis, categories);
-    }
-    const globalDomain = this.getDomainFromData(props, axis, datasets);
-    if (dependent) {
-      return globalDomain;
-    }
-    // find the cumulative max for stacked chart types
-    const cumulativeData = this.getCumulativeData(props, axis, datasets);
-    const cumulativeMax = cumulativeData.reduce((memo, dataset) => {
-      const currentMax = dataset.reduce((m, val) => {
-        return val > 0 ? m + val : m;
-      }, 0);
-      return memo > currentMax ? memo : currentMax;
-    }, -Infinity);
-
-    const cumulativeMin = cumulativeData.reduce((memo, dataset) => {
-      const currentMin = dataset.reduce((m, val) => {
-        return val < 0 ? m + val : m;
-      }, 0);
-      return memo < currentMin ? memo : currentMin;
-    }, Infinity);
-
-    // use greatest min / max
-    return this.getDomainFromMinMax(
-      Collection.getMinValue(globalDomain, cumulativeMin),
-      Collection.getMaxValue(globalDomain, cumulativeMax)
-    );
-  },
-
-  /**
-   * Returns cumulative datasets either by index or category
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @param {Array} datasets: an array of data arrays
-   * @returns {Array} an array of data arrays grouped by index or category
-   */
-  getCumulativeData(props, axis, datasets) {
-    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
-    const otherAxis = currentAxis === "x" ? "y" : "x";
-    const categories = [];
-    const axisValues = [];
-    datasets.forEach((dataset) => {
-      dataset.forEach((data) => {
-        if (data.category !== undefined && !includes(categories, data.category)) {
-          categories.push(data.category);
-        } else if (!includes(axisValues, data[`_${otherAxis}`])) {
-          axisValues.push(data[`_${otherAxis}`]);
-        }
-      });
-    });
-
-    const _dataByCategory = () => {
-      return categories.map((value) => {
-        return datasets.reduce((prev, data) => {
-          return data.category === value ? prev.concat(data[`_${axis}`]) : prev;
-        }, []);
-      });
-    };
-
-    const _dataByIndex = () => {
-      return axisValues.map((value, index) => {
-        return datasets.map((data) => data[index] && data[index][`_${currentAxis}`]);
-      });
-    };
-    return categories.length === 0 ? _dataByIndex() : _dataByCategory();
-  },
-
-  /**
-   * Returns the domain padding appropriate for a given axis
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @returns {Object} an object with padding specified for "left" and "right"
-   */
-  getDomainPadding(props, axis) {
-    const formatPadding = (padding) => {
-      return Array.isArray(padding) ?
-        { left: padding[0], right: padding[1] } : { left: padding, right: padding };
-    };
-
-    return isPlainObject(props.domainPadding) ?
-      formatPadding(props.domainPadding[axis]) : formatPadding(props.domainPadding);
-  },
-
-  /**
-   * Returns the domain with padding from the `domainPadding` prop applied
-   * @param {Array} domain: the original domain
-   * @param {Object} props: the props object
-   * @param {String} axis: the current axis
-   * @returns {Array} the domain with padding applied
-   */
-  padDomain(domain, props, axis) {
-    if (!props.domainPadding) {
-      return domain;
-    }
-
-    const padding = this.getDomainPadding(props, axis);
-    if (!padding.left && !padding.right) {
-      return domain;
-    }
-
-    const domainMin = Collection.getMinValue(domain);
-    const domainMax = Collection.getMaxValue(domain);
-    const range = Helpers.getRange(props, axis);
-    const rangeExtent = Math.abs(Math.max(...range) - Math.min(...range));
-
-    // Naive initial padding calculation
-    const initialPadding = {
-      left: Math.abs(domainMax - domainMin) * padding.left / rangeExtent,
-      right: Math.abs(domainMax - domainMin) * padding.right / rangeExtent
-    };
-
-    // Adjust the domain by the initial padding
-    const adjustedDomain = {
-      min: (domainMin >= 0 && (domainMin - initialPadding.left) <= 0) ?
-        0 : domainMin.valueOf() - initialPadding.left,
-      max: (domainMax <= 0 && (domainMax + initialPadding.right) >= 0) ?
-        0 : domainMax.valueOf() + initialPadding.right
-    };
-
-    // re-calculate padding, taking the adjusted domain into account
-    const finalPadding = {
-      left: Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.left / rangeExtent,
-      right: Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.right / rangeExtent
-    };
-
-    // Adjust the domain by the final padding
-    const finalDomain = {
-      min: (domainMin >= 0 && (domainMin - finalPadding.left) <= 0) ?
-        0 : domainMin.valueOf() - finalPadding.left,
-      max: (domainMax >= 0 && (domainMax + finalPadding.right) <= 0) ?
-        0 : domainMax.valueOf() + finalPadding.right
-    };
-
-    return domainMin instanceof Date || domainMax instanceof Date ?
-      [new Date(finalDomain.min), new Date(finalDomain.max)] : [finalDomain.min, finalDomain.max];
   }
+
+  const rules = (dom) => {
+    const almostZero = dom[0] < 0 || dom[1] < 0 ? -1 / Number.MAX_SAFE_INTEGER
+    : 1 / Number.MAX_SAFE_INTEGER;
+    const domainOne = dom[0] === 0 ? almostZero : dom[0];
+    const domainTwo = dom[1] === 0 ? almostZero : dom[1];
+    return [domainOne, domainTwo];
+  };
+
+  return rules(domain);
+}
+
+function getCumulativeData(props, axis, datasets) {
+  const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
+  const otherAxis = currentAxis === "x" ? "y" : "x";
+  const categories = [];
+  const axisValues = [];
+  datasets.forEach((dataset) => {
+    dataset.forEach((data) => {
+      if (data.category !== undefined && !includes(categories, data.category)) {
+        categories.push(data.category);
+      } else if (!includes(axisValues, data[`_${otherAxis}`])) {
+        axisValues.push(data[`_${otherAxis}`]);
+      }
+    });
+  });
+
+  const _dataByCategory = () => {
+    return categories.map((value) => {
+      return datasets.reduce((prev, data) => {
+        return data.category === value ? prev.concat(data[`_${axis}`]) : prev;
+      }, []);
+    });
+  };
+
+  const _dataByIndex = () => {
+    return axisValues.map((value, index) => {
+      return datasets.map((data) => data[index] && data[index][`_${currentAxis}`]);
+    });
+  };
+  return categories.length === 0 ? _dataByIndex() : _dataByCategory();
+}
+
+function getDomainFromCategories(props, axis, categories) {
+  categories = categories || Data.getCategories(props, axis);
+  const { polar, startAngle = 0, endAngle = 360 } = props;
+  if (!categories) {
+    return undefined;
+  }
+  const minDomain = getMinFromProps(props, axis);
+  const maxDomain = getMaxFromProps(props, axis);
+  const stringArray = Collection.containsStrings(categories) ?
+   Data.getStringsFromCategories(props, axis) : [];
+  const stringMap = stringArray.length === 0 ? null :
+    stringArray.reduce((memo, string, index) => {
+      memo[string] = index + 1;
+      return memo;
+    }, {});
+  const categoryValues = stringMap ?
+    categories.map((value) => stringMap[value]) : categories;
+  const min = minDomain !== undefined ? minDomain : Collection.getMinValue(categoryValues);
+  const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(categoryValues);
+  const categoryDomain = getDomainFromMinMax(min, max);
+  return polar && axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
+    getSymmetricDomain(categoryDomain, categoryValues) : categoryDomain;
+}
+
+function getDomainPadding(props, axis) {
+  const formatPadding = (padding) => {
+    return Array.isArray(padding) ?
+      { left: padding[0], right: padding[1] } : { left: padding, right: padding };
+  };
+
+  return isPlainObject(props.domainPadding) ?
+    formatPadding(props.domainPadding[axis]) : formatPadding(props.domainPadding);
+}
+
+function getFlatData(dataset, axis) {
+  return flatten(dataset).map((datum) => {
+    return datum[`_${axis}`] && datum[`_${axis}`][1] !== undefined ?
+      datum[`_${axis}`][1] : datum[`_${axis}`];
+  });
+}
+
+function getMaxFromData(dataset, axis) {
+  let containsDate = false;
+  const minValue = flatten(dataset).reduce((memo, datum) => {
+    const current = datum[`_${axis}`] && datum[`_${axis}`][1] !== undefined ?
+      datum[`_${axis}`][1] : datum[`_${axis}`];
+    containsDate = containsDate || current instanceof Date;
+    return memo > current ? memo : current;
+  }, -Infinity);
+  return containsDate ? new Date(minValue) : minValue;
+}
+
+function getMinFromData(dataset, axis) {
+  let containsDate = false;
+  const minValue = flatten(dataset).reduce((memo, datum) => {
+    const current = datum[`_${axis}`] && datum[`_${axis}`][0] !== undefined ?
+      datum[`_${axis}`][0] : datum[`_${axis}`];
+    containsDate = containsDate || current instanceof Date;
+    return memo < current ? memo : current;
+  }, Infinity);
+  return containsDate ? new Date(minValue) : minValue;
+}
+
+function padDomain(domain, props, axis) {
+  if (!props.domainPadding) {
+    return domain;
+  }
+
+  const padding = getDomainPadding(props, axis);
+  if (!padding.left && !padding.right) {
+    return domain;
+  }
+
+  const domainMin = Collection.getMinValue(domain);
+  const domainMax = Collection.getMaxValue(domain);
+  const range = Helpers.getRange(props, axis);
+  const rangeExtent = Math.abs(Math.max(...range) - Math.min(...range));
+
+  // Naive initial padding calculation
+  const initialPadding = {
+    left: Math.abs(domainMax - domainMin) * padding.left / rangeExtent,
+    right: Math.abs(domainMax - domainMin) * padding.right / rangeExtent
+  };
+
+  // Adjust the domain by the initial padding
+  const adjustedDomain = {
+    min: (domainMin >= 0 && (domainMin - initialPadding.left) <= 0) ?
+      0 : domainMin.valueOf() - initialPadding.left,
+    max: (domainMax <= 0 && (domainMax + initialPadding.right) >= 0) ?
+      0 : domainMax.valueOf() + initialPadding.right
+  };
+
+  // re-calculate padding, taking the adjusted domain into account
+  const finalPadding = {
+    left: Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.left / rangeExtent,
+    right: Math.abs(adjustedDomain.max - adjustedDomain.min) * padding.right / rangeExtent
+  };
+
+  // Adjust the domain by the final padding
+  const finalDomain = {
+    min: (domainMin >= 0 && (domainMin - finalPadding.left) <= 0) ?
+      0 : domainMin.valueOf() - finalPadding.left,
+    max: (domainMax >= 0 && (domainMax + finalPadding.right) <= 0) ?
+      0 : domainMax.valueOf() + finalPadding.right
+  };
+
+  return domainMin instanceof Date || domainMax instanceof Date ?
+    [new Date(finalDomain.min), new Date(finalDomain.max)] : [finalDomain.min, finalDomain.max];
+}
+
+// Public Methods
+
+/**
+ * Returns a getDomain function
+ * @param {Function} getDomainFromDataFunction: a function that takes props and axis and
+ * returns a domain based on data
+ * @param {Function} formatDomainFunction: a function that takes domain, props, and axis and
+ * returns a formatted domain
+ * @returns {Function} a function that takes props and axis and returns a formatted domain
+ */
+function createDomainFunction(getDomainFromDataFunction, formatDomainFunction) {
+  getDomainFromDataFunction = isFunction(getDomainFromDataFunction) ?
+    getDomainFromDataFunction : getDomainFromData;
+  formatDomainFunction = isFunction(formatDomainFunction) ?
+    formatDomainFunction : formatDomain;
+  return (props, axis) => {
+    const propsDomain = getDomainFromProps(props, axis);
+    if (propsDomain) {
+      return formatDomainFunction(propsDomain, props, axis);
+    }
+    const categories = Data.getCategories(props, axis);
+    const domain = categories ?
+      getDomainFromCategories(props, axis, categories) : getDomainFromDataFunction(props, axis);
+    return formatDomainFunction(domain, props, axis);
+  };
+}
+
+/**
+ * Returns a formatted domain.
+ * @param {Array} domain: a domain in the form of a two element array
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @returns {Array} a domain in the form of a two element array
+ */
+function formatDomain(domain, props, axis) {
+  return cleanDomain(padDomain(domain, props, axis), props, axis);
+}
+
+/**
+ * Returns a domain for a given axis based on props, category, or data
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @returns {Array} the domain for the given axis
+ */
+function getDomain(props, axis) {
+  return createDomainFunction()(props, axis);
+}
+
+/**
+ * Returns a domain from a dataset for a given axis
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @param {Array} dataset: an array of data
+ * @returns {Array} the domain based on data
+ */
+function getDomainFromData(props, axis, dataset) {
+  dataset = dataset || Data.getData(props, axis);
+  const { horizontal, polar, startAngle = 0, endAngle = 360 } = props;
+  const minDomain = getMinFromProps(props, axis);
+  const maxDomain = getMaxFromProps(props, axis);
+  if (dataset.length < 1) {
+    const scaleDomain = Scale.getBaseScale(props, axis).domain();
+    const min = minDomain !== undefined ? minDomain : Collection.getMinValue(scaleDomain);
+    const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(scaleDomain);
+    return getDomainFromMinMax(min, max);
+  }
+  const currentAxis = Helpers.getCurrentAxis(axis, horizontal);
+  const min = minDomain !== undefined ? minDomain : getMinFromData(dataset, currentAxis);
+  const max = maxDomain !== undefined ? maxDomain : getMaxFromData(dataset, currentAxis);
+  const domain = getDomainFromMinMax(min, max);
+
+  return polar && axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
+    getSymmetricDomain(domain, getFlatData(dataset, currentAxis)) : domain;
+}
+
+/**
+ * Returns a cumulative domain for a set of grouped datasets (i.e. stacked charts)
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @param {Array} datasets: an array of data arrays
+ * @returns {Array} the cumulative domain
+ */
+function getDomainFromGroupedData(props, axis, datasets) {
+  const { horizontal } = props;
+  const dependent = (axis === "x" && !horizontal) || (axis === "y" && horizontal);
+  const categories = isPlainObject(props.categories) ? props.categories[axis] : props.categories;
+  if (dependent && categories) {
+    return getDomainFromCategories(props, axis, categories);
+  }
+  const globalDomain = getDomainFromData(props, axis, datasets);
+  if (dependent) {
+    return globalDomain;
+  }
+  // find the cumulative max for stacked chart types
+  const cumulativeData = getCumulativeData(props, axis, datasets);
+  const cumulativeMax = cumulativeData.reduce((memo, dataset) => {
+    const currentMax = dataset.reduce((m, val) => {
+      return val > 0 ? m + val : m;
+    }, 0);
+    return memo > currentMax ? memo : currentMax;
+  }, -Infinity);
+
+  const cumulativeMin = cumulativeData.reduce((memo, dataset) => {
+    const currentMin = dataset.reduce((m, val) => {
+      return val < 0 ? m + val : m;
+    }, 0);
+    return memo < currentMin ? memo : currentMin;
+  }, Infinity);
+
+  // use greatest min / max
+  return getDomainFromMinMax(
+    Collection.getMinValue(globalDomain, cumulativeMin),
+    Collection.getMaxValue(globalDomain, cumulativeMax)
+  );
+}
+
+/**
+ * Returns a domain in the form of a two element array given a min and max value.
+ * @param {Number|Date} min: the props object
+ * @param {Number|Date} max: the current axis
+ * @returns {Array} the minDomain based on props
+ */
+function getDomainFromMinMax(min, max) {
+  const getSinglePointDomain = (val) => {
+    // d3-scale does not properly resolve very small differences.
+    // eslint-disable-next-line no-magic-numbers
+    const verySmallNumber = Math.pow(10, -10);
+    const verySmallDate = 1;
+    const minVal = val instanceof Date ? new Date(+val - verySmallDate) : val - verySmallNumber;
+    const maxVal = val instanceof Date ? new Date(+val + verySmallDate) : val + verySmallNumber;
+    return [minVal, maxVal];
+  };
+  return +min === +max ? getSinglePointDomain(max) : [min, max];
+}
+
+/**
+ * Returns a the domain for a given axis if domain is given in props
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @returns {Array|undefined} the domain based on props
+ */
+function getDomainFromProps(props, axis) {
+  const minDomain = getMinFromProps(props, axis);
+  const maxDomain = getMaxFromProps(props, axis);
+  if (isPlainObject(props.domain) && props.domain[axis]) {
+    return props.domain[axis];
+  } else if (Array.isArray(props.domain)) {
+    return props.domain;
+  } else if (minDomain !== undefined && maxDomain !== undefined) {
+    return getDomainFromMinMax(minDomain, maxDomain);
+  }
+  return undefined;
+}
+
+/**
+ * Returns a domain for a given axis. This method forces the domain to include
+ * zero unless the domain is explicitly specified in props.
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @returns {Array} the domain for the given axis
+ */
+function getDomainWithZero(props, axis) {
+  const ensureZero = (domain) => {
+    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
+    const minDomain = getMinFromProps(props, axis);
+    const maxDomain = getMaxFromProps(props, axis);
+    if (currentAxis === "x") {
+      return domain;
+    }
+    const defaultMin = minDomain || 0;
+    const defaultMax = maxDomain || 0;
+    const min = minDomain !== undefined ? minDomain : Collection.getMinValue(domain, defaultMin);
+    const max = maxDomain !== undefined ? maxDomain : Collection.getMaxValue(domain, defaultMax);
+    return getDomainFromMinMax(min, max);
+  };
+  const formatDomainFunction = (domain) => {
+    return formatDomain(ensureZero(domain), props, axis);
+  };
+  return createDomainFunction(null, formatDomainFunction)(props, axis);
+}
+
+/**
+ * Returns the maxDomain from props if it exists
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @returns {Number|undefined} the maxDomain based on props
+ */
+function getMaxFromProps(props, axis) {
+  if (isPlainObject(props.maxDomain) && props.maxDomain[axis] !== undefined) {
+    return props.maxDomain[axis];
+  }
+  return typeof props.maxDomain === "number" ? props.maxDomain : undefined;
+}
+
+/**
+ * Returns the minDomain from props if it exists
+ * @param {Object} props: the props object
+ * @param {String} axis: the current axis
+ * @returns {Number|undefined} the minDomain based on props
+ */
+function getMinFromProps(props, axis) {
+  if (isPlainObject(props.minDomain) && props.minDomain[axis] !== undefined) {
+    return props.minDomain[axis];
+  }
+  return typeof props.minDomain === "number" ? props.minDomain : undefined;
+}
+
+/**
+ * Returns a symmetrically padded domain for polar charts
+ * @param {Array} domain: the original domain
+ * @param {Array} values: a flat array of values corresponding to either tickValues, or data values
+ * for a given dimension i.e. only x values.
+ * @returns {Array} the symmetric domain
+ */
+function getSymmetricDomain(domain, values) {
+  const processedData = sortedUniq(values.sort((a, b) => a - b));
+  const step = processedData[1] - processedData[0];
+  return [domain[0], domain[1] + step];
+}
+
+export default {
+  createDomainFunction,
+  formatDomain,
+  getDomain,
+  getDomainFromData,
+  getDomainFromGroupedData,
+  getDomainFromMinMax,
+  getDomainFromProps,
+  getDomainWithZero,
+  getMaxFromProps,
+  getMinFromProps,
+  getSymmetricDomain
 };

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -16,19 +16,18 @@ export default {
     const propsDomain = this.getDomainFromProps(props, axis);
     const minDomain = this.getMinFromProps(props, axis);
     const maxDomain = this.getMaxFromProps(props, axis);
-    if (propsDomain || minDomain !== undefined && maxDomain !== undefined) {
-      const domain = propsDomain || this.getDomainFromMinMax(minDomain, maxDomain);
+    const formatDomain = (domain) => {
       return this.cleanDomain(this.padDomain(domain, props, axis), props, axis);
+    };
+    if (propsDomain || minDomain !== undefined && maxDomain !== undefined) {
+      return formatDomain(propsDomain || this.getDomainFromMinMax(minDomain, maxDomain));
     }
-    let domain;
     const categories = Data.getCategories(props, axis);
     if (categories) {
-      domain = this.getDomainFromCategories(props, axis, categories);
-    } else {
-      const dataset = Data.getData(props);
-      domain = this.getDomainFromData(props, axis, dataset);
+      return formatDomain(this.getDomainFromCategories(props, axis, categories));
     }
-    return this.cleanDomain(this.padDomain(domain, props, axis), props, axis);
+    const dataset = Data.getData(props);
+    return formatDomain(this.getDomainFromData(props, axis, dataset));
   },
 
   /**

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -60,9 +60,10 @@ describe("helpers/domain", () => {
         const domainPadding = { x: pad };
         const props = { ...baseProps, domainPadding };
         const paddedDomain = Domain.formatDomain(domain, props, "x");
-        const percentPad = pad / baseProps.width;
-        const totalPadding = (domain[1] * (1 + percentPad)) * percentPad;
-        expect(paddedDomain).to.eql([0, domain[1] + totalPadding]);
+        const adjustedDomain = Math.abs(domain[1] - domain[0]) + (2 * pad);
+        const adjustedPercent = adjustedDomain / (baseProps.width - baseProps.padding);
+        const totalPadding = adjustedPercent * pad;
+        expect(paddedDomain).to.eql([domain[0] - totalPadding, domain[1] + totalPadding]);
       });
     });
 

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -1,8 +1,7 @@
 /* eslint no-unused-expressions: 0 */
 /* eslint max-nested-callbacks: 0 */
-/* global sinon */
 
-import { Data, Domain, Helpers } from "src/index";
+import { Domain } from "src/index";
 
 describe("helpers/domain", () => {
   describe("padDomain", () => {
@@ -29,21 +28,9 @@ describe("helpers/domain", () => {
   });
 
   describe("getDomain", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Domain, "getDomainFromProps");
-      sandbox.spy(Domain, "getDomainFromData");
-    });
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it("gets the domain from props if they exist", () => {
       const props = { domain: [1, 2] };
       const resultDomain = Domain.getDomain(props, "x");
-      expect(Domain.getDomainFromProps).calledWith(props, "x").and.returned(props.domain);
-      expect(Domain.getDomainFromData).not.called;
       expect(resultDomain).to.eql(props.domain);
     });
 
@@ -52,9 +39,6 @@ describe("helpers/domain", () => {
         x: "x", y: "y", domain: { y: [1, 2] }, data: [{ x: 1, y: 3 }, { x: 3, y: 5 }]
       };
       const resultDomain = Domain.getDomain(props, "x");
-      const dataset = Data.getData(props);
-      expect(Domain.getDomainFromProps).calledWith(props, "x").and.returned(undefined);
-      expect(Domain.getDomainFromData).calledWith(props, "x", dataset).and.returned([1, 3]);
       expect(resultDomain).to.eql([1, 3]);
     });
   });
@@ -81,6 +65,51 @@ describe("helpers/domain", () => {
       const resultDomain = Domain.getDomainFromProps(props, "x");
       expect(resultDomain).to.eql(undefined);
     });
+
+    it("returns a domain from minDomain and maxDomain if both are defined", () => {
+      const props = { minDomain: 1, maxDomain: 10 };
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).to.eql([1, 10]);
+    });
+
+    it("returns an adjusted domain if minDomain equals maxDomain", () => {
+      const props = { minDomain: 0, maxDomain: 0 };
+      const verySmallNumber = Math.pow(10, -10);
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).to.eql([-1 * verySmallNumber, verySmallNumber]);
+    });
+
+    it("returns undefined if only minDomain is defined", () => {
+      const props = { minDomain: 1 };
+      const resultDomain = Domain.getDomainFromProps(props, "x");
+      expect(resultDomain).to.eql(undefined);
+    });
+  });
+
+  describe("getDomainFromMinMax", () => {
+    it("returns a min max array when min and max are given", () => {
+      const min = 1;
+      const max = 2;
+      const resultDomain = Domain.getDomainFromMinMax(min, max);
+      expect(resultDomain).to.eql([min, max]);
+    });
+
+    it("returns an adjusted domain if min equals max", () => {
+      const min = 0;
+      const max = 0;
+      const verySmallNumber = Math.pow(10, -10);
+      const resultDomain = Domain.getDomainFromMinMax(min, max);
+      expect(resultDomain).to.eql([-1 * verySmallNumber, verySmallNumber]);
+    });
+
+    it("returns an adjusted date domain if min equals max", () => {
+      const min = new Date(1980, 1, 1);
+      const max = new Date(1980, 1, 1);
+      const resultDomain = Domain.getDomainFromMinMax(min, max);
+      expect(resultDomain).to.eql([
+        new Date(+min - 1), new Date(+max + 1)
+      ]);
+    });
   });
 
   describe("getDomainFromData", () => {
@@ -92,55 +121,26 @@ describe("helpers/domain", () => {
   });
 
   describe("getDomainFromTickValues", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Helpers, "isVertical");
-      sandbox.spy(Helpers, "stringTicks");
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it("determines a domain from tickValues", () => {
       const props = { tickValues: [1, 2, 3] };
       const domainResult = Domain.getDomainFromTickValues(props);
-      expect(Helpers.stringTicks).calledWith(props).and.returned(false);
-      expect(Helpers.isVertical).calledWith(props).and.returned(false);
       expect(domainResult).to.eql([1, 3]);
     });
 
     it("determines a domain from string tick values", () => {
       const props = { tickValues: ["a", "b", "c", "d"] };
       const domainResult = Domain.getDomainFromTickValues(props);
-      expect(Helpers.stringTicks).calledWith(props).and.returned(true);
-      expect(Helpers.isVertical).calledWith(props).and.returned(false);
       expect(domainResult).to.eql([1, 4]);
     });
 
     it("reverses a domain from tickValues when the axis is vertical", () => {
       const props = { tickValues: [1, 2, 3], dependentAxis: true };
       const domainResult = Domain.getDomainFromTickValues(props);
-      expect(Helpers.stringTicks).calledWith(props).and.returned(false);
-      expect(Helpers.isVertical).calledWith(props).and.returned(true);
       expect(domainResult).to.eql([3, 1]);
     });
   });
 
   describe("getDomainFromGroupedData", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Domain, "getDomainFromData");
-      sandbox.spy(Domain, "getDomainFromCategories");
-      sandbox.spy(Domain, "getCumulativeData");
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     const data = [
       [{ _x: 1, _y: 0 }, { _x: 2, _y: 0 }, { _x: 3, _y: 0 }],
       [{ _x: 1, _y: 1 }, { _x: 2, _y: 1 }, { _x: 3, _y: 1 }],
@@ -150,17 +150,12 @@ describe("helpers/domain", () => {
     it("calculates a domain from categories for the independent axis", () => {
       const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
       const domainResultX = Domain.getDomainFromGroupedData(props, "x", data);
-      expect(Domain.getDomainFromCategories).calledWith(props, "x").and.returned([1, 3]);
-      expect(Domain.getDomainFromData).not.called;
-      expect(Domain.getCumulativeData).not.called;
       expect(domainResultX).to.eql([1, 3]);
     });
 
     it("calculates a stacked domain for the dependent axis", () => {
       const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
       const domainResultY = Domain.getDomainFromGroupedData(props, "y", data);
-      expect(Domain.getDomainFromData).calledOnce.and.returned([0, 2]);
-      expect(Domain.getCumulativeData).calledOnce;
       expect(domainResultY).to.eql([0, 3]);
     });
   });

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -3,12 +3,53 @@
 
 import { Domain } from "src/index";
 
+/*
+  createDomainFunction,
+  formatDomain,
+  getDomain,
+  getDomainFromCategories,
+  getDomainFromData,
+  getDomainFromGroupedData,
+  getDomainFromMinMax,
+  getDomainFromProps,
+  getDomainWithZero,
+  getMaxFromProps,
+  getMinFromProps,
+  getSymmetricDomain
+*/
+
 describe("helpers/domain", () => {
-  describe("padDomain", () => {
+  describe("createDomainFunction", () => {
+    it("returns a function equivalent to getDomain when no props are given", () => {
+      const props = {
+        x: "x", y: "y", domain: { y: [1, 2] }, data: [{ x: 1, y: 3 }, { x: 3, y: 5 }]
+      };
+      const domainGetter = Domain.createDomainFunction();
+      expect(domainGetter(props, "x")).to.eql(Domain.getDomain(props, "x"));
+    });
+
+    it("returns a function that uses a custom getDomainFromData function when given", () => {
+      const props = {
+        x: "x", y: "y", data: [{ x: 1, y: 3 }, { x: 3, y: 5 }]
+      };
+      const getDomainFromData = () => [0, 10];
+      const domainGetter = Domain.createDomainFunction(getDomainFromData);
+      expect(domainGetter(props, "x")).to.eql([0, 10]);
+    });
+
+    it("returns a function that uses a custom formatDomain function when given", () => {
+      const props = { domain: [0, 1] };
+      const formatDomain = () => [0, 10];
+      const domainGetter = Domain.createDomainFunction(null, formatDomain);
+      expect(domainGetter(props, "x")).to.eql([0, 10]);
+    });
+  });
+
+  describe("formatDomain", () => {
     const baseProps = { width: 100, height: 100, padding: 0 };
     it("returns the domain when no domain padding is specified", () => {
       const domain = [0, 1];
-      const paddedDomain = Domain.padDomain(domain, baseProps, "x");
+      const paddedDomain = Domain.formatDomain(domain, baseProps, "x");
       expect(paddedDomain).to.eql(domain);
     });
 
@@ -18,12 +59,18 @@ describe("helpers/domain", () => {
       padding.forEach((pad) => {
         const domainPadding = { x: pad };
         const props = { ...baseProps, domainPadding };
-        const paddedDomain = Domain.padDomain(domain, props, "x");
+        const paddedDomain = Domain.formatDomain(domain, props, "x");
         const percentPad = pad / baseProps.width;
         const totalPadding = (domain[1] * (1 + percentPad)) * percentPad;
         expect(paddedDomain).to.eql([0, domain[1] + totalPadding]);
-      }
-      );
+      });
+    });
+
+    it("filters zero from the domain for log scales", () => {
+      const verySmallNumber = 1 / Number.MAX_SAFE_INTEGER;
+      const props = { scale: { y: "log" } };
+      const formattedDomain = Domain.formatDomain([0, 1], props, "y");
+      expect(formattedDomain).to.eql([verySmallNumber, 1]);
     });
   });
 
@@ -40,6 +87,54 @@ describe("helpers/domain", () => {
       };
       const resultDomain = Domain.getDomain(props, "x");
       expect(resultDomain).to.eql([1, 3]);
+    });
+  });
+
+  describe("getDomainFromCategories", () => {
+    it("calculates a domain from categories for the independent axis", () => {
+      const props = { categories: [1, 2, 3] };
+      const domainResult = Domain.getDomainFromCategories(props, "x");
+      expect(domainResult).to.eql([1, 3]);
+    });
+
+    it("calculates a domain from categories for the dependent axis", () => {
+      const props = { categories: { y: [ 1, 2, 3] } };
+      const domainResult = Domain.getDomainFromCategories(props, "y");
+      expect(domainResult).to.eql([1, 3]);
+    });
+
+    it("calculates a domain from string categories", () => {
+      const props = { categories: { x: ["cats", "kittens"] } };
+      const domainResult = Domain.getDomainFromCategories(props, "x");
+      expect(domainResult).to.eql([1, 2]);
+    });
+  });
+
+  describe("getDomainFromData", () => {
+    it("returns a domain from a dataset", () => {
+      const dataset = [{ _x: 1, _y: 3 }, { _x: 3, _y: 5 }];
+      const resultDomain = Domain.getDomainFromData({}, "x", dataset);
+      expect(resultDomain).to.eql([1, 3]);
+    });
+  });
+
+  describe("getDomainFromGroupedData", () => {
+    const data = [
+      [{ _x: 1, _y: 0 }, { _x: 2, _y: 0 }, { _x: 3, _y: 0 }],
+      [{ _x: 1, _y: 1 }, { _x: 2, _y: 1 }, { _x: 3, _y: 1 }],
+      [{ _x: 1, _y: 2 }, { _x: 2, _y: 2 }, { _x: 3, _y: 2 }]
+    ];
+
+    it("calculates a domain from categories for the independent axis", () => {
+      const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
+      const domainResultX = Domain.getDomainFromGroupedData(props, "x", data);
+      expect(domainResultX).to.eql([1, 3]);
+    });
+
+    it("calculates a stacked domain for the dependent axis", () => {
+      const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
+      const domainResultY = Domain.getDomainFromGroupedData(props, "y", data);
+      expect(domainResultY).to.eql([0, 3]);
     });
   });
 
@@ -112,71 +207,65 @@ describe("helpers/domain", () => {
     });
   });
 
-  describe("getDomainFromData", () => {
-    it("returns a domain from a dataset", () => {
-      const dataset = [{ _x: 1, _y: 3 }, { _x: 3, _y: 5 }];
-      const resultDomain = Domain.getDomainFromData({}, "x", dataset);
+  describe("getDomainWithZero", () => {
+    it("ensures that the domain includes zero for the dependent axis", () => {
+      const props = {
+        x: "x", y: "y", data: [{ x: 1, y: 3 }, { x: 3, y: 5 }]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "y");
+      expect(resultDomain).to.eql([0, 5]);
+    });
+    it("does not force the independent domain to include zero", () => {
+      const props = {
+        x: "x", y: "y", data: [{ x: 1, y: 3 }, { x: 3, y: 5 }]
+      };
+      const resultDomain = Domain.getDomainWithZero(props, "x");
       expect(resultDomain).to.eql([1, 3]);
     });
   });
 
-  describe("getDomainFromTickValues", () => {
-    it("determines a domain from tickValues", () => {
-      const props = { tickValues: [1, 2, 3] };
-      const domainResult = Domain.getDomainFromTickValues(props);
-      expect(domainResult).to.eql([1, 3]);
+  describe("getMaxFromProps", () => {
+    it("returns maxDomain from props as an object", () => {
+      const props = { maxDomain: { x: 3 } };
+      const maxDomain = Domain.getMaxFromProps(props, "x");
+      expect(maxDomain).to.eql(props.maxDomain.x);
     });
-
-    it("determines a domain from string tick values", () => {
-      const props = { tickValues: ["a", "b", "c", "d"] };
-      const domainResult = Domain.getDomainFromTickValues(props);
-      expect(domainResult).to.eql([1, 4]);
+    it("returns maxDomain from props as a number", () => {
+      const props = { maxDomain: 3 };
+      const maxDomain = Domain.getMaxFromProps(props, "x");
+      expect(maxDomain).to.eql(props.maxDomain);
     });
-
-    it("reverses a domain from tickValues when the axis is vertical", () => {
-      const props = { tickValues: [1, 2, 3], dependentAxis: true };
-      const domainResult = Domain.getDomainFromTickValues(props);
-      expect(domainResult).to.eql([3, 1]);
+    it("returns undefined when maxDomain is not defined for a given axis", () => {
+      const props = { maxDomain: { y: 3 } };
+      const maxDomain = Domain.getMaxFromProps(props, "x");
+      expect(maxDomain).to.eql(undefined);
     });
   });
 
-  describe("getDomainFromGroupedData", () => {
-    const data = [
-      [{ _x: 1, _y: 0 }, { _x: 2, _y: 0 }, { _x: 3, _y: 0 }],
-      [{ _x: 1, _y: 1 }, { _x: 2, _y: 1 }, { _x: 3, _y: 1 }],
-      [{ _x: 1, _y: 2 }, { _x: 2, _y: 2 }, { _x: 3, _y: 2 }]
-    ];
-
-    it("calculates a domain from categories for the independent axis", () => {
-      const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
-      const domainResultX = Domain.getDomainFromGroupedData(props, "x", data);
-      expect(domainResultX).to.eql([1, 3]);
+  describe("getMinFromProps", () => {
+    it("returns minDomain from props as an object", () => {
+      const props = { minDomain: { x: 3 } };
+      const minDomain = Domain.getMinFromProps(props, "x");
+      expect(minDomain).to.eql(props.minDomain.x);
     });
-
-    it("calculates a stacked domain for the dependent axis", () => {
-      const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
-      const domainResultY = Domain.getDomainFromGroupedData(props, "y", data);
-      expect(domainResultY).to.eql([0, 3]);
+    it("returns minDomain from props as a number", () => {
+      const props = { minDomain: 3 };
+      const minDomain = Domain.getMinFromProps(props, "x");
+      expect(minDomain).to.eql(props.minDomain);
+    });
+    it("returns undefined when minDomain is not defined for a given axis", () => {
+      const props = { minDomain: { y: 3 } };
+      const minDomain = Domain.getMinFromProps(props, "x");
+      expect(minDomain).to.eql(undefined);
     });
   });
 
-  describe("getDomainFromCategories", () => {
-    it("calculates a domain from categories for the independent axis", () => {
-      const props = { categories: [1, 2, 3] };
-      const domainResult = Domain.getDomainFromCategories(props, "x");
-      expect(domainResult).to.eql([1, 3]);
-    });
-
-    it("calculates a domain from categories for the dependent axis", () => {
-      const props = { categories: { y: [ 1, 2, 3] } };
-      const domainResult = Domain.getDomainFromCategories(props, "y");
-      expect(domainResult).to.eql([1, 3]);
-    });
-
-    it("calculates a domain from string categories", () => {
-      const props = { categories: { x: ["cats", "kittens"] } };
-      const domainResult = Domain.getDomainFromCategories(props, "x");
-      expect(domainResult).to.eql([1, 2]);
+  describe("getSymmetricDomain", () => {
+    it("pads the domain by a value determined by data spacing", () => {
+      const domain = [0, 10];
+      const data = [2, 4, 6, 8];
+      const resultDomain = Domain.getSymmetricDomain(domain, data);
+      expect(resultDomain).to.eql([0, 12]);
     });
   });
 });


### PR DESCRIPTION
**This is a breaking change**

This PR 
- adds support for `minDomain` and `maxDomain`. closes https://github.com/FormidableLabs/victory/issues/1008
- changes how `domainPadding` works (no longer constrains padding to existing quadrants) closes https://github.com/FormidableLabs/victory/issues/1009
- significantly refactors `Domain` methods to use named exports.