### PR TITLE
revert domainPadding change

### DIFF
--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -121,8 +121,8 @@ function padDomain(domain, props, axis) {
 
   // Adjust the domain by the initial padding
   const adjustedDomain = {
-    min: +min - initialPadding.left,
-    max: +max + initialPadding.right
+    min: (min >= 0 && (min - initialPadding.left) <= 0) ? 0 : min.valueOf() - initialPadding.left,
+    max: (max <= 0 && (max + initialPadding.right) >= 0) ? 0 : max.valueOf() + initialPadding.right
   };
 
   // re-calculate padding, taking the adjusted domain into account
@@ -132,9 +132,15 @@ function padDomain(domain, props, axis) {
   };
 
   // Adjust the domain by the final padding
+  const paddedDomain = {
+    min: (min >= 0 && (min - finalPadding.left) <= 0) ? 0 : min.valueOf() - finalPadding.left,
+    max: (max >= 0 && (max + finalPadding.right) <= 0) ? 0 : max.valueOf() + finalPadding.right
+  };
+
+  // default to minDomain / maxDomain if they exist
   const finalDomain = {
-    min: minDomain !== undefined ? minDomain : min.valueOf() - finalPadding.left,
-    max: maxDomain !== undefined ? maxDomain : max.valueOf() + finalPadding.right
+    min: minDomain !== undefined ? minDomain : paddedDomain.min,
+    max: maxDomain !== undefined ? maxDomain : paddedDomain.max
   };
 
   return min instanceof Date || max instanceof Date ?

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -60,10 +60,10 @@ describe("victory-util/domain", () => {
         const domainPadding = { x: pad };
         const props = { ...baseProps, domainPadding };
         const paddedDomain = Domain.formatDomain(domain, props, "x");
-        const adjustedDomain = Math.abs(domain[1] - domain[0]) + (2 * pad);
+        const adjustedDomain = domain[1] + pad;
         const adjustedPercent = adjustedDomain / (baseProps.width - baseProps.padding);
         const totalPadding = adjustedPercent * pad;
-        expect(paddedDomain).to.eql([domain[0] - totalPadding, domain[1] + totalPadding]);
+        expect(paddedDomain).to.eql([0, domain[1] + totalPadding]);
       });
     });
 


### PR DESCRIPTION
reverts changes to `domainPadding` so that it is still confined to existing quadrants. 