### PR TITLE
Coerce domainPadding unless singleQuadrantDomainPadding is set false

### DIFF
--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -122,6 +122,7 @@ function padDomain(domain, props, axis) {
 
   const singleQuadrantDomainPadding = isPlainObject(props.singleQuadrantDomainPadding) ?
     props.singleQuadrantDomainPadding[axis] : props.singleQuadrantDomainPadding;
+
   const adjust = (val, type) => {
     if (singleQuadrantDomainPadding === false) {
       return val;
@@ -133,8 +134,8 @@ function padDomain(domain, props, axis) {
 
   // Adjust the domain by the initial padding
   const adjustedDomain = {
-    min: adjust(min.valueOf() - initialPadding.left),
-    max: adjust(max.valueOf() + initialPadding.right)
+    min: adjust(min.valueOf() - initialPadding.left, "min"),
+    max: adjust(max.valueOf() + initialPadding.right, "max")
   };
 
   // re-calculate padding, taking the adjusted domain into account
@@ -145,8 +146,8 @@ function padDomain(domain, props, axis) {
 
   // Adjust the domain by the final padding
   const paddedDomain = {
-    min: adjust(min.valueOf() - finalPadding.left),
-    max: adjust(max.valueOf() + finalPadding.right)
+    min: adjust(min.valueOf() - finalPadding.left, "min"),
+    max: adjust(max.valueOf() + finalPadding.right, "max")
   };
 
   // default to minDomain / maxDomain if they exist

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -101,6 +101,7 @@ function padDomain(domain, props, axis) {
   if (!props.domainPadding) {
     return domain;
   }
+
   const minDomain = getMinFromProps(props, axis);
   const maxDomain = getMaxFromProps(props, axis);
   const padding = getDomainPadding(props, axis);
@@ -119,10 +120,21 @@ function padDomain(domain, props, axis) {
     right: Math.abs(max - min) * padding.right / rangeExtent
   };
 
+  const singleQuadrantDomainPadding = isPlainObject(props.singleQuadrantDomainPadding) ?
+    props.singleQuadrantDomainPadding[axis] : props.singleQuadrantDomainPadding;
+  const adjust = (val, type) => {
+    if (singleQuadrantDomainPadding === false) {
+      return val;
+    }
+    const coerce = (type === "min" && min >= 0 && val <= 0) ||
+      (type === "max" && max <= 0 && val >= 0);
+    return coerce ? 0 : val;
+  };
+
   // Adjust the domain by the initial padding
   const adjustedDomain = {
-    min: (min >= 0 && (min - initialPadding.left) <= 0) ? 0 : min.valueOf() - initialPadding.left,
-    max: (max <= 0 && (max + initialPadding.right) >= 0) ? 0 : max.valueOf() + initialPadding.right
+    min: adjust(min.valueOf() - initialPadding.left),
+    max: adjust(max.valueOf() + initialPadding.right)
   };
 
   // re-calculate padding, taking the adjusted domain into account
@@ -133,8 +145,8 @@ function padDomain(domain, props, axis) {
 
   // Adjust the domain by the final padding
   const paddedDomain = {
-    min: (min >= 0 && (min - finalPadding.left) <= 0) ? 0 : min.valueOf() - finalPadding.left,
-    max: (max >= 0 && (max + finalPadding.right) <= 0) ? 0 : max.valueOf() + finalPadding.right
+    min: adjust(min.valueOf() - finalPadding.left),
+    max: adjust(max.valueOf() + finalPadding.right)
   };
 
   // default to minDomain / maxDomain if they exist

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -121,8 +121,8 @@ function padDomain(domain, props, axis) {
 
   // Adjust the domain by the initial padding
   const adjustedDomain = {
-    min: +min - initialPadding.left,
-    max: +max + initialPadding.right
+    min: (min >= 0 && (min - initialPadding.left) <= 0) ? 0 : min.valueOf() - initialPadding.left,
+    max: (max <= 0 && (max + initialPadding.right) >= 0) ? 0 : max.valueOf() + initialPadding.right
   };
 
   // re-calculate padding, taking the adjusted domain into account
@@ -132,9 +132,15 @@ function padDomain(domain, props, axis) {
   };
 
   // Adjust the domain by the final padding
+  const paddedDomain = {
+    min: (min >= 0 && (min - finalPadding.left) <= 0) ? 0 : min.valueOf() - finalPadding.left,
+    max: (max >= 0 && (max + finalPadding.right) <= 0) ? 0 : max.valueOf() + finalPadding.right
+  };
+
+  // default to minDomain / maxDomain if they exist
   const finalDomain = {
-    min: minDomain !== undefined ? minDomain : min.valueOf() - finalPadding.left,
-    max: maxDomain !== undefined ? maxDomain : max.valueOf() + finalPadding.right
+    min: minDomain !== undefined ? minDomain : paddedDomain.min,
+    max: maxDomain !== undefined ? maxDomain : paddedDomain.max
   };
 
   return min instanceof Date || max instanceof Date ?

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -60,10 +60,10 @@ describe("victory-util/domain", () => {
         const domainPadding = { x: pad };
         const props = { ...baseProps, domainPadding };
         const paddedDomain = Domain.formatDomain(domain, props, "x");
-        const adjustedDomain = Math.abs(domain[1] - domain[0]) + (2 * pad);
+        const adjustedDomain = domain[1] + pad;
         const adjustedPercent = adjustedDomain / (baseProps.width - baseProps.padding);
         const totalPadding = adjustedPercent * pad;
-        expect(paddedDomain).to.eql([domain[0] - totalPadding, domain[1] + totalPadding]);
+        expect(paddedDomain).to.eql([0, domain[1] + totalPadding]);
       });
     });
 


### PR DESCRIPTION
This PR adds a prop for changing the behavior of `domainPadding`.

When the `singleQuadrantDomainPadding` prop is set to `false` (or an object with false for x and/or y), domainPadding will _not_ be limited to existing quadrants. If this prop is omitted or set to true, domainPadding will be limited to existing quadrants (old behavior)

see https://github.com/FormidableLabs/victory/issues/1009