### PR TITLE
Improvement/reduce children

### DIFF
--- a/src/victory-shared-events/victory-shared-events.js
+++ b/src/victory-shared-events/victory-shared-events.js
@@ -157,18 +157,15 @@ export default class VictorySharedEvents extends React.Component {
 
   getNewChildren(props, baseProps) {
     const { events, eventKey } = props;
-    let nameIndex = 0;
     const alterChildren = (children, childNames) => {
-      return children.reduce((memo, child) => {
+      return children.reduce((memo, child, index) => {
         if (child.props.children) {
           const newChildren = React.Children.toArray(child.props.children);
-          const names = childNames.slice(nameIndex, newChildren.length);
+          const names = childNames.slice(index, index + newChildren.length);
           const results = React.cloneElement(child, child.props, alterChildren(newChildren, names));
-          nameIndex += newChildren.length;
           return memo.concat(results);
         } else if (child.type && isFunction(child.type.getBaseProps)) {
-          const name = child.props.name || childNames[nameIndex];
-          nameIndex++;
+          const name = child.props.name || childNames[index];
           const childEvents = Array.isArray(events) &&
             events.filter((event) => {
               if (event.target === "parent") {

--- a/src/victory-util/domain.js
+++ b/src/victory-util/domain.js
@@ -1,11 +1,10 @@
 /* eslint-disable func-style */
 /* eslint-disable no-use-before-define */
-import { flatten, includes, isPlainObject, sortedUniq, isFunction } from "lodash";
+import { flatten, isPlainObject, sortedUniq, isFunction } from "lodash";
 import Data from "./data";
 import Scale from "./scale";
 import Helpers from "./helpers";
 import Collection from "./collection";
-import { DEFAULT_ENCODING } from "crypto";
 
 // Private Methods
 
@@ -25,37 +24,6 @@ function cleanDomain(domain, props, axis) {
   };
 
   return rules(domain);
-}
-
-function getCumulativeData(props, axis, datasets) {
-  const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
-  const otherAxis = currentAxis === "x" ? "y" : "x";
-  const categories = [];
-  const axisValues = [];
-  datasets.forEach((dataset) => {
-    dataset.forEach((data) => {
-      if (data.category !== undefined && !includes(categories, data.category)) {
-        categories.push(data.category);
-      } else if (!includes(axisValues, data[`_${otherAxis}`])) {
-        axisValues.push(data[`_${otherAxis}`]);
-      }
-    });
-  });
-
-  const _dataByCategory = () => {
-    return categories.map((value) => {
-      return datasets.reduce((prev, data) => {
-        return data.category === value ? prev.concat(data[`_${axis}`]) : prev;
-      }, []);
-    });
-  };
-
-  const _dataByIndex = () => {
-    return axisValues.map((value, index) => {
-      return datasets.map((data) => data[index] && data[index][`_${currentAxis}`]);
-    });
-  };
-  return categories.length === 0 ? _dataByIndex() : _dataByCategory();
 }
 
 function getDomainPadding(props, axis) {
@@ -78,7 +46,7 @@ function getFlatData(dataset, axis) {
 function getExtremeFromData(dataset, axis, type = "min") {
   const getExtreme = (arr) => type === "max" ? Math.max(...arr) : Math.min(...arr);
   const initialValue = type === "max" ? -Infinity : Infinity;
-  let containsDate = false
+  let containsDate = false;
   const result = flatten(dataset).reduce((memo, datum) => {
     const current0 = datum[`_${axis}0`] !== undefined ? datum[`_${axis}0`] : datum[`_${axis}`];
     const current1 = datum[`_${axis}1`] !== undefined ? datum[`_${axis}1`] : datum[`_${axis}`];
@@ -261,47 +229,6 @@ function getDomainFromData(props, axis, dataset) {
 }
 
 /**
- * Returns a cumulative domain for a set of grouped datasets (i.e. stacked charts)
- * @param {Object} props: the props object
- * @param {String} axis: the current axis
- * @param {Array} datasets: an array of data arrays
- * @returns {Array} the cumulative domain
- */
-function getDomainFromGroupedData(props, axis, datasets) {
-  const { horizontal } = props;
-  const dependent = (axis === "x" && !horizontal) || (axis === "y" && horizontal);
-  const categories = isPlainObject(props.categories) ? props.categories[axis] : props.categories;
-  if (dependent && categories) {
-    return getDomainFromCategories(props, axis, categories);
-  }
-  const globalDomain = getDomainFromData(props, axis, datasets);
-  if (dependent) {
-    return globalDomain;
-  }
-  // find the cumulative max for stacked chart types
-  const cumulativeData = getCumulativeData(props, axis, datasets);
-  const cumulativeMax = cumulativeData.reduce((memo, dataset) => {
-    const currentMax = dataset.reduce((m, val) => {
-      return val > 0 ? m + val : m;
-    }, 0);
-    return memo > currentMax ? memo : currentMax;
-  }, -Infinity);
-
-  const cumulativeMin = cumulativeData.reduce((memo, dataset) => {
-    const currentMin = dataset.reduce((m, val) => {
-      return val < 0 ? m + val : m;
-    }, 0);
-    return memo < currentMin ? memo : currentMin;
-  }, Infinity);
-
-  // use greatest min / max
-  return getDomainFromMinMax(
-    Collection.getMinValue(globalDomain, cumulativeMin),
-    Collection.getMaxValue(globalDomain, cumulativeMax)
-  );
-}
-
-/**
  * Returns a domain in the form of a two element array given a min and max value.
  * @param {Number|Date} min: the props object
  * @param {Number|Date} max: the current axis
@@ -415,7 +342,6 @@ export default {
   getDomain,
   getDomainFromCategories,
   getDomainFromData,
-  getDomainFromGroupedData,
   getDomainFromMinMax,
   getDomainFromProps,
   getDomainWithZero,

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -189,10 +189,11 @@ function getCurrentAxis(axis, horizontal) {
 /**
  * @param {Array} children: an array of child components
  * @param {Function} iteratee: a function with arguments "child", "childName", and "parent"
+ * @param {Object} parentProps: props from the parent that are applied to children
  * @returns {Array} returns an array of results from calling the iteratee on all nested children
  */
-function reduceChildren(children, iteratee) {
-  const parentProps = [
+function reduceChildren(children, iteratee, parentProps = {}) {
+  const sharedProps = [
     "data", "domain", "categories", "polar", "startAngle", "endAngle", "minDomain", "maxDomain"
   ];
   const traverseChildren = (childArray, names, parent) => {
@@ -200,11 +201,12 @@ function reduceChildren(children, iteratee) {
       const childRole = child.type && child.type.role;
       const childName = child.props.name || `${childRole}-${names[index]}`;
       if (child.props && child.props.children) {
+        const childProps = assign({}, child.props, pick(parentProps, sharedProps));
         const nestedChildren = child.type && isFunction(child.type.getChildren) ?
-          child.type.getChildren(child.props) :
+          child.type.getChildren(childProps) :
           React.Children.toArray(child.props.children).map((c) => {
-            const childProps = assign({}, c.props, pick(child.props, parentProps));
-            return React.cloneElement(c, childProps);
+            const nestedChildProps = assign({}, c.props, pick(childProps, sharedProps));
+            return React.cloneElement(c, nestedChildProps);
           });
         const childNames = nestedChildren.map((c, i) => `${childName}-${i}`);
         const nestedResults = traverseChildren(nestedChildren, childNames, child);

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -198,13 +198,15 @@ function reduceChildren(children, iteratee, rolesToSkip = []) {
   const traverseChildren = (childArray, parent) => {
     return childArray.reduce((memo, child) => {
       const childRole = child.type && child.type.role;
-      const childName = child.props.name || childIndex;
-      childIndex++;
       if (!includes(rolesToSkip, childRole) && child.props && child.props.children) {
-        const nestedChildren = React.Children.toArray(child.props.children);
+        const nestedChildren = child.type && isFunction(child.type.getChildren) ?
+          child.type.getChildren(child.props) :
+          React.Children.toArray(child.props.children);
         const nestedResults = traverseChildren(nestedChildren, child);
         memo = memo.concat(nestedResults);
       } else {
+        const childName = child.props.name || childIndex;
+        childIndex++;
         const result = iteratee(child, childName, parent);
         memo = result ? memo.concat(result) : memo;
       }

--- a/src/victory-util/helpers.js
+++ b/src/victory-util/helpers.js
@@ -194,26 +194,26 @@ function getCurrentAxis(axis, horizontal) {
  * @returns {Array} returns an array of results from calling the iteratee on all nested children
  */
 function reduceChildren(children, iteratee, rolesToSkip = []) {
-  let childIndex = 0;
-  const traverseChildren = (childArray, parent) => {
-    return childArray.reduce((memo, child) => {
+  const traverseChildren = (childArray, names, parent) => {
+    return childArray.reduce((memo, child, index) => {
       const childRole = child.type && child.type.role;
+      const childName = child.props.name || `${childRole}-${names[index]}`;
       if (!includes(rolesToSkip, childRole) && child.props && child.props.children) {
         const nestedChildren = child.type && isFunction(child.type.getChildren) ?
           child.type.getChildren(child.props) :
           React.Children.toArray(child.props.children);
-        const nestedResults = traverseChildren(nestedChildren, child);
+        const childNames = nestedChildren.map((c, i) => `${childName}-${i}`);
+        const nestedResults = traverseChildren(nestedChildren, childNames, child);
         memo = memo.concat(nestedResults);
       } else {
-        const childName = child.props.name || childIndex;
-        childIndex++;
         const result = iteratee(child, childName, parent);
         memo = result ? memo.concat(result) : memo;
       }
       return memo;
     }, []);
   };
-  return traverseChildren(children);
+  const childNames = children.map((c, i) => i);
+  return traverseChildren(children, childNames);
 }
 
 export default {

--- a/test/client/spec/victory-util/domain.spec.js
+++ b/test/client/spec/victory-util/domain.spec.js
@@ -9,7 +9,6 @@ import { Domain } from "src/index";
   getDomain,
   getDomainFromCategories,
   getDomainFromData,
-  getDomainFromGroupedData,
   getDomainFromMinMax,
   getDomainFromProps,
   getDomainWithZero,
@@ -116,26 +115,6 @@ describe("victory-util/domain", () => {
       const dataset = [{ _x: 1, _y: 3 }, { _x: 3, _y: 5 }];
       const resultDomain = Domain.getDomainFromData({}, "x", dataset);
       expect(resultDomain).to.eql([1, 3]);
-    });
-  });
-
-  describe("getDomainFromGroupedData", () => {
-    const data = [
-      [{ _x: 1, _y: 0 }, { _x: 2, _y: 0 }, { _x: 3, _y: 0 }],
-      [{ _x: 1, _y: 1 }, { _x: 2, _y: 1 }, { _x: 3, _y: 1 }],
-      [{ _x: 1, _y: 2 }, { _x: 2, _y: 2 }, { _x: 3, _y: 2 }]
-    ];
-
-    it("calculates a domain from categories for the independent axis", () => {
-      const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
-      const domainResultX = Domain.getDomainFromGroupedData(props, "x", data);
-      expect(domainResultX).to.eql([1, 3]);
-    });
-
-    it("calculates a stacked domain for the dependent axis", () => {
-      const props = { categories: [1, 2, 3], data, x: "x", y: "y" };
-      const domainResultY = Domain.getDomainFromGroupedData(props, "y", data);
-      expect(domainResultY).to.eql([0, 3]);
     });
   });
 


### PR DESCRIPTION
works with https://github.com/FormidableLabs/victory-chart/pull/555

This PR alters how `reduceChildren` works so that wrappers like `VictoryStack` correctly alter their children before the children are traversed. 

This PR also cleans up some domain methods that became irrelevant after changes in https://github.com/FormidableLabs/victory-chart/pull/555