### PR TITLE
chore: remove unprintable character

### DIFF
--- a/src/victory-theme/grayscale.js
+++ b/src/victory-theme/grayscale.js
@@ -18,7 +18,7 @@ const grey = "#969696";
 // *
 // * Typography
 // *
-const sansSerif = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
+const sansSerif = "'Gill Sans', 'Gill Sans MT', 'Seravek', 'Trebuchet MS', sans-serif";
 const letterSpacing = "normal";
 const fontSize = 14;
 // *


### PR DESCRIPTION
`\u00ad` was before the letter a in Seravek.